### PR TITLE
refactor(log): rename builder struct

### DIFF
--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -142,14 +142,14 @@ fn log(
     logger().log(&builder.args(format_args!("{message}")).build());
 }
 
-pub struct LoggerBuilder {
+pub struct Builder {
     dispatch: fern::Dispatch,
     rotation_strategy: RotationStrategy,
     max_file_size: u128,
     targets: Vec<LogTarget>,
 }
 
-impl Default for LoggerBuilder {
+impl Default for Builder {
     fn default() -> Self {
         let format =
             time::format_description::parse("[[[year]-[month]-[day]][[[hour]:[minute]:[second]]")
@@ -172,7 +172,7 @@ impl Default for LoggerBuilder {
     }
 }
 
-impl LoggerBuilder {
+impl Builder {
     pub fn new() -> Self {
         Default::default()
     }


### PR DESCRIPTION
Rename the plugin builder struct from `LoggerBuilder` to `Builder` to align with conventions