### PR TITLE
refactor(store): rename plugin

### DIFF
--- a/plugins/store/src/lib.rs
+++ b/plugins/store/src/lib.rs
@@ -244,12 +244,12 @@ async fn save<R: Runtime>(
 }
 
 #[derive(Default)]
-pub struct PluginBuilder {
+pub struct Builder {
     stores: HashMap<PathBuf, Store>,
     frozen: bool,
 }
 
-impl PluginBuilder {
+impl Builder {
     /// Registers a store with the plugin.
     ///
     /// # Examples


### PR DESCRIPTION
Rename the plugin builder struct from `PluginBuilder` to `Builder` to align with conventions