### PR TITLE
[sql] Make sqlite the default database driver

### DIFF
--- a/plugins/sql/Cargo.toml
+++ b/plugins/sql/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1", features = ["sync"] }
 futures = "0.3"
 
 [features]
+default = ["sqlite"]
 sqlite = ["sqlx/sqlite"]
 mysql = ["sqlx/mysql"]
 postgres = ["sqlx/postgres"]

--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -14,10 +14,12 @@ Install the Core plugin by adding the following to your `Cargo.toml` file:
 
 `src-tauri/Cargo.toml`
 ```toml
-[dependencies.tauri-plugin-sql]
-git = "https://github.com/tauri-apps/plugins-workspace"
-branch = "dev"
-features = ["sqlite"] # or "postgres", or "mysql"
+[dependencies]
+tauri-plugin-sql = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev" }
+# or
+tauri-plugin-sql = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev", default-features = false, features = ["postgres"] }
+# or 
+tauri-plugin-sql = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev", default-features = false, features = ["mysql"] } 
 ```
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:

--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -1,6 +1,6 @@
 ![plugin-sql](banner.png)
 
-Interface with SQL databases through [sqlx](https://github.com/launchbadge/sqlx). It supports the `sqlite`, `mysql` and `postgres` drivers, enabled by a Cargo feature.
+Interface with SQL databases through [sqlx](https://github.com/launchbadge/sqlx). By default the `sqlite` driver is enabled, but `mysql` and `postgres` can be enabled by a Cargo feature.
 
 ## Install
 


### PR DESCRIPTION
We talked about how annoying the current state of the sql plugin is and that is breaks virtually all code-related tooling there is. Since the vast majority of people use sqlite anyway (and they should) this PR makes it the actual default flag.