### PR TITLE
fix: change dist for js files, fixes #76 for yarn3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 node_modules
 dist
+dist-js

--- a/plugins/authenticator/package.json
+++ b/plugins/authenticator/package.json
@@ -7,20 +7,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/autostart/package.json
+++ b/plugins/autostart/package.json
@@ -6,20 +6,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/fs-extra/package.json
+++ b/plugins/fs-extra/package.json
@@ -7,20 +7,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/fs-watch/package.json
+++ b/plugins/fs-watch/package.json
@@ -7,20 +7,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/log/package.json
+++ b/plugins/log/package.json
@@ -7,20 +7,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/positioner/package.json
+++ b/plugins/positioner/package.json
@@ -7,20 +7,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/sql/package.json
+++ b/plugins/sql/package.json
@@ -7,20 +7,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/store/package.json
+++ b/plugins/store/package.json
@@ -7,20 +7,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/stronghold/package.json
+++ b/plugins/stronghold/package.json
@@ -7,20 +7,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/upload/package.json
+++ b/plugins/upload/package.json
@@ -7,20 +7,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/websocket/package.json
+++ b/plugins/websocket/package.json
@@ -6,20 +6,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/shared/template/package.json
+++ b/shared/template/package.json
@@ -6,20 +6,20 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
-  "browser": "guest-js/dist/index.min.js",
-  "module": "guest-js/dist/index.mjs",
-  "types": "guest-js/dist/index.d.ts",
+  "browser": "dist-js/index.min.js",
+  "module": "dist-js/index.mjs",
+  "types": "dist-js/index.d.ts",
   "exports": {
-    "import": "./guest-js/dist/index.mjs",
-    "types": "./guest-js/dist/index.d.ts",
-    "browser": "./guest-js/dist/index.min.js"
+    "import": "./dist-js/index.mjs",
+    "types": "./dist-js/index.d.ts",
+    "browser": "./dist-js/index.min.js"
   },
   "scripts": {
     "build": "rollup -c"
   },
   "files": [
-    "guest-js/dist",
-    "!guest-js/dist/**/*.map",
+    "dist-js",
+    "!dist-js/**/*.map",
     "README.md",
     "LICENSE"
   ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,5 +16,5 @@
     "declaration": true,
     "declarationDir": "dist"
   },
-  "exclude": ["guest-js/dist", "node_modules", "test/types"]
+  "exclude": ["dist-js", "node_modules", "test/types"]
 }


### PR DESCRIPTION
See https://github.com/tauri-apps/plugins-workspace/issues/76 for reference. yarn3 likes to be really weird again :)) Not the only solution but the one i'd like the most i think. didn't like adding the whole guest-js folder to files as shown in the linked issue.