### PR TITLE
feat(upload): Add function to download files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,7 +4440,7 @@ dependencies = [
 name = "tauri-plugin-upload"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures-util",
  "log",
  "read-progress-stream",
  "reqwest",

--- a/plugins/upload/Cargo.toml
+++ b/plugins/upload/Cargo.toml
@@ -18,5 +18,5 @@ thiserror.workspace = true
 tokio = { version = "1", features = [ "fs" ] }
 tokio-util = { version = "0.7", features = [ "codec" ] }
 reqwest = { version = "0.11", features = [ "json", "stream" ] }
-futures = "0.3"
+futures-util = "0.3"
 read-progress-stream = "1.0.0"


### PR DESCRIPTION
re: #44

Apparently there are people using https://github.com/FabianLars/tauri-plugin-download so i may as well upstream it.

We probablyyy should look into renaming the plugin? i thought about it for way too long without coming up with something so i'm fine with an `upload` plugin that can `download` files 😂

p.s. no idea if the implementation is actually any good, may be a bit low effort tbh.