### PR TITLE
Update Readme.md

### DIFF
--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -42,7 +42,7 @@ First you need to register the core plugin with Tauri:
 ```rust
 fn main() {
     tauri::Builder::default()
-        .plugin(tauri_plugin_sql::Builder::default())
+        .plugin(tauri_plugin_sql::Builder::default().build())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
The line where the plugin is added: `.plugin(tauri_plugin_sql::Builder::default())` give my this error;

```the trait `Plugin<tauri_runtime_wry::Wry<EventLoopMessage>>` is not implemented for `tauri_plugin_sql::Builder````


I found this fix: https://github.com/tauri-apps/tauri/issues/5947 and it works.