### PR TITLE
fix: Bump MSRV to 1.64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ thiserror = "1"
 edition = "2021"
 authors = [ "Tauri Programme within The Commons Conservancy" ]
 license = "Apache-2.0 OR MIT"
-rust-version = "1.59"
+rust-version = "1.64"


### PR DESCRIPTION
Bumps the MSRV to 1.64 since that's the version that introduced the workspace inheritance we are using here.