### PR TITLE
feat(sql): Improve type decoding. Adds support for time and dates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3901,6 +3901,7 @@ dependencies = [
  "sqlx-rt",
  "stringprep",
  "thiserror",
+ "time 0.3.17",
  "tokio-stream",
  "url",
  "webpki-roots",
@@ -4380,13 +4381,14 @@ dependencies = [
 name = "tauri-plugin-sql"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures-core",
  "log",
  "serde",
  "serde_json",
  "sqlx",
  "tauri",
  "thiserror",
+ "time 0.3.17",
  "tokio",
 ]
 

--- a/plugins/sql/Cargo.toml
+++ b/plugins/sql/Cargo.toml
@@ -15,11 +15,13 @@ serde_json.workspace = true
 tauri.workspace = true
 log.workspace = true
 thiserror.workspace = true
-sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "json"] }
+futures-core = "0.3"
+sqlx = { version = "0.6", features = ["runtime-tokio-rustls", "json", "time"] }
+time = "0.3"
 tokio = { version = "1", features = ["sync"] }
-futures = "0.3"
 
 [features]
+default = ["mysql"]
 sqlite = ["sqlx/sqlite"]
 mysql = ["sqlx/mysql"]
 postgres = ["sqlx/postgres"]

--- a/plugins/sql/Cargo.toml
+++ b/plugins/sql/Cargo.toml
@@ -21,7 +21,6 @@ time = "0.3"
 tokio = { version = "1", features = ["sync"] }
 
 [features]
-default = ["mysql"]
 sqlite = ["sqlx/sqlite"]
 mysql = ["sqlx/mysql"]
 postgres = ["sqlx/postgres"]

--- a/plugins/sql/src/decode/mod.rs
+++ b/plugins/sql/src/decode/mod.rs
@@ -1,0 +1,15 @@
+#[cfg(feature = "mysql")]
+mod mysql;
+#[cfg(feature = "postgres")]
+mod postgres;
+#[cfg(feature = "sqlite")]
+mod sqlite;
+
+#[cfg(feature = "mysql")]
+pub(crate) use mysql::to_json;
+
+#[cfg(feature = "postgres")]
+pub(crate) use postgres::to_json;
+
+#[cfg(feature = "sqlite")]
+pub(crate) use sqlite::to_json;

--- a/plugins/sql/src/decode/mysql.rs
+++ b/plugins/sql/src/decode/mysql.rs
@@ -1,0 +1,90 @@
+use serde_json::Value as JsonValue;
+use sqlx::{mysql::MySqlValueRef, TypeInfo, Value, ValueRef};
+use time::{Date, OffsetDateTime, PrimitiveDateTime, Time};
+
+use crate::Error;
+
+pub(crate) fn to_json(v: MySqlValueRef) -> Result<JsonValue, Error> {
+    if v.is_null() {
+        return Ok(JsonValue::Null);
+    }
+
+    let res = match v.type_info().name() {
+        "CHAR" | "VARCHAR" | "TINYTEXT" | "TEXT" | "MEDIUMTEXT" | "LONGTEXT" | "ENUM" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode() {
+                JsonValue::String(v)
+            } else {
+                JsonValue::Null
+            }
+        }
+        "FLOAT" | "DOUBLE" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<f64>() {
+                JsonValue::from(v)
+            } else {
+                JsonValue::Null
+            }
+        }
+        "TINYINT" | "SMALLINT" | "INT" | "MEDIUMINT" | "BIGINT" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<i64>() {
+                JsonValue::Number(v.into())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "TINYINT UNSIGNED" | "SMALLINT UNSIGNED" | "INT UNSIGNED" | "MEDIUMINT UNSIGNED"
+        | "BIGINT UNSIGNED" | "YEAR" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<u64>() {
+                JsonValue::Number(v.into())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "BOOLEAN" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode() {
+                JsonValue::Bool(v)
+            } else {
+                JsonValue::Null
+            }
+        }
+        "DATE" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<Date>() {
+                JsonValue::String(v.to_string())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "TIME" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<Time>() {
+                JsonValue::String(v.to_string())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "DATETIME" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<PrimitiveDateTime>() {
+                JsonValue::String(v.to_string())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "TIMESTAMP" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<OffsetDateTime>() {
+                JsonValue::String(v.to_string())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "JSON" => ValueRef::to_owned(&v).try_decode().unwrap_or_default(),
+        "TINIYBLOB" | "MEDIUMBLOB" | "BLOB" | "LONGBLOB" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<Vec<u8>>() {
+                JsonValue::Array(v.into_iter().map(|n| JsonValue::Number(n.into())).collect())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "NULL" => JsonValue::Null,
+        _ => return Err(Error::UnsupportedDatatype(v.type_info().name().to_string())),
+    };
+
+    Ok(res)
+}

--- a/plugins/sql/src/decode/postgres.rs
+++ b/plugins/sql/src/decode/postgres.rs
@@ -1,0 +1,82 @@
+use serde_json::Value as JsonValue;
+use sqlx::{postgres::PgValueRef, TypeInfo, Value, ValueRef};
+use time::{Date, OffsetDateTime, PrimitiveDateTime, Time};
+
+use crate::Error;
+
+pub(crate) fn to_json(v: PgValueRef) -> Result<JsonValue, Error> {
+    if v.is_null() {
+        return Ok(JsonValue::Null);
+    }
+
+    let res = match v.type_info().name() {
+        "CHAR" | "VARCHAR" | "TEXT" | "NAME" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode() {
+                JsonValue::String(v)
+            } else {
+                JsonValue::Null
+            }
+        }
+        "FLOAT$" | "FLOAT8" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<f64>() {
+                JsonValue::from(v)
+            } else {
+                JsonValue::Null
+            }
+        }
+        "INT2" | "INT4" | "INT8" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<i64>() {
+                JsonValue::Number(v.into())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "BOOL" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode() {
+                JsonValue::Bool(v)
+            } else {
+                JsonValue::Null
+            }
+        }
+        "DATE" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<Date>() {
+                JsonValue::String(v.to_string())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "TIME" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<Time>() {
+                JsonValue::String(v.to_string())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "TIMESTAMP" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<PrimitiveDateTime>() {
+                JsonValue::String(v.to_string())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "TIMESTAMPTZ" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<OffsetDateTime>() {
+                JsonValue::String(v.to_string())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "JSON" | "JSONB" => ValueRef::to_owned(&v).try_decode().unwrap_or_default(),
+        "BYTEA" => {
+            if let Ok(v) = ValueRef::to_owned(&v).try_decode::<Vec<u8>>() {
+                JsonValue::Array(v.into_iter().map(|n| JsonValue::Number(n.into())).collect())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "VOID" => JsonValue::Null,
+        _ => return Err(Error::UnsupportedDatatype(v.type_info().name().to_string())),
+    };
+
+    Ok(res)
+}

--- a/plugins/sql/src/decode/postgres.rs
+++ b/plugins/sql/src/decode/postgres.rs
@@ -17,7 +17,7 @@ pub(crate) fn to_json(v: PgValueRef) -> Result<JsonValue, Error> {
                 JsonValue::Null
             }
         }
-        "FLOAT$" | "FLOAT8" => {
+        "FLOAT4" | "FLOAT8" => {
             if let Ok(v) = ValueRef::to_owned(&v).try_decode::<f64>() {
                 JsonValue::from(v)
             } else {

--- a/plugins/sql/src/decode/sqlite.rs
+++ b/plugins/sql/src/decode/sqlite.rs
@@ -1,0 +1,74 @@
+use serde_json::Value as JsonValue;
+use sqlx::{sqlite::SqliteValueRef, TypeInfo, Value, ValueRef};
+use time::{Date, PrimitiveDateTime, Time};
+
+use crate::Error;
+
+pub(crate) fn to_json(v: SqliteValueRef) -> Result<JsonValue, Error> {
+    if v.is_null() {
+        return Ok(JsonValue::Null);
+    }
+
+    let res = match v.type_info().name() {
+        "TEXT" => {
+            if let Ok(v) = v.to_owned().try_decode() {
+                JsonValue::String(v)
+            } else {
+                JsonValue::Null
+            }
+        }
+        "REAL" => {
+            if let Ok(v) = v.to_owned().try_decode::<f64>() {
+                JsonValue::from(v)
+            } else {
+                JsonValue::Null
+            }
+        }
+        "INTEGER" | "NUMERIC" => {
+            if let Ok(v) = v.to_owned().try_decode::<i64>() {
+                JsonValue::Number(v.into())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "BOOLEAN" => {
+            if let Ok(v) = v.to_owned().try_decode() {
+                JsonValue::Bool(v)
+            } else {
+                JsonValue::Null
+            }
+        }
+        "DATE" => {
+            if let Ok(v) = v.to_owned().try_decode::<Date>() {
+                JsonValue::String(v.to_string())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "TIME" => {
+            if let Ok(v) = v.to_owned().try_decode::<Time>() {
+                JsonValue::String(v.to_string())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "DATETIME" => {
+            if let Ok(v) = v.to_owned().try_decode::<PrimitiveDateTime>() {
+                JsonValue::String(v.to_string())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "BLOB" => {
+            if let Ok(v) = v.to_owned().try_decode::<Vec<u8>>() {
+                JsonValue::Array(v.into_iter().map(|n| JsonValue::Number(n.into())).collect())
+            } else {
+                JsonValue::Null
+            }
+        }
+        "NULL" => JsonValue::Null,
+        _ => return Err(Error::UnsupportedDatatype(v.type_info().name().to_string())),
+    };
+
+    Ok(res)
+}

--- a/plugins/sql/src/lib.rs
+++ b/plugins/sql/src/lib.rs
@@ -14,15 +14,6 @@ compile_error!(
     "Database driver not defined. Please set the feature flag for the driver of your choice."
 );
 
-#[cfg(any(
-    all(feature = "sqlite", not(any(feature = "mysql", feature = "postgres"))),
-    all(feature = "mysql", not(any(feature = "sqlite", feature = "postgres"))),
-    all(feature = "postgres", not(any(feature = "sqlite", feature = "mysql"))),
-))]
+mod decode;
 mod plugin;
-#[cfg(any(
-    all(feature = "sqlite", not(any(feature = "mysql", feature = "postgres"))),
-    all(feature = "mysql", not(any(feature = "sqlite", feature = "postgres"))),
-    all(feature = "postgres", not(any(feature = "sqlite", feature = "mysql"))),
-))]
 pub use plugin::*;


### PR DESCRIPTION
and mysql's enum type. ref https://github.com/tauri-apps/plugins-workspace/issues/204#issuecomment-1450518137

The string returned from date/datetime columns may be different in format than what was inserted but working with these types was super annoying that i want to leave it as-is for now...