### PR TITLE
fix(window-state): Use outer position

### DIFF
--- a/plugins/window-state/src/lib.rs
+++ b/plugins/window-state/src/lib.rs
@@ -225,7 +225,7 @@ impl<R: Runtime> WindowExtInternal for Window<R> {
         }
 
         if flags.contains(StateFlags::POSITION) {
-            let position = self.inner_position()?;
+            let position = self.outer_position()?;
             if let Ok(Some(monitor)) = self.current_monitor() {
                 // save only window positions that are inside the current monitor
                 if monitor.contains(position) && !is_maximized {


### PR DESCRIPTION
Previously, using `.inner_position()` would shift the window down slightly (approximately the size of the title bar) each time the app was started. Using `.inner_size()` still seems to correctly set the window size though.