### PR TITLE
ci: Replace actions-rs/audit-check with rustsec fork

### DIFF
--- a/.github/workflows/audit-rust.yml
+++ b/.github/workflows/audit-rust.yml
@@ -28,6 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/audit-check@v1
+      - uses: rustsec/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit-rust.yml
+++ b/.github/workflows/audit-rust.yml
@@ -28,6 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: FabianLars/audit-check@new-warning-types
+      - uses: rustsec/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit-rust.yml
+++ b/.github/workflows/audit-rust.yml
@@ -28,6 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: rustsec/audit-check@v1
+      - uses: FabianLars/audit-check@new-warning-types
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
They finally decided to maintain it for now and recently released an update. rustsec is the same org that hosts the advisory database so imo it should be fairly trustworthy.

This PR is a follow-up of https://github.com/tauri-apps/plugins-workspace/pull/45 where we replaced all other actions-rs actions.