### PR TITLE
chore: Make renovate update dependencies of examples

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,15 @@
 {
   "extends": ["config:base"],
   "enabledManagers": ["cargo", "npm"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
   "packageRules": [
     {
       "description": "Disable node/pnpm version updates",


### PR DESCRIPTION
`config:base` uses a somewhat extensive ignore list: https://docs.renovatebot.com/presets-default/#ignoremodulesandtests so we have to overwrite it with the paths we actually want to ignore (not the examples dirs). I left the rest of the default list in there even though most of the entries don't and won't apply to this repo.