### PR TITLE
fix(persisted-scope): Prevent memory leaks, fixes #274

### DIFF
--- a/.changes/persisted-scope-fix-oom.md
+++ b/.changes/persisted-scope-fix-oom.md
@@ -1,0 +1,5 @@
+---
+persisted-scope: patch
+---
+
+Recursively unescape saved patterns before allowing/forbidding them. This effectively prevents `.persisted-scope` files from blowing up, which caused Out-Of-Memory issues, while automatically fixing existing broken files seamlessly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4362,6 +4362,7 @@ dependencies = [
 name = "tauri-plugin-persisted-scope"
 version = "0.1.0"
 dependencies = [
+ "aho-corasick",
  "bincode",
  "log",
  "serde",

--- a/plugins/persisted-scope/Cargo.toml
+++ b/plugins/persisted-scope/Cargo.toml
@@ -15,6 +15,7 @@ serde_json.workspace = true
 tauri.workspace = true
 log.workspace = true
 thiserror.workspace = true
+aho-corasick = "0.7"
 bincode = "1"
 
 [features]

--- a/plugins/persisted-scope/src/lib.rs
+++ b/plugins/persisted-scope/src/lib.rs
@@ -89,7 +89,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                     for allowed in &scope.allowed_paths {
                         let allowed = fix_pattern(&ac, allowed);
 
-                        let _ = fs_scope.allow_file(allowed);
+                        let _ = fs_scope.allow_file(&allowed);
                         #[cfg(feature = "protocol-asset")]
                         let _ = asset_protocol_scope.allow_file(&allowed);
                     }

--- a/plugins/persisted-scope/src/lib.rs
+++ b/plugins/persisted-scope/src/lib.rs
@@ -6,11 +6,10 @@ use aho_corasick::AhoCorasick;
 use serde::{Deserialize, Serialize};
 use tauri::{
     plugin::{Builder, TauriPlugin},
-    FsScopeEvent, GlobPattern, Manager, Runtime,
+    FsScopeEvent, Manager, Runtime,
 };
 
 use std::{
-    collections::HashSet,
     fs::{create_dir_all, File},
     io::Write,
 };

--- a/plugins/persisted-scope/src/lib.rs
+++ b/plugins/persisted-scope/src/lib.rs
@@ -24,14 +24,10 @@ const PATTERNS: &[&str] = &[
     r"[?]",
     r"[*]",
     r"\?\?",
-    r"\\?\\?",
+    r"\\?\\?\",
     r"\\?\\\?\",
-    r"\\\\?\\\\?",
-    r"\\\\?\\\\\\?\\",
 ];
-const REPLACE_WITH: &[&str] = &[
-    r"[", r"]", r"?", r"*", r"\?", r"\\?", r"\\?\", r"\\\\?", r"\\\\?\\",
-];
+const REPLACE_WITH: &[&str] = &[r"[", r"]", r"?", r"*", r"\?", r"\\?\", r"\\?\"];
 
 #[derive(Debug, thiserror::Error)]
 enum Error {

--- a/plugins/persisted-scope/src/lib.rs
+++ b/plugins/persisted-scope/src/lib.rs
@@ -78,7 +78,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                 #[cfg(feature = "protocol-asset")]
                 let _ = asset_protocol_scope.forbid_file(&scope_state_path);
 
-                // We're trying to fix broken .persisted-scope files seemlessly, so we'll be running this on the values read on the saved file.
+                // We're trying to fix broken .persisted-scope files seamlessly, so we'll be running this on the values read on the saved file.
                 // We will still save some semi-broken values because the scope events are quite spammy and we don't want to reduce runtime performance any further.
                 let ac = AhoCorasick::new_auto_configured(PATTERNS);
 

--- a/plugins/persisted-scope/src/lib.rs
+++ b/plugins/persisted-scope/src/lib.rs
@@ -55,6 +55,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                     .into_iter()
                     .map(|p| p.to_string())
                     .collect();
+                #[cfg(feature = "protocol-asset")]
                 let initial_asset_allowed: Vec<String> = asset_protocol_scope
                     .allowed_patterns()
                     .into_iter()
@@ -65,6 +66,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                     .into_iter()
                     .map(|p| p.to_string())
                     .collect();
+                #[cfg(feature = "protocol-asset")]
                 let initial_asset_forbidden: Vec<String> = asset_protocol_scope
                     .forbidden_patterns()
                     .into_iter()

--- a/plugins/persisted-scope/src/lib.rs
+++ b/plugins/persisted-scope/src/lib.rs
@@ -65,7 +65,7 @@ fn save_scopes<R: Runtime>(app: &AppHandle<R>, app_dir: &Path, scope_state_path:
         allowed_paths: fs_scope
             .allowed_patterns()
             .into_iter()
-            .map(|p| dbg!(p.to_string()))
+            .map(|p| p.to_string())
             .collect(),
         forbidden_patterns: fs_scope
             .forbidden_patterns()

--- a/plugins/persisted-scope/src/lib.rs
+++ b/plugins/persisted-scope/src/lib.rs
@@ -52,13 +52,13 @@ struct Scope {
 }
 
 fn fix_pattern(ac: &AhoCorasick, s: &str) -> String {
-    let s = ac.replace_all(&s, REPLACE_WITH);
+    let s = ac.replace_all(s, REPLACE_WITH);
 
     if ac.find(&s).is_some() {
         return fix_pattern(ac, &s);
     }
 
-    s.to_string()
+    s
 }
 
 pub fn init<R: Runtime>() -> TauriPlugin<R> {

--- a/plugins/persisted-scope/src/lib.rs
+++ b/plugins/persisted-scope/src/lib.rs
@@ -90,7 +90,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                     for allowed in &scope.allowed_paths {
                         let allowed = fix_pattern(&ac, allowed);
 
-                        let _ = fs_scope.allow_file(&dbg!(allowed));
+                        let _ = fs_scope.allow_file(allowed);
                         #[cfg(feature = "protocol-asset")]
                         let _ = asset_protocol_scope.allow_file(&allowed);
                     }


### PR DESCRIPTION
It's not actually a memory _leak_ the plugin just breaks the .persisted-scope file, bloating it up (to 100mb after a few uses/restarts if you actually use the scope) to a point where it gets too large to work correctly.

This PR adds more pattern than strictly necessary to fix existing files seamlessly - well, hopefully at least.

Fixes #274