### PR TITLE
fix(log): Replace unknown js location with `webview::unknown`, fixes #41

### DIFF
--- a/plugins/log/guest-js/index.ts
+++ b/plugins/log/guest-js/index.ts
@@ -52,10 +52,15 @@ async function log(
 
   const { file, line, ...keyValues } = options ?? {};
 
+  let location = filtered?.[0]?.filter((v) => v.length > 0).join("@");
+  if (location === "Error") {
+    location = "webview::unknown";
+  }
+
   await invoke("plugin:log|log", {
     level,
     message,
-    location: filtered?.[0]?.filter((v) => v.length > 0).join("@"),
+    location,
     file,
     line,
     keyValues,

--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -146,8 +146,8 @@ fn log(
     let location = location.unwrap_or("webview");
     let mut builder = RecordBuilder::new();
     builder
-        .target(location)
         .level(level.into())
+        .target(location)
         .file(file)
         .line(line);
 
@@ -178,8 +178,8 @@ impl Default for Builder {
             out.finish(format_args!(
                 "{}[{}][{}] {}",
                 DEFAULT_TIMEZONE_STRATEGY.get_now().format(&format).unwrap(),
-                record.target(),
                 record.level(),
+                record.target(),
                 message
             ))
         });
@@ -213,8 +213,8 @@ impl Builder {
             out.finish(format_args!(
                 "{}[{}][{}] {}",
                 timezone_strategy.get_now().format(&format).unwrap(),
-                record.target(),
                 record.level(),
+                record.target(),
                 message
             ))
         });
@@ -273,8 +273,8 @@ impl Builder {
             out.finish(format_args!(
                 "{}[{}][{}] {}",
                 timezone_strategy.get_now().format(&format).unwrap(),
-                record.target(),
                 colors.color(record.level()),
+                record.target(),
                 message
             ))
         })


### PR DESCRIPTION
This also swaps the order of location and target to match the fern docs (the new order makes more sense to me)