### PR TITLE
Avoid type conflict

### DIFF
--- a/plugins/log/guest-js/index.ts
+++ b/plugins/log/guest-js/index.ts
@@ -4,7 +4,7 @@ import { listen, UnlistenFn } from "@tauri-apps/api/event";
 export type LogOptions = {
   file?: string;
   line?: number;
-  extras?: Record<string, string | undefined>;
+  keyValues?: Record<string, string | undefined>;
 };
 
 enum LogLevel {
@@ -51,7 +51,7 @@ async function log(
     return name.length > 0 && location !== "[native code]";
   });
 
-  const { file, line, extras = {} } = options ?? {};
+  const { file, line, keyValues = {} } = options ?? {};
 
   let location = filtered?.[0]?.filter((v) => v.length > 0).join("@");
   if (location === "Error") {
@@ -64,7 +64,7 @@ async function log(
     location,
     file,
     line,
-    keyValues: extras,
+    keyValues,
   });
 }
 

--- a/plugins/log/guest-js/index.ts
+++ b/plugins/log/guest-js/index.ts
@@ -51,7 +51,7 @@ async function log(
     return name.length > 0 && location !== "[native code]";
   });
 
-  const { file, line, keyValues = {} } = options ?? {};
+  const { file, line, keyValues } = options ?? {};
 
   let location = filtered?.[0]?.filter((v) => v.length > 0).join("@");
   if (location === "Error") {

--- a/plugins/log/guest-js/index.ts
+++ b/plugins/log/guest-js/index.ts
@@ -37,7 +37,7 @@ enum LogLevel {
    *
    * Designates very serious errors.
    */
-  Error
+  Error,
 }
 
 async function log(
@@ -64,7 +64,7 @@ async function log(
     location,
     file,
     line,
-    keyValues: extras
+    keyValues: extras,
   });
 }
 

--- a/plugins/log/guest-js/index.ts
+++ b/plugins/log/guest-js/index.ts
@@ -4,7 +4,8 @@ import { listen, UnlistenFn } from "@tauri-apps/api/event";
 export type LogOptions = {
   file?: string;
   line?: number;
-} & Record<string, string | undefined>;
+  extras: Record<string, string | undefined>;
+};
 
 enum LogLevel {
   /**
@@ -36,7 +37,7 @@ enum LogLevel {
    *
    * Designates very serious errors.
    */
-  Error,
+  Error
 }
 
 async function log(
@@ -50,7 +51,7 @@ async function log(
     return name.length > 0 && location !== "[native code]";
   });
 
-  const { file, line, ...keyValues } = options ?? {};
+  const { file, line, extras = {} } = options ?? {};
 
   let location = filtered?.[0]?.filter((v) => v.length > 0).join("@");
   if (location === "Error") {
@@ -63,7 +64,7 @@ async function log(
     location,
     file,
     line,
-    keyValues,
+    keyValues: extras
   });
 }
 

--- a/plugins/log/guest-js/index.ts
+++ b/plugins/log/guest-js/index.ts
@@ -4,7 +4,7 @@ import { listen, UnlistenFn } from "@tauri-apps/api/event";
 export type LogOptions = {
   file?: string;
   line?: number;
-  extras: Record<string, string | undefined>;
+  extras?: Record<string, string | undefined>;
 };
 
 enum LogLevel {


### PR DESCRIPTION
Avoid type conflict.

> Argument of type '{ file: string; line: number; }' is not assignable to parameter of type 'LogOptions'.
> Type '{ file: string; line: number; }' is not assignable to type 'Record<string, string>'.
> Property 'line' is incompatible with index signature.
> Type 'number' is not assignable to type 'string'.ts(2345)
> No quick fixes available