### PR TITLE
feat: documentation for download func.

### DIFF
--- a/plugins/upload/README.md
+++ b/plugins/upload/README.md
@@ -1,6 +1,7 @@
 ![plugin-upload](banner.png)
 
 Upload files from disk to a remote server over HTTP.
+Download files from a remote HTTP server to disk
 
 ## Install
 
@@ -56,7 +57,18 @@ import { upload } from 'tauri-plugin-upload-api'
 upload(
     'https://example.com/file-upload'
     './path/to/my/file.txt'
-    (progress, total) => console.log(`Downloaded ${progress} of ${total} bytes`) // a callback that will be called with the upload progress
+    (progress, total) => console.log(`Uploaded ${progress} of ${total} bytes`) // a callback that will be called with the upload progress
+    { 'ContentType': 'text/plain' } // optional headers to send with the request
+)
+```
+
+```javascript
+import { download } from "tauri-plugin-upload-api";
+
+download(
+    'https://example.com/file-download-link'
+    './path/to/save/my/file.txt'
+    (progress, total) => console.log(`Downloaded ${progress} of ${total} bytes`) // a callback that will be called with the download progress
     { 'ContentType': 'text/plain' } // optional headers to send with the request
 )
 ```

--- a/plugins/upload/README.md
+++ b/plugins/upload/README.md
@@ -1,7 +1,7 @@
 ![plugin-upload](banner.png)
 
 Upload files from disk to a remote server over HTTP.
-Download files from a remote HTTP server to disk
+Download files from a remote HTTP server to disk.
 
 ## Install
 
@@ -55,10 +55,10 @@ Afterwards all the plugin's APIs are available through the JavaScript guest bind
 import { upload } from 'tauri-plugin-upload-api'
 
 upload(
-    'https://example.com/file-upload'
-    './path/to/my/file.txt'
-    (progress, total) => console.log(`Uploaded ${progress} of ${total} bytes`) // a callback that will be called with the upload progress
-    { 'ContentType': 'text/plain' } // optional headers to send with the request
+    'https://example.com/file-upload',
+    './path/to/my/file.txt',
+    (progress, total) => console.log(`Uploaded ${progress} of ${total} bytes`), // a callback that will be called with the upload progress
+    { 'Content-Type': 'text/plain' } // optional headers to send with the request
 )
 ```
 
@@ -66,10 +66,10 @@ upload(
 import { download } from "tauri-plugin-upload-api";
 
 download(
-    'https://example.com/file-download-link'
-    './path/to/save/my/file.txt'
-    (progress, total) => console.log(`Downloaded ${progress} of ${total} bytes`) // a callback that will be called with the download progress
-    { 'ContentType': 'text/plain' } // optional headers to send with the request
+    'https://example.com/file-download-link',
+    './path/to/save/my/file.txt',
+    (progress, total) => console.log(`Downloaded ${progress} of ${total} bytes`), // a callback that will be called with the download progress
+    { 'Content-Type': 'text/plain' } // optional headers to send with the request
 )
 ```
 


### PR DESCRIPTION
# Need
Even though the `upload-plugin` supports download functionality too, there is no documentation regarding this so I added 
a brief documentation about the download functionality along with a small example similar to the upload function

## Changes Implemented

![image](https://github.com/tauri-apps/plugins-workspace/assets/72456774/19a85b2b-e2e4-4f31-b32a-90933685f35f)

![image](https://github.com/tauri-apps/plugins-workspace/assets/72456774/9ee6db0a-08ff-42a4-ad7f-628f3edaabf9)
In the console.log message, it was written download even though it is an upload function, same with the associated comment

![image](https://github.com/tauri-apps/plugins-workspace/assets/72456774/e7ef0bbb-1976-414b-a421-1099fd55baef)
Code example for download function