### PR TITLE
fix: exclude debug only function in release mode

### DIFF
--- a/plugins/window/src/lib.rs
+++ b/plugins/window/src/lib.rs
@@ -79,6 +79,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                         desktop_commands::set_icon,
                         desktop_commands::toggle_maximize,
                         desktop_commands::internal_toggle_maximize,
+                        #[cfg(any(debug_assertions, feature = "devtools"))]
                         desktop_commands::internal_toggle_devtools,
                     ]);
                 #[allow(clippy::needless_return)]


### PR DESCRIPTION
Resolves the following error
![image](https://github.com/tauri-apps/plugins-workspace/assets/79983560/37465c0b-06f3-4cf2-a8af-e8b0aeea1f6e)
