### PR TITLE
fix(stronghold) data race on initialization and wrong argument name

### DIFF
--- a/plugins/stronghold/guest-js/index.ts
+++ b/plugins/stronghold/guest-js/index.ts
@@ -378,7 +378,7 @@ export class Vault extends ProcedureExecutor {
       snapshotPath: this.path,
       client: this.client,
       vault: this.name,
-      location,
+      recordPath: location.payload.record,
     });
   }
 }

--- a/plugins/stronghold/guest-js/index.ts
+++ b/plugins/stronghold/guest-js/index.ts
@@ -390,14 +390,25 @@ export class Stronghold {
   path: string;
 
   /**
+   * Private constructor.
+   * Use `Stronghold.init` to create a Stronghold instance.
+   * @param path
+   * @param password
+   */
+  private constructor(path: string) {
+    this.path = path;
+  }
+
+  /**
    * Initializes a stronghold.
    * If the snapshot path located at `path` exists, the password must match.
    * @param path
    * @param password
    */
-  constructor(path: string, password: string) {
-    this.path = path;
-    void this.reload(password);
+  static async init(path: string, password: string): Promise<Stronghold> {
+    let stronghold = new Stronghold(path);
+    await stronghold.reload(password);
+    return stronghold;
   }
 
   /**


### PR DESCRIPTION
Small PR on two bugs that I found while looking at the Stronghold plugin

- [minor: Interface breaks] Data race on initialization of Stronghold (you could call Stronghold functions during initialization). New initialization function
- [patch] Fix wrong argument name

I have poor knowledge of JS so the data race fix might be improvable to not change the Stronghold interface 
