### PR TITLE
fix(dialog): using AsyncMessageDialog for non linux, closes tauri#7182

### DIFF
--- a/.changes/dialog-async-message-dialog.md
+++ b/.changes/dialog-async-message-dialog.md
@@ -1,0 +1,5 @@
+---
+"dialog": "patch"
+---
+
+On non-Linux system, use `AsyncMessageDialog` instead of `MessageDialog`. [(tauri#7182)](https://github.com/tauri-apps/tauri/issues/7182)

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -200,7 +200,9 @@ impl<R: Runtime> MessageDialogBuilder<R> {
         show_message_dialog(self, f)
     }
 
-    //// Shows a message dialog.
+    /// Shows a message dialog.
+    /// This is a blocking operation,
+    /// and should *NOT* be used when running on the main thread context.
     pub fn blocking_show(self) -> bool {
         blocking_fn!(self, show)
     }


### PR DESCRIPTION
Issue https://github.com/tauri-apps/tauri/issues/7182
Although the issue requests to center the dialog on the window, I think someone might want to center the dialog on the screen.

I'm trying to follow how `FileDialog` deals with the async dialog. Non-Linux systems will use the `AsyncMessageDialog`.

Tested in macOS, Windows, and Linux. Only macOS will center the dialog.