### PR TITLE
Fix README Javascript example

### DIFF
--- a/plugins/websocket/README.md
+++ b/plugins/websocket/README.md
@@ -51,7 +51,7 @@ fn main() {
 Afterwards all the plugin's APIs are available through the JavaScript guest bindings:
 
 ```javascript
-import { WebSocket } from "tauri-plugin-websocket-api";
+import WebSocket from "tauri-plugin-websocket-api";
 
 const ws = await WebSocket.connect("wss://example.com");
 


### PR DESCRIPTION
The example in the README doesn't work. Checking the examples/ directory, the import needs to be referenced differently.