### PR TITLE
fix(websocket): config

### DIFF
--- a/plugins/websocket/guest-js/index.ts
+++ b/plugins/websocket/guest-js/index.ts
@@ -1,7 +1,8 @@
 import { invoke, transformCallback } from "@tauri-apps/api/tauri";
 
 export interface ConnectionConfig {
-  maxSendQueue?: number;
+  writeBufferSize?: number;
+  maxWriteBufferSize?: number;
   maxMessageSize?: number;
   maxFrameSize?: number;
   acceptUnmaskedFrames?: boolean;

--- a/plugins/websocket/guest-js/index.ts
+++ b/plugins/websocket/guest-js/index.ts
@@ -1,10 +1,10 @@
 import { invoke, transformCallback } from "@tauri-apps/api/tauri";
 
 export interface ConnectionConfig {
-  maxSendQueue?: number
-  maxMessageSize?: number
-  maxFrameSize?: number
-  acceptUnmaskedFrames?: boolean
+  maxSendQueue?: number;
+  maxMessageSize?: number;
+  maxFrameSize?: number;
+  acceptUnmaskedFrames?: boolean;
 }
 
 export interface MessageKind<T, D> {
@@ -33,7 +33,10 @@ export default class WebSocket {
     this.listeners = listeners;
   }
 
-  static async connect(url: string, config?: ConnectionConfig): Promise<WebSocket> {
+  static async connect(
+    url: string,
+    config?: ConnectionConfig,
+  ): Promise<WebSocket> {
     const listeners: Array<(arg: Message) => void> = [];
     const handler = (message: Message): void => {
       listeners.forEach((l) => l(message));

--- a/plugins/websocket/guest-js/index.ts
+++ b/plugins/websocket/guest-js/index.ts
@@ -26,17 +26,19 @@ export default class WebSocket {
     this.listeners = listeners;
   }
 
-  static async connect(url: string, options?: unknown): Promise<WebSocket> {
+  static async connect(url: string, config?: unknown): Promise<WebSocket> {
     const listeners: Array<(arg: Message) => void> = [];
     const handler = (message: Message): void => {
       listeners.forEach((l) => l(message));
     };
 
-    return await invoke<number>("plugin:websocket|connect", {
-      url,
-      callbackFunction: transformCallback(handler),
-      options,
-    }).then((id) => new WebSocket(id, listeners));
+    return await window
+      .__TAURI_INVOKE__<number>("plugin:websocket|connect", {
+        url,
+        callbackFunction: window.__TAURI__.transformCallback(handler),
+        config,
+      })
+      .then((id) => new WebSocket(id, listeners));
   }
 
   addListener(cb: (arg: Message) => void): void {

--- a/plugins/websocket/guest-js/index.ts
+++ b/plugins/websocket/guest-js/index.ts
@@ -1,5 +1,12 @@
 import { invoke, transformCallback } from "@tauri-apps/api/tauri";
 
+export interface ConnectionConfig {
+  maxSendQueue?: number
+  maxMessageSize?: number
+  maxFrameSize?: number
+  acceptUnmaskedFrames?: boolean
+}
+
 export interface MessageKind<T, D> {
   type: T;
   data: D;
@@ -26,7 +33,7 @@ export default class WebSocket {
     this.listeners = listeners;
   }
 
-  static async connect(url: string, config?: unknown): Promise<WebSocket> {
+  static async connect(url: string, config?: ConnectionConfig): Promise<WebSocket> {
     const listeners: Array<(arg: Message) => void> = [];
     const handler = (message: Message): void => {
       listeners.forEach((l) => l(message));

--- a/plugins/websocket/guest-js/index.ts
+++ b/plugins/websocket/guest-js/index.ts
@@ -42,13 +42,11 @@ export default class WebSocket {
       listeners.forEach((l) => l(message));
     };
 
-    return await window
-      .__TAURI_INVOKE__<number>("plugin:websocket|connect", {
-        url,
-        callbackFunction: window.__TAURI__.transformCallback(handler),
-        config,
-      })
-      .then((id) => new WebSocket(id, listeners));
+    return await invoke<number>("plugin:websocket|connect", {
+      url,
+      callbackFunction: transformCallback(handler),
+      config,
+    }).then((id) => new WebSocket(id, listeners));
   }
 
   addListener(cb: (arg: Message) => void): void {

--- a/plugins/websocket/src/lib.rs
+++ b/plugins/websocket/src/lib.rs
@@ -42,14 +42,14 @@ impl Serialize for Error {
 #[derive(Default)]
 struct ConnectionManager(Mutex<HashMap<Id, WebSocketWriter>>);
 
-#[derive(Default, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectionConfig {
     pub write_buffer_size: Option<usize>,
     pub max_write_buffer_size: Option<usize>,
     pub max_message_size: Option<usize>,
     pub max_frame_size: Option<usize>,
-    pub accept_unmasked_frames: bool,
+    pub accept_unmasked_frames: Option<bool>,
 }
 
 impl From<ConnectionConfig> for WebSocketConfig {
@@ -64,7 +64,7 @@ impl From<ConnectionConfig> for WebSocketConfig {
             max_message_size: config.max_message_size,
             // This may be harmful since if it's not provided from js we're overwriting the default value with None, meaning no size limit.
             max_frame_size: config.max_frame_size,
-            accept_unmasked_frames: config.accept_unmasked_frames,
+            accept_unmasked_frames: config.accept_unmasked_frames.unwrap_or_default(),
         }
     }
 }

--- a/plugins/websocket/src/lib.rs
+++ b/plugins/websocket/src/lib.rs
@@ -49,7 +49,8 @@ pub struct ConnectionConfig {
     pub max_write_buffer_size: Option<usize>,
     pub max_message_size: Option<usize>,
     pub max_frame_size: Option<usize>,
-    pub accept_unmasked_frames: Option<bool>,
+    #[serde(default)]
+    pub accept_unmasked_frames: bool,
 }
 
 impl From<ConnectionConfig> for WebSocketConfig {
@@ -64,7 +65,7 @@ impl From<ConnectionConfig> for WebSocketConfig {
             max_message_size: config.max_message_size,
             // This may be harmful since if it's not provided from js we're overwriting the default value with None, meaning no size limit.
             max_frame_size: config.max_frame_size,
-            accept_unmasked_frames: config.accept_unmasked_frames.unwrap_or_default(),
+            accept_unmasked_frames: config.accept_unmasked_frames,
         }
     }
 }


### PR DESCRIPTION
In the current version of the tauri-websocket plugin, configurations are being ignored due to the disparity in naming between JavaScript's guest-js and Rust implementation. This Pull Request resolves the issue by aligning the name inside guest-js to 'config', ensuring the configurations function as intended.