### PR TITLE
fix: tuple to struct variant

### DIFF
--- a/.changes/fix-tuple-to-struct-variant.md
+++ b/.changes/fix-tuple-to-struct-variant.md
@@ -1,0 +1,5 @@
+---
+window: patch
+---
+
+`FileDropEvent` has been changed from a struct variant to a tuple variant.

--- a/plugins/fs/src/lib.rs
+++ b/plugins/fs/src/lib.rs
@@ -83,7 +83,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R, Option<Config>> {
         .on_event(|app, event| {
             if let RunEvent::WindowEvent {
                 label: _,
-                event: WindowEvent::FileDrop(FileDropEvent::Dropped(paths)),
+                event: WindowEvent::FileDrop(FileDropEvent::Dropped { paths, .. }),
                 ..
             } = event
             {


### PR DESCRIPTION
`FileDropEvent` is now a struct variant instead of a tuple variant.