### PR TITLE
fix(window): use `button` property for `data-tauri-drag-region` left mouse button detection

### DIFF
--- a/.changes/window-tap-drag-region-detection.md
+++ b/.changes/window-tap-drag-region-detection.md
@@ -1,0 +1,5 @@
+---
+"window": "patch"
+---
+
+On macOS, fixed tapping on custom title bar doesn't maximize the window.

--- a/plugins/window/src/scripts/drag.js
+++ b/plugins/window/src/scripts/drag.js
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 document.addEventListener("mousedown", (e) => {
-  if (e.target.hasAttribute("data-tauri-drag-region") && e.buttons === 1) {
+  if (e.target.hasAttribute("data-tauri-drag-region") && e.button === 0) {
     // prevents text cursor
     e.preventDefault();
     // fix #2549: double click on drag region edge causes content to maximize without window sizing change


### PR DESCRIPTION
Relates to [[bug] double tap on data-tauri-drag-region doesn't work #7694](https://github.com/tauri-apps/tauri/issues/7694)

Updated the `data-tauri-drag-region` attribute to use the `button` property instead of the `buttons` property to check if the left mouse button was pressed. 

This change is intended to fix an issue that if the "Tap to Click" option is enabled on the macOS, `event.buttons` will return `0` and `1` randomly when tapping the element.

**Behavior changed**
Before this patch, the `drag` event will be triggered only when the left mouse button is pressed. In this patch, if multiple mouse buttons are clicked along with the left mouse button simultaneously, it would see as the left mouse button clicked and trigger the `drag` event.

