### PR TITLE
fix(notification): function 'invoke' not found in permission request 

### DIFF
--- a/plugins/notification/src/init.js
+++ b/plugins/notification/src/init.js
@@ -21,8 +21,7 @@
   }
 
   function requestPermission() {
-    return window.__TAURI__
-      .invoke("plugin:notification|request_permission")
+    return window.__TAURI_INVOKE__("plugin:notification|request_permission")
       .then(function (permission) {
         setNotificationPermission(permission);
         return permission;


### PR DESCRIPTION
Use `__TAURI_INVOKE__` instead of `__TAURI__.invoke`