### PR TITLE
add support for absolute sqlite db path in case of using tauri dialog…

### DIFF
--- a/plugins/sql/src/plugin.rs
+++ b/plugins/sql/src/plugin.rs
@@ -73,6 +73,18 @@ fn app_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
 /// Maps the user supplied DB connection string to a connection string
 /// with a fully qualified file path to the App's designed "app_path"
 fn path_mapper(mut app_path: PathBuf, connection_string: &str) -> String {
+    if connection_string.contains(std::path::MAIN_SEPARATOR_STR) {
+        let file_path = std::path::Path::new(connection_string);
+        if file_path.exists() {
+            format!(
+                "sqlite:{}",
+                connection_string
+                    .split_once(':')
+                    .expect("Couldn't parse the connection string for DB!")
+                    .1
+            )
+        };
+    }
     app_path.push(
         connection_string
             .split_once(':')


### PR DESCRIPTION
Since tauri provide dialog api, we can use it to browse files on the computer and get the file's absolute path, it is more flexible to make the sqlite plugin adapt to that, so user can operate on any sqlite db file in their computer, no need to put db file to the app's path anymore.