### PR TITLE
Fix incomplete overwriting behaviour in fs.writeFile.

### DIFF
--- a/plugins/fs/src/commands.rs
+++ b/plugins/fs/src/commands.rs
@@ -117,9 +117,9 @@ pub fn write_file<R: Runtime>(
         .with_context(|| format!("path: {}", resolved_path.display()))
         .map_err(Into::into)
         .and_then(|mut f| {
-            f.write_all(&contents)
-                .map_err(|err| anyhow::anyhow!("{}", err))
-                .map_err(Into::into)
+            f.write_all(&contents).map_err(|err| anyhow::anyhow!("{}", err))?;
+            f.set_len(contents.len() as u64).map_err(|err| anyhow::anyhow!("{}", err))?;
+            Ok(())
         })
 }
 


### PR DESCRIPTION
This contains the same fix as https://github.com/tauri-apps/tauri/pull/7982 which fixes https://github.com/tauri-apps/tauri/issues/7973 But as v2 moves things around a little bit the fix is necessary here as well.