### PR TITLE
feat: build docs.rs documentation for Android

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -155,10 +155,6 @@ jobs:
         if: matrix.package != 'tauri-plugin-sql'
         run: cargo clippy --package ${{ matrix.package }} --all-targets -- -D warnings
 
-      - name: clippy ${{ matrix.package }} --all-features
-        if: ${{ !contains(fromJSON('["tauri-plugin-http", "tauri-plugin-upload", "tauri-plugin-updater", "tauri-plugin-websocket", "tauri-plugin-sql"]'), matrix.package) }}
-        run: cargo clippy --package ${{ matrix.package }} --all-targets --all-features -- -D warnings
-
       - name: clippy ${{ matrix.package }} mysql
         if: matrix.package == 'tauri-plugin-sql'
         run: cargo clippy --package ${{ matrix.package }} --all-targets --no-default-features --features mysql -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ checksum = "f3125b15ec28b84c238f6f476c6034016a5f6cc0221cb514ca46c532139fc97d"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-sys-rs",
+ "freetype-rs",
  "glib",
  "libc",
  "once_cell",
@@ -760,6 +761,7 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+ "x11",
 ]
 
 [[package]]
@@ -916,6 +918,15 @@ dependencies = [
  "error-code",
  "str-buf",
  "winapi",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1755,6 +1766,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "freetype-rs"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4200d5c6da26d4b5acff9098c1747f9f86da5e0f23bd7d63fed4c4a07e0b60ba"
+dependencies = [
+ "bitflags 1.3.2",
+ "freetype-sys",
+ "libc",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17c696ead7d51c6c585f3513eee3b604a73c4e8345b16d450843eb0a59591b2"
+dependencies = [
+ "cmake",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,6 +2159,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
+ "log",
  "once_cell",
  "smallvec",
  "thiserror",

--- a/plugins/app/Cargo.toml
+++ b/plugins/app/Cargo.toml
@@ -5,6 +5,7 @@ description = "APIs to read application metadata and change app visibility on ma
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 features = [ "tauri/dox" ]

--- a/plugins/barcode-scanner/Cargo.toml
+++ b/plugins/barcode-scanner/Cargo.toml
@@ -5,7 +5,12 @@ description = "Scan QR codes, EAN-13 and other kinds of barcodes on Android and 
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 links = "tauri-plugin-barcode-scanner"
+
+[package.metadata.docs.rs]
+features = [ "dox" ]
+targets = [ "x86_64-linux-android" ]
 
 [build-dependencies]
 tauri-build = { workspace = true }
@@ -16,3 +21,6 @@ serde_json = { workspace = true }
 tauri = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
+
+[features]
+dox = [ "tauri/dox" ]

--- a/plugins/barcode-scanner/build.rs
+++ b/plugins/barcode-scanner/build.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::process::exit;
-
 fn main() {
     if let Err(error) = tauri_build::mobile::PluginBuilder::new()
         .android_path("android")
@@ -11,6 +9,9 @@ fn main() {
         .run()
     {
         println!("{error:#}");
-        exit(1);
+        // when building documentation for Android the plugin build result is irrelevant to the crate itself
+        if !(cfg!(feature = "dox") && std::env::var("TARGET").unwrap().contains("android")) {
+            std::process::exit(1);
+        }
     }
 }

--- a/plugins/cli/Cargo.toml
+++ b/plugins/cli/Cargo.toml
@@ -5,6 +5,7 @@ description = "Parse arguments from your Tauri application's command line interf
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 features = [ "tauri/dox" ]

--- a/plugins/clipboard-manager/Cargo.toml
+++ b/plugins/clipboard-manager/Cargo.toml
@@ -5,10 +5,15 @@ description = "Read and write to the system clipboard."
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 links = "tauri-plugin-clipboard-manager"
 
 [package.metadata.docs.rs]
-features = [ "tauri/dox" ]
+features = [ "dox" ]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "x86_64-linux-android"
+]
 
 [build-dependencies]
 tauri-build = { workspace = true }
@@ -22,3 +27,6 @@ thiserror = { workspace = true }
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 arboard = "3"
+
+[features]
+dox = [ "tauri/dox" ]

--- a/plugins/clipboard-manager/build.rs
+++ b/plugins/clipboard-manager/build.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::process::exit;
-
 fn main() {
     if let Err(error) = tauri_build::mobile::PluginBuilder::new()
         .android_path("android")
@@ -11,6 +9,9 @@ fn main() {
         .run()
     {
         println!("{error:#}");
-        exit(1);
+        // when building documentation for Android the plugin build result is irrelevant to the crate itself
+        if !(cfg!(feature = "dox") && std::env::var("TARGET").unwrap().contains("android")) {
+            std::process::exit(1);
+        }
     }
 }

--- a/plugins/deep-link/Cargo.toml
+++ b/plugins/deep-link/Cargo.toml
@@ -8,6 +8,10 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 links = "tauri-plugin-deep-link"
 
+[package.metadata.docs.rs]
+features = [ "dox" ]
+targets = [ "x86_64-linux-android" ]
+
 [build-dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -20,3 +24,6 @@ tauri = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
 url = "2"
+
+[features]
+dox = [ "tauri/dox" ]

--- a/plugins/deep-link/build.rs
+++ b/plugins/deep-link/build.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::process::exit;
-
 #[path = "src/config.rs"]
 mod config;
 use config::{AssociatedDomain, Config};
@@ -37,7 +35,9 @@ fn main() {
         .run()
     {
         println!("{error:#}");
-        exit(1);
+        if !(cfg!(feature = "dox") && std::env::var("TARGET").unwrap().contains("android")) {
+            std::process::exit(1);
+        }
     }
 
     if let Some(config) = tauri_build::config::plugin_config::<Config>("deep-link") {

--- a/plugins/dialog/Cargo.toml
+++ b/plugins/dialog/Cargo.toml
@@ -5,10 +5,15 @@ description = "Native system dialogs for opening and saving files along with mes
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 links = "tauri-plugin-dialog"
 
 [package.metadata.docs.rs]
-features = [ "tauri/dox" ]
+features = [ "dox" ]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "x86_64-linux-android"
+]
 
 [dependencies]
 serde = { workspace = true }
@@ -27,3 +32,6 @@ raw-window-handle = "0.5"
 
 [build-dependencies]
 tauri-build = { workspace = true }
+
+[features]
+dox = [ "tauri/dox" ]

--- a/plugins/dialog/build.rs
+++ b/plugins/dialog/build.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::process::exit;
-
 fn main() {
     if let Err(error) = tauri_build::mobile::PluginBuilder::new()
         .android_path("android")
@@ -11,6 +9,9 @@ fn main() {
         .run()
     {
         println!("{error:#}");
-        exit(1);
+        // when building documentation for Android the plugin build result is irrelevant to the crate itself
+        if !(cfg!(feature = "dox") && std::env::var("TARGET").unwrap().contains("android")) {
+            std::process::exit(1);
+        }
     }
 }

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -129,7 +129,7 @@ pub struct MessageDialogBuilder<R: Runtime> {
 #[cfg(mobile)]
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct MessageDialogPayload<'a> {
+pub(crate) struct MessageDialogPayload<'a> {
     title: &'a String,
     message: &'a String,
     kind: &'a MessageDialogKind,
@@ -272,7 +272,7 @@ pub struct FileDialogBuilder<R: Runtime> {
 #[cfg(mobile)]
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct FileDialogPayload<'a> {
+pub(crate) struct FileDialogPayload<'a> {
     filters: &'a Vec<Filter>,
     multiple: bool,
 }

--- a/plugins/global-shortcut/Cargo.toml
+++ b/plugins/global-shortcut/Cargo.toml
@@ -5,6 +5,7 @@ description = "Register global hotkeys listeners on your Tauri application."
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 features = [ "tauri/dox" ]

--- a/plugins/http/Cargo.toml
+++ b/plugins/http/Cargo.toml
@@ -5,6 +5,7 @@ description = "Access an HTTP client written in Rust."
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 features = [ "tauri/dox" ]

--- a/plugins/notification/Cargo.toml
+++ b/plugins/notification/Cargo.toml
@@ -5,10 +5,15 @@ description = "Send desktop and mobile notifications on your Tauri application."
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 links = "tauri-plugin-notification"
 
 [package.metadata.docs.rs]
-features = [ "tauri/dox" ]
+features = [ "dox" ]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "x86_64-linux-android"
+]
 
 [build-dependencies]
 tauri-build = { workspace = true }
@@ -32,3 +37,4 @@ win7-notifications = { version = "0.3.1", optional = true }
 
 [features]
 windows7-compat = [ "win7-notifications" ]
+dox = [ "tauri/dox" ]

--- a/plugins/notification/build.rs
+++ b/plugins/notification/build.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::process::exit;
-
 fn main() {
     if let Err(error) = tauri_build::mobile::PluginBuilder::new()
         .android_path("android")
@@ -11,6 +9,9 @@ fn main() {
         .run()
     {
         println!("{error:#}");
-        exit(1);
+        // when building documentation for Android the plugin build result is irrelevant to the crate itself
+        if !(cfg!(feature = "dox") && std::env::var("TARGET").unwrap().contains("android")) {
+            std::process::exit(1);
+        }
     }
 }

--- a/plugins/os/Cargo.toml
+++ b/plugins/os/Cargo.toml
@@ -5,6 +5,7 @@ description = "Read information about the operating system."
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 features = [ "tauri/dox" ]

--- a/plugins/process/Cargo.toml
+++ b/plugins/process/Cargo.toml
@@ -5,6 +5,7 @@ description = "Access the current process of your Tauri application."
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 features = [ "tauri/dox" ]

--- a/plugins/shell/Cargo.toml
+++ b/plugins/shell/Cargo.toml
@@ -5,6 +5,7 @@ description = "Access the system shell. Allows you to spawn child processes and 
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 features = [ "tauri/dox" ]

--- a/plugins/updater/Cargo.toml
+++ b/plugins/updater/Cargo.toml
@@ -5,6 +5,7 @@ description = "In-app updates for Tauri applications."
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 features = [ "tauri/dox" ]

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -431,7 +431,7 @@ impl Update {
         self.install(bytes)
     }
 
-    #[cfg(any(target_os = "android", target_os = "ios"))]
+    #[cfg(mobile)]
     fn install_inner(&self, bytes: Vec<u8>) -> Result<()> {
         Ok(())
     }

--- a/plugins/window/Cargo.toml
+++ b/plugins/window/Cargo.toml
@@ -5,6 +5,7 @@ description = "Interact with the Tauri window."
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 features = [ "tauri/dox" ]

--- a/shared/template/Cargo.toml
+++ b/shared/template/Cargo.toml
@@ -7,7 +7,7 @@ license = { workspace = true }
 links = "tauri-plugin-{{name}}"
 
 [package.metadata.docs.rs]
-features = [ "tauri/dox" ]
+features = [ "dox" ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,3 +20,6 @@ serde_json = { workspace = true }
 tauri = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
+
+[features]
+dox = [ "tauri/dox" ]

--- a/shared/template/build.rs
+++ b/shared/template/build.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::process::exit;
-
 fn main() {
     if let Err(error) = tauri_build::mobile::PluginBuilder::new()
         .android_path("android")
@@ -11,6 +9,9 @@ fn main() {
         .run()
     {
         println!("{error:#}");
-        exit(1);
+        // when building documentation for Android the plugin build result is irrelevant to the crate itself
+        if !(cfg!(feature = "dox") && std::env::var("TARGET").unwrap().contains("android")) {
+            std::process::exit(1);
+        }
     }
 }


### PR DESCRIPTION
I had to adapt our build scripts to not fail on Android because it tries to write to the crate's `android` folder and the filesystem is read-only on the docs.rs VM.

iOS doesn't work because it needs `xcrun` (swift-rs). I didn't bother adapting to it because we don't have any iOS-only APIs yet. Otherwise we'd need to "mock" the plugin init function, and let the build script fail (or skip running it).