### PR TITLE
fix(updater): Fix endpoint string replacements, fixes #655

### DIFF
--- a/.changes/updater-string-replace.md
+++ b/.changes/updater-string-replace.md
@@ -1,0 +1,5 @@
+---
+"updater": "patch"
+---
+
+The plugin now correctly replaces `arch`, `current_version` and `target` again.

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -259,7 +259,10 @@ impl Updater {
             let url: Url = url
                 .to_string()
                 // url::Url automatically url-encodes the string
-                .replace("%7B%7Bcurrent_version%7D%7D", &self.current_version.to_string())
+                .replace(
+                    "%7B%7Bcurrent_version%7D%7D",
+                    &self.current_version.to_string(),
+                )
                 .replace("%7B%7Btarget%7D%7D", &self.target)
                 .replace("%7B%7Barch%7D%7D", self.arch)
                 .parse()?;

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -258,9 +258,10 @@ impl Updater {
             // the URL will be generated dynamically
             let url: Url = url
                 .to_string()
-                .replace("{{current_version}}", &self.current_version.to_string())
-                .replace("{{target}}", &self.target)
-                .replace("{{arch}}", self.arch)
+                // url::Url automatically url-encodes the string
+                .replace("%7B%7Bcurrent_version%7D%7D", &self.current_version.to_string())
+                .replace("%7B%7Btarget%7D%7D", &self.target)
+                .replace("%7B%7Barch%7D%7D", self.arch)
                 .parse()?;
 
             let mut request = Client::new().get(url).headers(headers.clone());


### PR DESCRIPTION
i know it's ugly and i'm open for discussion.
One thing i really wanted to avoid though was decoding the url just for the replacement, to be 100% sure not to mess up whatever url the user provided.
So the only 2 solutions i could think of were this, or reverting it to a simple String again but i wanted to keep the Url validation in the Deserialization impl but that would have made error handling ugly at first glance.

Maybe i'm just too tired and overthinking this while missing the obvious...