### PR TITLE
fix(authenticator): u2f cannot handle the chrono 0.4.30 breaking change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "d87d9d13be47a5b7c3907137f1290b0459a7f80efb26be8c52afb11963bccb02"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -852,7 +852,7 @@ dependencies = [
  "serde",
  "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/plugins/authenticator/Cargo.toml
+++ b/plugins/authenticator/Cargo.toml
@@ -23,7 +23,7 @@ once_cell = "1"
 sha2 = "0.10"
 base64 = "0.21"
 u2f = "0.2"
-chrono = "=0.4.29"
+chrono = "<=0.4.29"
 
 [dev-dependencies]
 rand = "0.8"

--- a/plugins/authenticator/Cargo.toml
+++ b/plugins/authenticator/Cargo.toml
@@ -23,7 +23,7 @@ once_cell = "1"
 sha2 = "0.10"
 base64 = "0.21"
 u2f = "0.2"
-chrono = "0.4"
+chrono = "=0.4.29"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
see https://github.com/chronotope/chrono/releases/tag/v0.4.30

```
Compiling u2f v0.2.0
error[E0308]: mismatched types
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/u2f-0.2.0/src/util.rs:25:5
   |
20 | pub fn expiration(timestamp: String) -> Duration {
   |                                         -------- expected `time::Duration` because of return type
...
25 |     now.signed_duration_since(ts.unwrap())
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `time::Duration`, found `chrono::Duration`
   |
   = note: `chrono::Duration` and `time::Duration` have similar names, but are actually distinct types
note: `chrono::Duration` is defined in crate `chrono`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/chrono-0.4.31/src/duration.rs:55:1
   |
55 | pub struct Duration {
   | ^^^^^^^^^^^^^^^^^^^
note: `time::Duration` is defined in crate `time`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.1.45/src/duration.rs:45:1
   |
45 | pub struct Duration {
   | ^^^^^^^^^^^^^^^^^^^
```