### PR TITLE
dialog: pass readData through to mobile plugin

### DIFF
--- a/plugins/dialog/android/src/main/java/DialogPlugin.kt
+++ b/plugins/dialog/android/src/main/java/DialogPlugin.kt
@@ -49,6 +49,7 @@ class DialogPlugin(private val activity: Activity): Plugin(activity) {
   fun showFilePicker(invoke: Invoke) {
     try {
       val args = invoke.parseArgs(FilePickerOptions::class.java)
+      filePickerOptions = args
       val parsedTypes = parseFiltersOption(args.filters)
       
       val intent = if (parsedTypes.isNotEmpty()) {

--- a/plugins/dialog/src/commands.rs
+++ b/plugins/dialog/src/commands.rs
@@ -51,6 +51,10 @@ pub struct OpenDialogOptions {
     #[serde(default)]
     #[cfg_attr(mobile, allow(dead_code))]
     recursive: bool,
+    /// Read the contents of the selected files
+    #[serde(default)]
+    #[cfg_attr(desktop, allow(dead_code))]
+    read_data: bool,
 }
 
 /// The options for the save dialog API.
@@ -107,6 +111,11 @@ pub(crate) async fn open<R: Runtime>(
         let extensions: Vec<&str> = filter.extensions.iter().map(|s| &**s).collect();
         dialog_builder = dialog_builder.add_filter(filter.name, &extensions);
     }
+    #[cfg(mobile)]
+    {
+        dialog_builder = dialog_builder.set_read_data(options.read_data);
+    }
+
 
     let res = if options.directory {
         #[cfg(desktop)]

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -267,6 +267,8 @@ pub struct FileDialogBuilder<R: Runtime> {
     pub(crate) title: Option<String>,
     #[cfg(desktop)]
     pub(crate) parent: Option<raw_window_handle::RawWindowHandle>,
+    #[cfg(mobile)]
+    pub(crate) read_data: bool,
 }
 
 #[cfg(mobile)]
@@ -275,6 +277,8 @@ pub struct FileDialogBuilder<R: Runtime> {
 pub(crate) struct FileDialogPayload<'a> {
     filters: &'a Vec<Filter>,
     multiple: bool,
+    read_data: bool
+
 }
 
 // raw window handle :(
@@ -291,6 +295,8 @@ impl<R: Runtime> FileDialogBuilder<R> {
             title: None,
             #[cfg(desktop)]
             parent: None,
+            #[cfg(mobile)]
+            read_data: false,
         }
     }
 
@@ -299,6 +305,7 @@ impl<R: Runtime> FileDialogBuilder<R> {
         FileDialogPayload {
             filters: &self.filters,
             multiple,
+            read_data: self.read_data,
         }
     }
 
@@ -338,6 +345,13 @@ impl<R: Runtime> FileDialogBuilder<R> {
     #[must_use]
     pub fn set_title(mut self, title: impl Into<String>) -> Self {
         self.title.replace(title.into());
+        self
+    }
+
+    #[cfg(mobile)]
+    #[must_use]
+    pub fn set_read_data(mut self, read_data: bool) -> Self {
+        self.read_data = read_data;
         self
     }
 

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -127,7 +127,7 @@ impl From<Command> for StdCommand {
 }
 
 impl Command {
-    pub(crate) fn new<S: AsRef<OsStr>>(program: S) -> Self {
+    pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
         let mut command = StdCommand::new(program);
 
         command.stdout(Stdio::piped());
@@ -139,7 +139,7 @@ impl Command {
         Self(command)
     }
 
-    pub(crate) fn new_sidecar<S: AsRef<Path>>(program: S) -> crate::Result<Self> {
+    pub fn new_sidecar<S: AsRef<Path>>(program: S) -> crate::Result<Self> {
         Ok(Self::new(relative_command_path(program.as_ref())?))
     }
 


### PR DESCRIPTION
This enables passing `readData` as an argument to `OpenDialogOptions` to enable reading selected files on Android. While the Dialog plugin code for Android correctly deals with `readData` and populates `base64Data` (which allows Android `ContentProvider` to be read from guest-js), the argument itself can't currently be populated from guest-js and used 🙂 