### PR TITLE
fix(updater): Use escaped installer path to start the nsis updater

### DIFF
--- a/.changes/updater-escaped-path.md
+++ b/.changes/updater-escaped-path.md
@@ -1,0 +1,5 @@
+---
+updater: patch
+---
+
+Use escaped installer path to start the nsis updater to prevent crashes if app name contained spaces.

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -501,7 +501,7 @@ impl Update {
                 Command::new(powershell_path)
                     .args(["-NoProfile", "-WindowStyle", "Hidden"])
                     .args(["Start-Process"])
-                    .arg(found_path)
+                    .arg(installer_arg)
                     .arg("-ArgumentList")
                     .arg(
                         [


### PR DESCRIPTION
Port of v1 change: https://github.com/tauri-apps/tauri/pull/7956