### PR TITLE
fix(updater): Use escaped installer path to start the msi updater

### DIFF
--- a/.changes/updater-escaped-path.md
+++ b/.changes/updater-escaped-path.md
@@ -2,4 +2,4 @@
 updater: patch
 ---
 
-Use escaped installer path to start the nsis updater to prevent crashes if app name contained spaces.
+Use escaped installer path to start the nsis/msi updater to prevent crashes if app name contained spaces.

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -551,7 +551,7 @@ impl Update {
                         "-ArgumentList",
                     ])
                     .arg("/i,")
-                    .arg(msi_path_arg)
+                    .arg(&msi_path_arg)
                     .arg(format!(", {}, /promptrestart;", msiexec_args.join(", ")))
                     .arg("Start-Process")
                     .arg(current_exe_arg)

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -565,7 +565,7 @@ impl Update {
                     );
                     let _ = Command::new(msiexec_path)
                         .arg("/i")
-                        .arg(found_path)
+                        .arg(msi_path_arg)
                         .args(msiexec_args)
                         .arg("/promptrestart")
                         .spawn();


### PR DESCRIPTION
Continuation of #727