### PR TITLE
fix: add back `main`, `module` and `types` field in top-level package.json

### DIFF
--- a/plugins/authenticator/package.json
+++ b/plugins/authenticator/package.json
@@ -7,6 +7,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/autostart/package.json
+++ b/plugins/autostart/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/barcode-scanner/package.json
+++ b/plugins/barcode-scanner/package.json
@@ -7,6 +7,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/cli/package.json
+++ b/plugins/cli/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/clipboard-manager/package.json
+++ b/plugins/clipboard-manager/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/deep-link/package.json
+++ b/plugins/deep-link/package.json
@@ -7,6 +7,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/dialog/package.json
+++ b/plugins/dialog/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/fs/package.json
+++ b/plugins/fs/package.json
@@ -7,6 +7,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/global-shortcut/package.json
+++ b/plugins/global-shortcut/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/http/package.json
+++ b/plugins/http/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/log/package.json
+++ b/plugins/log/package.json
@@ -7,6 +7,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/notification/package.json
+++ b/plugins/notification/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/os/package.json
+++ b/plugins/os/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/positioner/package.json
+++ b/plugins/positioner/package.json
@@ -7,6 +7,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/process/package.json
+++ b/plugins/process/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/shell/package.json
+++ b/plugins/shell/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/sql/package.json
+++ b/plugins/sql/package.json
@@ -7,6 +7,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/store/package.json
+++ b/plugins/store/package.json
@@ -7,6 +7,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/stronghold/package.json
+++ b/plugins/stronghold/package.json
@@ -7,6 +7,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/updater/package.json
+++ b/plugins/updater/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/upload/package.json
+++ b/plugins/upload/package.json
@@ -7,6 +7,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/websocket/package.json
+++ b/plugins/websocket/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/plugins/window-state/package.json
+++ b/plugins/window-state/package.json
@@ -7,6 +7,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",

--- a/shared/template/package.json
+++ b/shared/template/package.json
@@ -6,6 +6,9 @@
     "Tauri Programme within The Commons Conservancy"
   ],
   "type": "module",
+  "types": "./dist-js/index.d.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
   "exports": {
     "types": "./dist-js/index.d.ts",
     "import": "./dist-js/index.js",


### PR DESCRIPTION
closes #738

`"moduleResolution": "node"` doesn't handle the `exports` field