### PR TITLE
Fix incorrect usage of RemoteDomainAccessScope in README.

### DIFF
--- a/plugins/localhost/README.md
+++ b/plugins/localhost/README.md
@@ -42,7 +42,7 @@ fn main() {
     .plugin(tauri_plugin_localhost::Builder::new(port).build())
     .setup(move |app| {
       app.ipc_scope().configure_remote_access(
-        RemoteDomainAccessScope::new(format!("localhost", port))
+        RemoteDomainAccessScope::new("localhost")
           .add_window("main")
       );
 

--- a/plugins/localhost/README.md
+++ b/plugins/localhost/README.md
@@ -42,7 +42,7 @@ fn main() {
     .plugin(tauri_plugin_localhost::Builder::new(port).build())
     .setup(move |app| {
       app.ipc_scope().configure_remote_access(
-        RemoteDomainAccessScope::new(format!("localhost:{}", port))
+        RemoteDomainAccessScope::new(format!("localhost", port))
           .add_window("main")
       );
 


### PR DESCRIPTION
The issue originates from: [#8287](https://github.com/tauri-apps/tauri/issues/8287)