### PR TITLE
ci: Test rust crates with all features enabled

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -192,8 +192,12 @@ jobs:
         run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: test ${{ matrix.package }}
-        if: matrix.package != 'tauri-plugin-sql'
+        if: matrix.package != 'tauri-plugin-sql' && matrix.package != 'tauri-plugin-http'
         run: ${{ matrix.platform.runner }} ${{ matrix.platform.command }} --package ${{ matrix.package }} --target ${{ matrix.platform.target }} --all-targets --all-features
+
+      - name: test ${{ matrix.package }}
+        if: matrix.package == 'tauri-plugin-http'
+        run: ${{ matrix.platform.runner }} ${{ matrix.platform.command }} --package ${{ matrix.package }} --target ${{ matrix.platform.target }} --all-targets
 
       - name: test ${{ matrix.package }} sqlite
         if: matrix.package == 'tauri-plugin-sql'

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -193,7 +193,11 @@ jobs:
 
       - name: test ${{ matrix.package }}
         if: matrix.package != 'tauri-plugin-sql'
-        run: ${{ matrix.platform.runner }} ${{ matrix.platform.command }} --package ${{ matrix.package }} --target ${{ matrix.platform.target }} --all-targets
+        run: ${{ matrix.platform.runner }} ${{ matrix.platform.command }} --package ${{ matrix.package }} --target ${{ matrix.platform.target }} --all-targets --all-features
+
+      - name: test ${{ matrix.package }} sqlite
+        if: matrix.package == 'tauri-plugin-sql'
+        run: ${{ matrix.platform.runner }} ${{ matrix.platform.command }} --package ${{ matrix.package }} --target ${{ matrix.platform.target }} --all-targets --features sqlite
 
       - name: test ${{ matrix.package }} mysql
         if: matrix.package == 'tauri-plugin-sql'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3517,30 +3517,32 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.2.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
+ "log",
  "mio",
  "serde",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "notify-debouncer-mini"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23e9fa24f094b143c1eb61f90ac6457de87be6987bc70746e0179f7dbc9007b"
+checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
 dependencies = [
  "crossbeam-channel",
+ "log",
  "notify",
  "serde",
 ]

--- a/plugins/fs/Cargo.toml
+++ b/plugins/fs/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 anyhow = "1"
 uuid = { version = "1", features = [ "v4" ] }
 glob = "0.3"
-notify = { version = "5", optional = true, features = [ "serde" ] }
-notify-debouncer-mini = { version = "0.2.1", optional = true, features = [ "serde" ] }
+notify = { version = "6", optional = true, features = [ "serde" ] }
+notify-debouncer-mini = { version = "0.4", optional = true, features = [ "serde" ] }
 
 [features]
 watch = [ "notify", "notify-debouncer-mini" ]


### PR DESCRIPTION
Came up when testing https://github.com/tauri-apps/plugins-workspace/pull/751 which fails to compile with the `watch` feature enabled.