### PR TITLE
chore: Disable workspace inheritance for [package]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,16 +3549,14 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
+checksum = "af6c4b23d99685a1408194da11270ef8e9809aff951cc70ec9b17350b087e474"
 dependencies = [
- "byteorder",
  "const-oid",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ tauri-build = "1"
 serde_json = "1"
 thiserror = "1"
 
+# TODO: Make plugins use these again once dependabot supports it.
 [workspace.package]
 edition = "2021"
 authors = [ "Tauri Programme within The Commons Conservancy" ]

--- a/plugins/authenticator/Cargo.toml
+++ b/plugins/authenticator/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-authenticator"
 version = "0.0.0"
 description = "Use hardware security-keys in your Tauri App."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/autostart/Cargo.toml
+++ b/plugins/autostart/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-autostart"
 version = "0.0.0"
 description = "Automatically launch your application at startup."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/fs-extra/Cargo.toml
+++ b/plugins/fs-extra/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-fs-extra"
 version = "0.0.0"
 description = "Additional file system methods not included in the core API."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/fs-watch/Cargo.toml
+++ b/plugins/fs-watch/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-fs-watch"
 version = "0.0.0"
 description = "Watch files and directories for changes."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/localhost/Cargo.toml
+++ b/plugins/localhost/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-localhost"
 version = "0.1.0"
 description = "Expose your apps assets through a localhost server instead of the default custom protocol."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/log/Cargo.toml
+++ b/plugins/log/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-log"
 version = "0.0.0"
 description = "Configurable logging for your Tauri app."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/persisted-scope/Cargo.toml
+++ b/plugins/persisted-scope/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-persisted-scope"
 version = "0.1.3"
 description = "Save filesystem and asset scopes and restore them when the app is reopened."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/positioner/Cargo.toml
+++ b/plugins/positioner/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-positioner"
 version = "1.0.4"
 description = "Position your windows at well-known locations."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/single-instance/Cargo.toml
+++ b/plugins/single-instance/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-single-instance"
 version = "0.0.0"
 description = "Ensure a single instance of your tauri app is running."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 exclude = ["/examples"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plugins/sql/Cargo.toml
+++ b/plugins/sql/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-sql"
 version = "0.0.0"
 description = "Interface with SQL databases."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-#rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+#rust-version = "1.64"
 rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plugins/store/Cargo.toml
+++ b/plugins/store/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-store"
 version = "0.0.0"
 description = "Simple, persistent key-value store."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/stronghold/Cargo.toml
+++ b/plugins/stronghold/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-stronghold"
 version = "0.0.0"
 description = "Store secrets and keys using the IOTA Stronghold encrypted database."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/upload/Cargo.toml
+++ b/plugins/upload/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-upload"
 version = "0.0.0"
 description = "Upload files from disk to a remote server over HTTP."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/websocket/Cargo.toml
+++ b/plugins/websocket/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "tauri-plugin-websocket"
 version = "0.0.0"
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 exclude = ["/examples"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plugins/window-state/Cargo.toml
+++ b/plugins/window-state/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-window-state"
 version = "0.1.0"
 description = "Save window positions and sizes and restore them when the app is reopened."
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/shared/template/Cargo.toml
+++ b/shared/template/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "tauri-plugin-{{name}}"
 version = "0.0.0"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+edition = "2021"
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+license = "Apache-2.0 OR MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Currently dependabot fails with errors like these:

![grafik](https://github.com/tauri-apps/plugins-workspace/assets/30730186/4252752f-2d30-4c3e-a78e-946d8260f357)

and i'd rather have it figure it out again instead of me dismissing 20 incorrect security alerts.