### PR TITLE
Revert "chore: Disable workspace inheritance for [package] (#775)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,14 +3549,16 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6c4b23d99685a1408194da11270ef8e9809aff951cc70ec9b17350b087e474"
+checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
 dependencies = [
+ "byteorder",
  "const-oid",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
+ "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ tauri-build = "1"
 serde_json = "1"
 thiserror = "1"
 
-# TODO: Make plugins use these again once dependabot supports it.
 [workspace.package]
 edition = "2021"
 authors = [ "Tauri Programme within The Commons Conservancy" ]

--- a/plugins/authenticator/Cargo.toml
+++ b/plugins/authenticator/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-authenticator"
 version = "0.0.0"
 description = "Use hardware security-keys in your Tauri App."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/autostart/Cargo.toml
+++ b/plugins/autostart/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-autostart"
 version = "0.0.0"
 description = "Automatically launch your application at startup."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/fs-extra/Cargo.toml
+++ b/plugins/fs-extra/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-fs-extra"
 version = "0.0.0"
 description = "Additional file system methods not included in the core API."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/fs-watch/Cargo.toml
+++ b/plugins/fs-watch/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-fs-watch"
 version = "0.0.0"
 description = "Watch files and directories for changes."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/localhost/Cargo.toml
+++ b/plugins/localhost/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-localhost"
 version = "0.1.0"
 description = "Expose your apps assets through a localhost server instead of the default custom protocol."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/log/Cargo.toml
+++ b/plugins/log/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-log"
 version = "0.0.0"
 description = "Configurable logging for your Tauri app."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/persisted-scope/Cargo.toml
+++ b/plugins/persisted-scope/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-persisted-scope"
 version = "0.1.3"
 description = "Save filesystem and asset scopes and restore them when the app is reopened."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/positioner/Cargo.toml
+++ b/plugins/positioner/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-positioner"
 version = "1.0.4"
 description = "Position your windows at well-known locations."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/single-instance/Cargo.toml
+++ b/plugins/single-instance/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-single-instance"
 version = "0.0.0"
 description = "Ensure a single instance of your tauri app is running."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 exclude = ["/examples"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plugins/sql/Cargo.toml
+++ b/plugins/sql/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-sql"
 version = "0.0.0"
 description = "Interface with SQL databases."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-#rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+#rust-version.workspace = true
 rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plugins/store/Cargo.toml
+++ b/plugins/store/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-store"
 version = "0.0.0"
 description = "Simple, persistent key-value store."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/stronghold/Cargo.toml
+++ b/plugins/stronghold/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-stronghold"
 version = "0.0.0"
 description = "Store secrets and keys using the IOTA Stronghold encrypted database."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/upload/Cargo.toml
+++ b/plugins/upload/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-upload"
 version = "0.0.0"
 description = "Upload files from disk to a remote server over HTTP."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/websocket/Cargo.toml
+++ b/plugins/websocket/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "tauri-plugin-websocket"
 version = "0.0.0"
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 exclude = ["/examples"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/plugins/window-state/Cargo.toml
+++ b/plugins/window-state/Cargo.toml
@@ -2,10 +2,10 @@
 name = "tauri-plugin-window-state"
 version = "0.1.0"
 description = "Save window positions and sizes and restore them when the app is reopened."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
-edition = "2021"
-rust-version = "1.64"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/shared/template/Cargo.toml
+++ b/shared/template/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "tauri-plugin-{{name}}"
 version = "0.0.0"
-edition = "2021"
-authors = [ "Tauri Programme within The Commons Conservancy" ]
-license = "Apache-2.0 OR MIT"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This reverts commit 4899ae007a8c565125892024433f1440f55291d6.

Didn't work, it still fails on the dependencies. Thought they would be handled explicitly since i found a PR in the dependabot repo to fix them. I'll check if adding a dependabot config works better.