### PR TITLE
fix(updater): fix appimage extraction

### DIFF
--- a/.changes/updater-appimage.md
+++ b/.changes/updater-appimage.md
@@ -1,0 +1,5 @@
+---
+"updater": patch
+---
+
+Fix updater failing to extract the AppImage resulting in failing to update and also deleting the current version. 

--- a/plugins/updater/Cargo.toml
+++ b/plugins/updater/Cargo.toml
@@ -33,7 +33,7 @@ tar = "0.4"
 [target."cfg(target_os = \"windows\")".dependencies]
 zip = { version = "0.6", default-features = false }
 
-[target."cfg(target_os = \"macos\")".dependencies]
+[target."cfg(any(target_os = \"macos\", target_os = \"linux\"))".dependencies]
 flate2 = "1.0.27"
 
 

--- a/plugins/updater/src/error.rs
+++ b/plugins/updater/src/error.rs
@@ -63,7 +63,7 @@ pub enum Error {
     #[error("temp directory is not on the same mount point as the AppImage")]
     TempDirNotOnSameMountPoint,
     #[error("binary for the current target not found in the archive")]
-    BinaryNotFound,
+    BinaryNotFoundInAcrhive,
     #[error(transparent)]
     Http(#[from] http::Error),
 }

--- a/plugins/updater/src/error.rs
+++ b/plugins/updater/src/error.rs
@@ -62,6 +62,8 @@ pub enum Error {
     /// Temp dir is not on same mount mount. This prevents our updater to rename the AppImage to a temp file.
     #[error("temp directory is not on the same mount point as the AppImage")]
     TempDirNotOnSameMountPoint,
+    #[error("binary for the current target not found in the archive")]
+    BinaryNotFound,
     #[error(transparent)]
     Http(#[from] http::Error),
 }

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -647,7 +647,7 @@ impl Update {
                     // if we have not returned early we should restore the backup
                     std::fs::rename(tmp_app_image, &self.extract_path)?;
 
-                    return Err(Error::BinaryNotFound);
+                    return Err(Error::BinaryNotFoundInAcrhive);
                 }
             }
         }

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -596,11 +596,11 @@ impl Update {
         target_os = "openbsd"
     ))]
     fn install_inner(&self, bytes: Vec<u8>) -> Result<()> {
+        use flate2::read::GzDecoder;
         use std::{
             ffi::OsStr,
             os::unix::fs::{MetadataExt, PermissionsExt},
         };
-        use flate2::read::GzDecoder;
         let archive = Cursor::new(bytes);
         let extract_path_metadata = self.extract_path.metadata()?;
 
@@ -647,10 +647,7 @@ impl Update {
                     // if we have not returned early we should restore the backup
                     std::fs::rename(tmp_app_image, &self.extract_path)?;
 
-                    // The convention here is to return Ok(()) if the right installer
-                    // was not found in the package, even though this means the update
-                    // failed.
-                    return Ok(());
+                    return Err(Error::BinaryNotFound);
                 }
             }
         }


### PR DESCRIPTION
The updater plugin currently does not work on Linux. This PR fixes two issues:

 * .tar.gz is correctly ungzipped instead of just untared
 * in case the archive is malformed or the AppImage is not present in it - nothing will happen (instead of the current behavior which is removing the current binary)