### PR TITLE
Do not use rfd 0.12.1

### DIFF
--- a/.changes/dialog-pin-rfd.md
+++ b/.changes/dialog-pin-rfd.md
@@ -1,0 +1,16 @@
+---
+"dialog": "patch"
+---
+
+Pin the version of `rfd` to 0.12.0.
+
+This is a workaround for [PolyMeilex/rfd#152](https://github.com/PolyMeilex/rfd/pull/152), in which rfd took over responsibility for `gtk_init` by running its own event loop thread. As described in that pull request:
+
+> Yeah, this is a decent solution, not much else we can do about this global state bs on C side.
+>
+> This will obviously blow up as soon as someone has other code that also uses GTK, but let's ignore that for now, as I want to get rid of GTK backend one day anyway (#66).
+
+Yes, Tauri is other code that uses GTK and it does, indeed, blow up. Tauri already worked around this issue by using the synchronous dialog API on GTK and carefully running it in the main event loop thread.
+
+The best way around this is to stop using rfd entirely (they're planning to drop the GTK backend, which will probably break since the XDG Portal API doesn't cover message dialogs).
+

--- a/.changes/dialog-pin-rfd.md
+++ b/.changes/dialog-pin-rfd.md
@@ -2,15 +2,4 @@
 "dialog": "patch"
 ---
 
-Pin the version of `rfd` to 0.12.0.
-
-This is a workaround for [PolyMeilex/rfd#152](https://github.com/PolyMeilex/rfd/pull/152), in which rfd took over responsibility for `gtk_init` by running its own event loop thread. As described in that pull request:
-
-> Yeah, this is a decent solution, not much else we can do about this global state bs on C side.
->
-> This will obviously blow up as soon as someone has other code that also uses GTK, but let's ignore that for now, as I want to get rid of GTK backend one day anyway (#66).
-
-Yes, Tauri is other code that uses GTK and it does, indeed, blow up. Tauri already worked around this issue by using the synchronous dialog API on GTK and carefully running it in the main event loop thread.
-
-The best way around this is to stop using rfd entirely (they're planning to drop the GTK backend, which will probably break since the XDG Portal API doesn't cover message dialogs).
-
+Pin the version of `rfd` to 0.12.0. This is a workaround for [PolyMeilex/rfd#152](https://github.com/PolyMeilex/rfd/pull/152), in which rfd took over responsibility for `gtk_init` by running its own event loop thread.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4622,9 +4622,9 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.12.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9e7b57df6e8472152674607f6cc68aa14a748a3157a857a94f516e11aeacc2"
+checksum = "241a0deb168c88050d872294f7b3106c1dfa8740942bcc97bc91b98e97b5c501"
 dependencies = [
  "block",
  "dispatch",

--- a/plugins/dialog/Cargo.toml
+++ b/plugins/dialog/Cargo.toml
@@ -25,7 +25,7 @@ tauri-plugin-fs = { path = "../fs", version = "2.0.0-alpha.4" }
 glib = "0.16"
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
-rfd = { version = "0.12", features = [ "gtk3", "common-controls-v6" ] }
+rfd = { version = "=0.12.0", features = [ "gtk3", "common-controls-v6" ] }
 raw-window-handle = "0.5"
 
 [build-dependencies]


### PR DESCRIPTION
https://github.com/PolyMeilex/rfd/pull/152
conflicts with the way tauri uses it.

> Yeah, this is a decent solution, not much else we can do about this global state bs on C side.
>
> This will obviously blow up as soon as someone has other code that also uses GTK, but let's ignore that for now, as I want to get rid of GTK backend one day anyway (#66).

Yes, Tauri is other code that also uses GTK, and it does, indeed, blow up. The best way around this is to stop using rfd entirely (they're planning to drop the GTK backend, which will probably break since the XDG Portal API doesn't cover message dialogs).