### PR TITLE
[SQL] Fix queries with SQLite JSON_EXTRACT and number params

### DIFF
--- a/.changes/fix-number-query-params.md
+++ b/.changes/fix-number-query-params.md
@@ -1,0 +1,5 @@
+---
+"sql": patch
+---
+
+Encode JSON number query params as f64 to fix JSON_EXTRACT queries on SQLite

--- a/plugins/sql/src/plugin.rs
+++ b/plugins/sql/src/plugin.rs
@@ -211,6 +211,8 @@ async fn execute(
             query = query.bind(None::<JsonValue>);
         } else if value.is_string() {
             query = query.bind(value.as_str().unwrap().to_owned())
+        } else if let Some(number) = value.as_number() {
+            query = query.bind(number.as_f64().unwrap_or_default())
         } else {
             query = query.bind(value);
         }
@@ -240,6 +242,8 @@ async fn select(
             query = query.bind(None::<JsonValue>);
         } else if value.is_string() {
             query = query.bind(value.as_str().unwrap().to_owned())
+        } else if let Some(number) = value.as_number() {
+            query = query.bind(number.as_f64().unwrap_or_default())
         } else {
             query = query.bind(value);
         }


### PR DESCRIPTION
By default, JSON numbers (and any other JSON value that's not null) are encoded as strings when bound as a parameter to a SQL query. This seems to be fine for most queries because I assume SQLite coerces these number-strings into INTEGER/REAL when compared to a number column.

However, I'm using a JSON column and JSON_EXTRACT() clauses in my SQL queries, and this seems to select zero rows no matter what number I bind to the query params. It looks like SQLite isn't able to coerce bound parameters when extracting and comparing to values from a JSON column.

To fix this, I explicitly check for JSON numbers and bind them as `f64`s to the query params.