### PR TITLE
feat(fs): include full error message

### DIFF
--- a/.changes/fs-improve-error-message.md
+++ b/.changes/fs-improve-error-message.md
@@ -1,0 +1,5 @@
+---
+"fs": patch
+---
+
+Fix promise rejection error only containing the context and stripping the actual error message.

--- a/plugins/fs/src/commands.rs
+++ b/plugins/fs/src/commands.rs
@@ -36,7 +36,11 @@ impl Serialize for CommandError {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_string().as_ref())
+        if let Self::Anyhow(err) = self {
+            serializer.serialize_str(format!("{err:#}").as_ref())
+        } else {
+            serializer.serialize_str(self.to_string().as_ref())
+        }
     }
 }
 


### PR DESCRIPTION
we need to use anyhow's full error representation otherwise the error string only contains its context