### PR TITLE
fix(fs-watch): fix typos in DebouncedEvent type

### DIFF
--- a/plugins/fs-watch/guest-js/index.ts
+++ b/plugins/fs-watch/guest-js/index.ts
@@ -35,8 +35,8 @@ type RawEventKind =
   | "other";
 
 export type DebouncedEvent =
-  | { kind: "any"; path: string }
-  | { kind: "AnyContinous"; path: string };
+  | { kind: "Any"; path: string }[]
+  | { kind: "AnyContinuous"; path: string }[];
 
 async function unwatch(id: number): Promise<void> {
   await invoke("plugin:fs-watch|unwatch", { id });


### PR DESCRIPTION
1. Fix 2 typos in DebouncedEvent type to match [what is returned from notify](https://github.com/notify-rs/notify/blob/2437896199e58283b4858e40f39d299f3d405e26/notify-debouncer-mini/src/lib.rs#L195-L200)

```diff
-  any
+  Any

-  AnyContinous
+  AnyContinuous
```

2. The `DebounceEventResult` [is a vec](https://github.com/notify-rs/notify/blob/2437896199e58283b4858e40f39d299f3d405e26/notify-debouncer-mini/src/lib.rs#L189C33-L189C33) so changed the type to be an array of those objects