### PR TITLE
Fix macos autostart when LaunchAgent is used

### DIFF
--- a/plugins/autostart/src/lib.rs
+++ b/plugins/autostart/src/lib.rs
@@ -119,7 +119,7 @@ pub fn init<R: Runtime>(
                 // exe path to not break it.
                 let exe_path = current_exe.canonicalize()?.display().to_string();
                 let parts: Vec<&str> = exe_path.split(".app/").collect();
-                let app_path = if parts.len() == 2 {
+                let app_path = if parts.len() == 2 && matches!(macos_launcher, MacosLauncher::AppleScript) {
                     format!("{}.app", parts.get(0).unwrap().to_string())
                 } else {
                     exe_path


### PR DESCRIPTION
When using a launch agent mode, the path to the executable file is the proper value for app_path. For now, the path to the app file is used. Autostart is not working because of that.

This PR fixes my own issue: https://github.com/tauri-apps/plugins-workspace/issues/634

Here is the example of generated `~/Library/LaunchAgents/Intray.plist` with applied patch:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
  <key>Label</key>
  <string>Intray</string>
  <key>ProgramArguments</key>
  <array><string>/Applications/Intray.app/Contents/MacOS/Intray</string></array>
  <key>RunAtLoad</key>
  <true/>
  </dict>
</plist>
```

fixes #634