### PR TITLE
fix(fs): match default value of `create` option with js documentation

### DIFF
--- a/.changes/fix-fs-write-default-option.md
+++ b/.changes/fix-fs-write-default-option.md
@@ -1,0 +1,6 @@
+---
+"fs": "patch"
+"fs-js": "patch"
+---
+
+Fix `create` option inconsistency for `writeFile` and `writeTextFile` in guest-js and rust side.

--- a/.changes/fix-fs-write-default-option.md
+++ b/.changes/fix-fs-write-default-option.md
@@ -3,4 +3,4 @@
 "fs-js": "patch"
 ---
 
-Fix `create` option inconsistency for `writeFile` and `writeTextFile` in guest-js and rust side.
+Fix incorrect `create` option default value for `writeFile` and `writeTextFile` which didn't match documentation.

--- a/plugins/fs/src/commands.rs
+++ b/plugins/fs/src/commands.rs
@@ -585,12 +585,16 @@ pub struct WriteFileOptions {
     base: BaseOptions,
     #[serde(default)]
     append: bool,
-    #[serde(default)]
+    #[serde(default = "default_create_value")]
     create: bool,
     #[serde(default)]
     create_new: bool,
     #[allow(unused)]
     mode: Option<u32>,
+}
+
+fn default_create_value() -> bool {
+    true
 }
 
 fn write_file_inner<R: Runtime>(


### PR DESCRIPTION
Fix `create` option inconsistency for `writeFile` and `writeTextFile` in guest-js and rust side.

related issue: [[fs] 2.0.0-alpha.6 bug](https://github.com/tauri-apps/plugins-workspace/issues/846#issuecomment-1871728512)