### PR TITLE
docs(sql): Add migrations section to README

### DIFF
--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -105,6 +105,68 @@ const result = await db.execute(
 );
 ```
 
+## Migrations
+
+This plugin supports database migrations, allowing you to manage database schema evolution over time.
+
+### Defining Migrations
+
+Migrations are defined in Rust using the `Migration` struct. Each migration should include a unique version number, a description, the SQL to be executed, and the type of migration (Up or Down).
+
+Example of a migration:
+
+```rust
+use tauri_plugin_sql::{Migration, MigrationKind};
+
+let migration = Migration {
+    version: 1,
+    description: "create_initial_tables",
+    sql: "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);",
+    kind: MigrationKind::Up,
+};
+```
+
+### Adding Migrations to the Plugin Builder
+
+Migrations are registered with the `Builder` struct provided by the plugin. Use the `add_migrations` method to add your migrations to the plugin for a specific database connection.
+
+Example of adding migrations:
+
+```rust
+use tauri_plugin_sql::{Builder, Migration, MigrationKind};
+
+fn main() {
+    let migrations = vec![
+        // Define your migrations here
+        Migration {
+            version: 1,
+            description: "create_initial_tables",
+            sql: "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);",
+            kind: MigrationKind::Up,
+        }
+    ];
+
+    tauri::Builder::default()
+        .plugin(tauri_plugin_shell::init())
+        .plugin(
+            tauri_plugin_sql::Builder::default()
+                .add_migrations("sqlite:mydatabase.db", migrations)
+                .build(),
+        )
+        ...
+}
+```
+
+### Applying Migrations
+
+Migrations are applied automatically when the plugin is initialized. The plugin runs these migrations against the database specified by the connection string. Ensure that the migrations are defined in the correct order and are idempotent (safe to run multiple times).
+
+### Migration Management
+
+- **Version Control**: Each migration must have a unique version number. This is crucial for ensuring the migrations are applied in the correct order.
+- **Idempotency**: Write migrations in a way that they can be safely re-run without causing errors or unintended consequences.
+- **Testing**: Thoroughly test migrations to ensure they work as expected and do not compromise the integrity of your database.
+
 ## Contributing
 
 PRs accepted. Please make sure to read the Contributing Guide before making a pull request.


### PR DESCRIPTION
As a newcomer to both Tauri and Rust, I initially encountered some challenges while attempting to integrate SQLite along with a migration workflow into my first Tauri application. However, upon examining the [plugin's source code](https://github.com/tauri-apps/plugins-workspace/blob/v2/plugins/sql/src/plugin.rs), I was pleased to discover that it included functionality related to database migrations. With assistance from ChatGPT, I was able to gain a better understanding of this feature and subsequently crafted a 'Migrations' section for the README file.

Following this guide, I have successfully setup a migration management system in my application. I think this section is a valuable addition to the documentation, which I believe will be beneficial for other developers embarking on similar projects.