### PR TITLE
fix(dialog): On Android, do not add a `Cancel` button to message dialogs

### DIFF
--- a/.changes/dialog-message-android.md
+++ b/.changes/dialog-message-android.md
@@ -1,0 +1,5 @@
+---
+"dialog": "patch"
+---
+
+On Android, do not add a `Cancel` button to message dialogs.

--- a/examples/api/src/views/Dialog.svelte
+++ b/examples/api/src/views/Dialog.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { open, save, confirm } from "@tauri-apps/plugin-dialog";
+  import { open, save, confirm, message } from "@tauri-apps/plugin-dialog";
   import { readFile } from "@tauri-apps/plugin-fs";
 
   export let onMessage;
@@ -22,6 +22,16 @@
   }
 
   async function prompt() {
+    confirm("Do you want to do something?")
+      .then((res) =>
+        onMessage(
+          res ? "Yes" : "No"
+        )
+      )
+      .catch(onMessage);
+  }
+
+  async function promptCustom() {
     confirm("Is Tauri awesome?", {
       okLabel: "Absolutely",
       cancelLabel: "Totally",
@@ -32,6 +42,10 @@
         )
       )
       .catch(onMessage);
+  }
+
+  async function msg() {
+    await message("Tauri is awesome!");
   }
 
   function openDialog() {
@@ -130,3 +144,5 @@
   >Open save dialog</button
 >
 <button class="btn" id="prompt-dialog" on:click={prompt}>Prompt</button>
+<button class="btn" id="custom-prompt-dialog" on:click={promptCustom}>Prompt (custom)</button>
+<button class="btn" id="message-dialog" on:click={msg}>Message</button>

--- a/plugins/dialog/android/src/main/java/DialogPlugin.kt
+++ b/plugins/dialog/android/src/main/java/DialogPlugin.kt
@@ -190,16 +190,16 @@ class DialogPlugin(private val activity: Activity): Plugin(activity) {
             dialog.dismiss()
             handler(false, true)
           }
-          .setNegativeButton(
-            args.cancelButtonLabel ?: "Cancel"
-          ) { dialog, _ ->
-            dialog.dismiss()
-            handler(false, false)
-          }
           .setOnCancelListener { dialog ->
             dialog.dismiss()
             handler(true, false)
           }
+        if (args.cancelButtonLabel != null) {
+          builder.setNegativeButton( args.cancelButtonLabel) { dialog, _ ->
+            dialog.dismiss()
+            handler(false, false)
+          }
+        }
         val dialog = builder.create()
         dialog.show()
       }


### PR DESCRIPTION
On Android, do not add a `Cancel` button to message dialogs. This is already the current behavior on desktop (I don't know for iOS devices).

Also, add a message dialog to the example app.