### PR TITLE
feat(fs/watch): migrate to `notify-debouncer-full`

### DIFF
--- a/.changes/fs-replace-notify-debouncer.md
+++ b/.changes/fs-replace-notify-debouncer.md
@@ -1,0 +1,6 @@
+---
+"fs": "patch"
+"fs-js": "patch"
+---
+
+Replace `notify-debouncer-mini` with `notify-debouncer-full`. [(plugins-workspace#885)](https://github.com/tauri-apps/plugins-workspace/pull/885)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,18 +3597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "notify-debouncer-mini"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
-dependencies = [
- "crossbeam-channel",
- "log",
- "notify",
- "serde",
-]
-
-[[package]]
 name = "notify-rust"
 version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6023,7 +6011,6 @@ dependencies = [
  "glob",
  "notify",
  "notify-debouncer-full",
- "notify-debouncer-mini",
  "serde",
  "serde_repr",
  "tauri",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,6 +1740,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,6 +3580,20 @@ dependencies = [
  "serde",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
+dependencies = [
+ "crossbeam-channel",
+ "file-id",
+ "log",
+ "notify",
+ "parking_lot",
+ "walkdir",
 ]
 
 [[package]]
@@ -5999,6 +6022,7 @@ dependencies = [
  "anyhow",
  "glob",
  "notify",
+ "notify-debouncer-full",
  "notify-debouncer-mini",
  "serde",
  "serde_repr",

--- a/examples/api/src-tauri/Cargo.toml
+++ b/examples/api/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ serde = { workspace = true }
 tiny_http = "0.11"
 log = { workspace = true }
 tauri-plugin-log = { path = "../../../plugins/log", version = "2.0.0-alpha.6" }
-tauri-plugin-fs = { path = "../../../plugins/fs", version = "2.0.0-alpha.7" }
+tauri-plugin-fs = { path = "../../../plugins/fs", version = "2.0.0-alpha.7", features = [ "watch" ] }
 tauri-plugin-clipboard-manager = { path = "../../../plugins/clipboard-manager", version = "2.0.0-alpha.6" }
 tauri-plugin-dialog = { path = "../../../plugins/dialog", version = "2.0.0-alpha.7" }
 tauri-plugin-http = { path = "../../../plugins/http", features = [ "multipart" ], version = "2.0.0-alpha.9" }

--- a/examples/api/src/views/FileSystem.svelte
+++ b/examples/api/src/views/FileSystem.svelte
@@ -9,6 +9,13 @@
   let img;
   let file;
   let renameTo;
+  let watchPath = "";
+  let watchDebounceDelay = 0;
+  let watchRecursive = false;
+  let watchDebounceFull = false;
+  let watchTrackFileIds = false;
+  let unwatchFn;
+  let unwatchPath = "";
 
   function getDir() {
     const dirSelect = document.getElementById("dir");
@@ -141,6 +148,43 @@
   function setSrc() {
     img.src = convertFileSrc(path);
   }
+
+  function watch() {
+    unwatch();
+    if (watchPath) {
+      onMessage(`Watching ${watchPath} for changes`);
+      let options = {
+        recursive: watchRecursive,
+        delayMs: parseInt(watchDebounceDelay),
+        debounceFull: watchDebounceFull,
+        trackFileIds: watchTrackFileIds,
+      };
+      if (options.delayMs === 0) {
+        fs.watchImmediate(watchPath, onMessage, options)
+          .then((fn) => {
+            unwatchFn = fn;
+            unwatchPath = watchPath;
+          })
+          .catch(onMessage);
+      } else {
+        fs.watch(watchPath, onMessage, options)
+          .then((fn) => {
+            unwatchFn = fn;
+            unwatchPath = watchPath;
+          })
+          .catch(onMessage);
+      }
+    }
+  }
+
+  function unwatch() {
+    if (unwatchFn) {
+      onMessage(`Stopped watching ${unwatchPath} for changes`);
+      unwatchFn();
+    }
+    unwatchFn = undefined;
+    unwatchPath = undefined;
+  }
 </script>
 
 <div class="flex flex-col">
@@ -175,6 +219,41 @@
       <button class="btn" on:click={stat}>Stat</button>
     </div>
   {/if}
+  
+  <h3>Watch</h3>
+
+  <input
+    class="input grow"
+    placeholder="Type the path to watch..."
+    bind:value={watchPath}
+  />
+  <br />
+  <div>
+    <label for="watch-debounce-delay">Debounce delay in milliseconds (`0` disables the debouncer)</label>
+    <input
+      class="input"
+      id="watch-debounce-delay"
+      bind:value={watchDebounceDelay}
+    />
+  </div>
+  <br />
+  <div>
+    <input type="checkbox" id="watch-recursive" bind:checked={watchRecursive} />
+    <label for="watch-recursive">Recursive</label>
+  </div>
+  <div>
+    <input type="checkbox" id="watch-debounce-full" bind:checked={watchDebounceFull} />
+    <label for="watch-debounce-full">Debounce full (requires a debounce delay to be set)</label>
+  </div>
+  <div>
+    <input type="checkbox" id="watch-track-file-ids" bind:checked={watchTrackFileIds} />
+    <label for="watch-track-file-ids">Track file IDs (requires debounce full to be set)</label>
+  </div>
+  <br />
+  <div>
+    <button class="btn" on:click={watch}>Watch</button>
+    <button class="btn" on:click={unwatch}>Unwatch</button>
+  </div>
 </div>
 
 <br />

--- a/examples/api/src/views/FileSystem.svelte
+++ b/examples/api/src/views/FileSystem.svelte
@@ -12,7 +12,6 @@
   let watchPath = "";
   let watchDebounceDelay = 0;
   let watchRecursive = false;
-  let watchTrackFileIds = false;
   let unwatchFn;
   let unwatchPath = "";
 
@@ -155,7 +154,6 @@
       let options = {
         recursive: watchRecursive,
         delayMs: parseInt(watchDebounceDelay),
-        trackFileIds: watchTrackFileIds,
       };
       if (options.delayMs === 0) {
         fs.watchImmediate(watchPath, onMessage, options)
@@ -238,10 +236,6 @@
   <div>
     <input type="checkbox" id="watch-recursive" bind:checked={watchRecursive} />
     <label for="watch-recursive">Recursive</label>
-  </div>
-  <div>
-    <input type="checkbox" id="watch-track-file-ids" bind:checked={watchTrackFileIds} />
-    <label for="watch-track-file-ids">Track file IDs (requires a debounce delay to be set)</label>
   </div>
   <br />
   <div>

--- a/examples/api/src/views/FileSystem.svelte
+++ b/examples/api/src/views/FileSystem.svelte
@@ -12,7 +12,6 @@
   let watchPath = "";
   let watchDebounceDelay = 0;
   let watchRecursive = false;
-  let watchDebounceFull = false;
   let watchTrackFileIds = false;
   let unwatchFn;
   let unwatchPath = "";
@@ -156,7 +155,6 @@
       let options = {
         recursive: watchRecursive,
         delayMs: parseInt(watchDebounceDelay),
-        debounceFull: watchDebounceFull,
         trackFileIds: watchTrackFileIds,
       };
       if (options.delayMs === 0) {
@@ -242,12 +240,8 @@
     <label for="watch-recursive">Recursive</label>
   </div>
   <div>
-    <input type="checkbox" id="watch-debounce-full" bind:checked={watchDebounceFull} />
-    <label for="watch-debounce-full">Debounce full (requires a debounce delay to be set)</label>
-  </div>
-  <div>
     <input type="checkbox" id="watch-track-file-ids" bind:checked={watchTrackFileIds} />
-    <label for="watch-track-file-ids">Track file IDs (requires debounce full to be set)</label>
+    <label for="watch-track-file-ids">Track file IDs (requires a debounce delay to be set)</label>
   </div>
   <br />
   <div>

--- a/plugins/fs/Cargo.toml
+++ b/plugins/fs/Cargo.toml
@@ -22,6 +22,7 @@ uuid = { version = "1", features = [ "v4" ] }
 glob = "0.3"
 notify = { version = "6", optional = true, features = [ "serde" ] }
 notify-debouncer-mini = { version = "0.4", optional = true, features = [ "serde" ] }
+notify-debouncer-full = { version = "0.3", optional = true }
 
 [features]
-watch = [ "notify", "notify-debouncer-mini" ]
+watch = [ "notify", "notify-debouncer-mini", "notify-debouncer-full" ]

--- a/plugins/fs/Cargo.toml
+++ b/plugins/fs/Cargo.toml
@@ -21,8 +21,7 @@ anyhow = "1"
 uuid = { version = "1", features = [ "v4" ] }
 glob = "0.3"
 notify = { version = "6", optional = true, features = [ "serde" ] }
-notify-debouncer-mini = { version = "0.4", optional = true, features = [ "serde" ] }
 notify-debouncer-full = { version = "0.3", optional = true }
 
 [features]
-watch = [ "notify", "notify-debouncer-mini", "notify-debouncer-full" ]
+watch = [ "notify", "notify-debouncer-full" ]

--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -1110,20 +1110,59 @@ type WatchEvent = {
  * @since 2.0.0
  */
 type WatchEventKind =
-  | "any "
-  | {
-      access?: unknown;
-    }
-  | {
-      create?: unknown;
-    }
-  | {
-      modify?: unknown;
-    }
-  | {
-      remove?: unknown;
-    }
+  | "any"
+  | { access: WatchEventKindAccess }
+  | { create: WatchEventKindCreate }
+  | { modify: WatchEventKindModify }
+  | { remove: WatchEventKindRemove }
   | "other";
+
+/**
+ * @since 2.0.0
+ */
+type WatchEventKindAccess =
+  | { kind: "any" }
+  | { kind: "close"; mode: "any" | "execute" | "read" | "write" | "other" }
+  | { kind: "open"; mode: "any" | "execute" | "read" | "write" | "other" }
+  | { kind: "other" };
+
+/**
+ * @since 2.0.0
+ */
+type WatchEventKindCreate =
+  | { kind: "any" }
+  | { kind: "file" }
+  | { kind: "folder" }
+  | { kind: "other" };
+
+/**
+ * @since 2.0.0
+ */
+type WatchEventKindModify =
+  | { kind: "any" }
+  | { kind: "data"; mode: "any" | "size" | "content" | "other" }
+  | {
+      kind: "metadata";
+      mode:
+        | "any"
+        | "access-time"
+        | "write-time"
+        | "permissions"
+        | "ownership"
+        | "extended"
+        | "other";
+    }
+  | { kind: "name"; mode: "any" | "to" | "from" | "both" | "other" }
+  | { kind: "other" };
+
+/**
+ * @since 2.0.0
+ */
+type WatchEventKindRemove =
+  | { kind: "any" }
+  | { kind: "file" }
+  | { kind: "folder" }
+  | { kind: "other" };
 
 /**
  * @since 2.0.0

--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -1093,6 +1093,10 @@ interface WatchOptions {
 interface DebouncedWatchOptions extends WatchOptions {
   /** Debounce delay */
   delayMs?: number;
+  /** Use {@link https://docs.rs/notify-debouncer-full | full debouncer} instead of the {@link https://docs.rs/notify-debouncer-mini | mini debouncer} */
+  debounceFull?: boolean;
+  /** Keep track of the file system IDs of all files */
+  trackFileIds?: boolean;
 }
 
 /**

--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -1093,8 +1093,6 @@ interface WatchOptions {
 interface DebouncedWatchOptions extends WatchOptions {
   /** Debounce delay */
   delayMs?: number;
-  /** Use {@link https://docs.rs/notify-debouncer-full | full debouncer} instead of the {@link https://docs.rs/notify-debouncer-mini | mini debouncer} */
-  debounceFull?: boolean;
   /** Keep track of the file system IDs of all files */
   trackFileIds?: boolean;
 }
@@ -1130,13 +1128,6 @@ type RawEventKind =
 /**
  * @since 2.0.0
  */
-type DebouncedEvent =
-  | { kind: "Any"; path: string }[]
-  | { kind: "AnyContinuous"; path: string }[];
-
-/**
- * @since 2.0.0
- */
 type UnwatchFn = () => void;
 
 async function unwatch(rid: number): Promise<void> {
@@ -1150,7 +1141,7 @@ async function unwatch(rid: number): Promise<void> {
  */
 async function watch(
   paths: string | string[] | URL | URL[],
-  cb: (event: DebouncedEvent) => void,
+  cb: (event: RawEvent) => void,
   options?: DebouncedWatchOptions,
 ): Promise<UnwatchFn> {
   const opts = {
@@ -1167,7 +1158,7 @@ async function watch(
     }
   }
 
-  const onEvent = new Channel<DebouncedEvent>();
+  const onEvent = new Channel<RawEvent>();
   onEvent.onmessage = cb;
 
   const rid: number = await invoke("plugin:fs|watch", {
@@ -1236,7 +1227,6 @@ export type {
   FileInfo,
   WatchOptions,
   DebouncedWatchOptions,
-  DebouncedEvent,
   RawEvent,
   UnwatchFn,
 };

--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -1100,8 +1100,8 @@ interface DebouncedWatchOptions extends WatchOptions {
 /**
  * @since 2.0.0
  */
-type RawEvent = {
-  type: RawEventKind;
+type WatchEvent = {
+  type: WatchEventKind;
   paths: string[];
   attrs: unknown;
 };
@@ -1109,7 +1109,7 @@ type RawEvent = {
 /**
  * @since 2.0.0
  */
-type RawEventKind =
+type WatchEventKind =
   | "any "
   | {
       access?: unknown;
@@ -1141,7 +1141,7 @@ async function unwatch(rid: number): Promise<void> {
  */
 async function watch(
   paths: string | string[] | URL | URL[],
-  cb: (event: RawEvent) => void,
+  cb: (event: WatchEvent) => void,
   options?: DebouncedWatchOptions,
 ): Promise<UnwatchFn> {
   const opts = {
@@ -1158,7 +1158,7 @@ async function watch(
     }
   }
 
-  const onEvent = new Channel<RawEvent>();
+  const onEvent = new Channel<WatchEvent>();
   onEvent.onmessage = cb;
 
   const rid: number = await invoke("plugin:fs|watch", {
@@ -1179,7 +1179,7 @@ async function watch(
  */
 async function watchImmediate(
   paths: string | string[] | URL | URL[],
-  cb: (event: RawEvent) => void,
+  cb: (event: WatchEvent) => void,
   options?: WatchOptions,
 ): Promise<UnwatchFn> {
   const opts = {
@@ -1196,7 +1196,7 @@ async function watchImmediate(
     }
   }
 
-  const onEvent = new Channel<RawEvent>();
+  const onEvent = new Channel<WatchEvent>();
   onEvent.onmessage = cb;
 
   const rid: number = await invoke("plugin:fs|watch", {
@@ -1227,7 +1227,7 @@ export type {
   FileInfo,
   WatchOptions,
   DebouncedWatchOptions,
-  RawEvent,
+  WatchEvent,
   UnwatchFn,
 };
 

--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -1093,8 +1093,6 @@ interface WatchOptions {
 interface DebouncedWatchOptions extends WatchOptions {
   /** Debounce delay */
   delayMs?: number;
-  /** Keep track of the file system IDs of all files */
-  trackFileIds?: boolean;
 }
 
 /**

--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -1265,6 +1265,11 @@ export type {
   WatchOptions,
   DebouncedWatchOptions,
   WatchEvent,
+  WatchEventKind,
+  WatchEventKindAccess,
+  WatchEventKindCreate,
+  WatchEventKindModify,
+  WatchEventKindRemove,
   UnwatchFn,
 };
 

--- a/plugins/fs/src/watcher.rs
+++ b/plugins/fs/src/watcher.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: MIT
 
 use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
-use notify_debouncer_full::FileIdCache;
+use notify_debouncer_full::{
+    new_debouncer, DebounceEventResult, Debouncer, FileIdCache, FileIdMap,
+};
 use serde::Deserialize;
 use tauri::{
     ipc::Channel,
@@ -43,10 +45,7 @@ impl WatcherResource {
 impl Resource for WatcherResource {}
 
 enum WatcherKind {
-    DebouncerMini(notify_debouncer_mini::Debouncer<RecommendedWatcher>),
-    DebouncerFull(
-        notify_debouncer_full::Debouncer<RecommendedWatcher, notify_debouncer_full::FileIdMap>,
-    ),
+    Debouncer(Debouncer<RecommendedWatcher, FileIdMap>),
     Watcher(RecommendedWatcher),
 }
 
@@ -61,24 +60,7 @@ fn watch_raw(on_event: Channel, rx: Receiver<notify::Result<Event>>) {
     });
 }
 
-fn watch_debounced_mini(
-    on_event: Channel,
-    rx: Receiver<notify_debouncer_mini::DebounceEventResult>,
-) {
-    spawn(move || {
-        while let Ok(event) = rx.recv() {
-            if let Ok(event) = event {
-                // TODO: Should errors be emitted too?
-                let _ = on_event.send(&event);
-            }
-        }
-    });
-}
-
-fn watch_debounced_full(
-    on_event: Channel,
-    rx: Receiver<notify_debouncer_full::DebounceEventResult>,
-) {
+fn watch_debounced(on_event: Channel, rx: Receiver<DebounceEventResult>) {
     spawn(move || {
         while let Ok(Ok(events)) = rx.recv() {
             for event in events {
@@ -95,8 +77,6 @@ pub struct WatchOptions {
     dir: Option<BaseDirectory>,
     recursive: bool,
     delay_ms: Option<u64>,
-    #[serde(default)]
-    debounce_full: bool,
     #[serde(default)]
     track_file_ids: bool,
 }
@@ -120,28 +100,16 @@ pub async fn watch<R: Runtime>(
     };
 
     let kind = if let Some(delay) = options.delay_ms {
-        if options.debounce_full {
-            let (tx, rx) = channel();
-            let mut debouncer =
-                notify_debouncer_full::new_debouncer(Duration::from_millis(delay), None, tx)?;
-            for path in &resolved_paths {
-                debouncer.watcher().watch(path.as_ref(), mode)?;
-                if options.track_file_ids {
-                    debouncer.cache().add_path(path.as_ref());
-                }
+        let (tx, rx) = channel();
+        let mut debouncer = new_debouncer(Duration::from_millis(delay), None, tx)?;
+        for path in &resolved_paths {
+            debouncer.watcher().watch(path.as_ref(), mode)?;
+            if options.track_file_ids {
+                debouncer.cache().add_path(path.as_ref());
             }
-            watch_debounced_full(on_event, rx);
-            WatcherKind::DebouncerFull(debouncer)
-        } else {
-            let (tx, rx) = channel();
-            let mut debouncer =
-                notify_debouncer_mini::new_debouncer(Duration::from_millis(delay), tx)?;
-            for path in &resolved_paths {
-                debouncer.watcher().watch(path.as_ref(), mode)?;
-            }
-            watch_debounced_mini(on_event, rx);
-            WatcherKind::DebouncerMini(debouncer)
         }
+        watch_debounced(on_event, rx);
+        WatcherKind::Debouncer(debouncer)
     } else {
         let (tx, rx) = channel();
         let mut watcher = RecommendedWatcher::new(tx, Config::default())?;
@@ -164,14 +132,7 @@ pub async fn unwatch<R: Runtime>(app: AppHandle<R>, rid: ResourceId) -> CommandR
     let watcher = app.resources_table().take::<WatcherResource>(rid)?;
     WatcherResource::with_lock(&watcher, |watcher| {
         match &mut watcher.kind {
-            WatcherKind::DebouncerMini(ref mut debouncer) => {
-                for path in &watcher.paths {
-                    debouncer.watcher().unwatch(path.as_ref()).map_err(|e| {
-                        format!("failed to unwatch path: {} with error: {e}", path.display())
-                    })?;
-                }
-            }
-            WatcherKind::DebouncerFull(ref mut debouncer) => {
+            WatcherKind::Debouncer(ref mut debouncer) => {
                 for path in &watcher.paths {
                     debouncer.watcher().unwatch(path.as_ref()).map_err(|e| {
                         format!("failed to unwatch path: {} with error: {e}", path.display())


### PR DESCRIPTION
- Adds support for notify-debouncer-full

  This complicates the API some more and I'm not super happy with it, yet. But at least this allows Tauri users to take advantage of the more involved `notify-debouncer-full`.

- Adds a watch section to the file system page of the demo app

  ![image](https://github.com/tauri-apps/plugins-workspace/assets/893710/b5abd65a-d399-48dc-82c2-a956e3536768)

I'm a contributor to the `notify` crate, on which the fs watcher is built. So if you have any questions or suggestions, please let me/the rest of the notify team know.
One thing that I noticed is that Tauri might be the first application that really uses the event serialization. At least for me this feature has been more of an afterthought until now. I'm not happy with the way events are serialized, maybe we can change that - I'm thinking of using `#[serde(tag = "kind")]` for enums.