### PR TITLE
Add track file ids option to fs watcher

### DIFF
--- a/examples/api/src/views/FileSystem.svelte
+++ b/examples/api/src/views/FileSystem.svelte
@@ -12,6 +12,7 @@
   let watchPath = "";
   let watchDebounceDelay = 0;
   let watchRecursive = false;
+  let watchTrackFileIds = false;
   let unwatchFn;
   let unwatchPath = "";
 
@@ -154,6 +155,7 @@
       let options = {
         recursive: watchRecursive,
         delayMs: parseInt(watchDebounceDelay),
+        trackFileIds: watchTrackFileIds,
       };
       if (options.delayMs === 0) {
         fs.watchImmediate(watchPath, onMessage, options)
@@ -236,6 +238,10 @@
   <div>
     <input type="checkbox" id="watch-recursive" bind:checked={watchRecursive} />
     <label for="watch-recursive">Recursive</label>
+  </div>
+  <div>
+    <input type="checkbox" id="watch-track-file-ids" bind:checked={watchTrackFileIds} />
+    <label for="watch-track-file-ids">Track file IDs (requires a debounce delay to be set)</label>
   </div>
   <br />
   <div>

--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -1093,6 +1093,8 @@ interface WatchOptions {
 interface DebouncedWatchOptions extends WatchOptions {
   /** Debounce delay */
   delayMs?: number;
+  /** Keep track of the file system IDs of all files in order to stich together rename events */
+  trackFileIds?: boolean;
 }
 
 /**

--- a/plugins/fs/src/watcher.rs
+++ b/plugins/fs/src/watcher.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: MIT
 
 use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
-use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, FileIdMap};
+use notify_debouncer_full::{
+    new_debouncer, DebounceEventResult, Debouncer, FileIdCache, FileIdMap,
+};
 use serde::Deserialize;
 use tauri::{
     ipc::Channel,
@@ -75,6 +77,8 @@ pub struct WatchOptions {
     dir: Option<BaseDirectory>,
     recursive: bool,
     delay_ms: Option<u64>,
+    #[serde(default)]
+    track_file_ids: bool,
 }
 
 #[tauri::command]
@@ -100,6 +104,9 @@ pub async fn watch<R: Runtime>(
         let mut debouncer = new_debouncer(Duration::from_millis(delay), None, tx)?;
         for path in &resolved_paths {
             debouncer.watcher().watch(path.as_ref(), mode)?;
+            if options.track_file_ids {
+                debouncer.cache().add_path(path.as_ref());
+            }
         }
         watch_debounced(on_event, rx);
         WatcherKind::Debouncer(debouncer)
@@ -130,6 +137,7 @@ pub async fn unwatch<R: Runtime>(app: AppHandle<R>, rid: ResourceId) -> CommandR
                     debouncer.watcher().unwatch(path.as_ref()).map_err(|e| {
                         format!("failed to unwatch path: {} with error: {e}", path.display())
                     })?;
+                    debouncer.cache().remove_path(path.as_ref());
                 }
             }
             WatcherKind::Watcher(ref mut w) => {


### PR DESCRIPTION
Add `trackFileIds` to the `DebouncedWatchOptions`.

When enabled, the fs watcher gets the filesystem ids of all watched files and keeps them in memory in order to be able to stitch together rename events on Windows and MacOS.

When disabled, users may receive events like:

```
rename /home/user/file.txt
rename /home/user/file-backup.txt
```

When enabled, the events would be merged into:

```
rename /home/user/file.txt to /home/user/file-backup.txt
```

The feature is disabled by default. But we might want to enable it by default, as it is pretty useful.
Also, we may want to automatically disable it on Linux, since inotify emits a cookie for rename events, so `notify-debouncer-full` handles them correctly already.

I didn't add a .changes file because `notify-debouncer-full` is new for the v2 release.