### PR TITLE
ci: Ignore RSA advisory outside of scheduled runs

### DIFF
--- a/.github/workflows/audit-rust.yml
+++ b/.github/workflows/audit-rust.yml
@@ -33,3 +33,5 @@ jobs:
       - uses: rustsec/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # https://github.com/tauri-apps/plugins-workspace/issues/774
+          ignore: ${{ github.event_name != 'schedule' && 'RUSTSEC-2023-0071' || '' }}


### PR DESCRIPTION
Doesn't look like there'll be a fix to it anytime soon and i'd like to not scare contributors.