### PR TITLE
Added Security Policy to All Plugins

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/authenticator/SECURITY.md
+++ b/plugins/authenticator/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/autostart/SECURITY.md
+++ b/plugins/autostart/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/biometric/SECURITY.md
+++ b/plugins/biometric/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/cli/SECURITY.md
+++ b/plugins/cli/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/clipboard-manager/SECURITY.md
+++ b/plugins/clipboard-manager/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/deep-link/SECURITY.md
+++ b/plugins/deep-link/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/dialog/SECURITY.md
+++ b/plugins/dialog/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/global-shortcut/SECURITY.md
+++ b/plugins/global-shortcut/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/http/SECURITY.md
+++ b/plugins/http/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/localhost/SECURITY.md
+++ b/plugins/localhost/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/nfc/SECURITY.md
+++ b/plugins/nfc/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/notification/SECURITY.md
+++ b/plugins/notification/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/os/SECURITY.md
+++ b/plugins/os/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/persisted-scope/SECURITY.md
+++ b/plugins/persisted-scope/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/positioner/SECURITY.md
+++ b/plugins/positioner/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/process/SECURITY.md
+++ b/plugins/process/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/shell/SECURITY.md
+++ b/plugins/shell/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/single-instance/SECURITY.md
+++ b/plugins/single-instance/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/sql/SECURITY.md
+++ b/plugins/sql/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/store/SECURITY.md
+++ b/plugins/store/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/stronghold/SECURITY.md
+++ b/plugins/stronghold/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/updater/SECURITY.md
+++ b/plugins/updater/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/upload/SECURITY.md
+++ b/plugins/upload/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/websocket/SECURITY.md
+++ b/plugins/websocket/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/plugins/window-state/SECURITY.md
+++ b/plugins/window-state/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).

--- a/shared/template/SECURITY.md
+++ b/shared/template/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+**Please use the [Private Vulnerability Disclosure](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) feature of GitHub.**
+
+Include as much of the following information:
+
+- Type of issue (e.g. improper input parsing, privilege escalation, etc.)
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- The distribution affected or used to help us with reproduction of the issue
+- Step-by-step instructions to reproduce the issue
+- Ideally a reproduction repository
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer to receive reports in English.
+
+## Contact
+
+Please disclose a vulnerability or security relevant issue here: [https://github.com/tauri-apps/plugins-workspace/security/advisories/new](https://github.com/tauri-apps/plugins-workspace/security/advisories/new).
+
+Alternatively, you can also contact us by email via [security@tauri.app](mailto:security@tauri.app).


### PR DESCRIPTION
This PR adds a simplistic contact policy to all remaining plugins, which did not have this previously.
The workspace repository itself also contains this policy now.

The threat model of each plugin will be extended once more fine grained permissions are added.

Fixes #599 with at least a contact policy.