### PR TITLE
fix(fs/wtacher): fix incorrect type for rename events

### DIFF
--- a/.changes/fs-watcher-rename-event-type.md
+++ b/.changes/fs-watcher-rename-event-type.md
@@ -1,0 +1,5 @@
+---
+"fs-js": "patch"
+---
+
+Fix incorrect `WatchEventKindModify` type for `rename` events.

--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -1150,7 +1150,7 @@ type WatchEventKindModify =
         | "extended"
         | "other";
     }
-  | { kind: "name"; mode: "any" | "to" | "from" | "both" | "other" }
+  | { kind: "rename"; mode: "any" | "to" | "from" | "both" | "other" }
   | { kind: "other" };
 
 /**


### PR DESCRIPTION
closes #943

notify-rs has a `serde(rename="rename")` on the rust type