### PR TITLE
fix(fs): make rename third parameter optional

### DIFF
--- a/.changes/fs-rename-optional-type.md
+++ b/.changes/fs-rename-optional-type.md
@@ -1,0 +1,5 @@
+---
+"fs-js": patch
+---
+
+Make `rename` function third paramter optional as it was supposed to be.

--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -853,7 +853,7 @@ interface RenameOptions {
 async function rename(
   oldPath: string | URL,
   newPath: string | URL,
-  options: RenameOptions,
+  options?: RenameOptions,
 ): Promise<void> {
   if (
     (oldPath instanceof URL && oldPath.protocol !== "file:") ||


### PR DESCRIPTION
It's optional in the rust side

https://github.com/tauri-apps/plugins-workspace/blob/e28115cb42be401e4cca3dbbb02b6dbe7865a3d7/plugins/fs/src/commands.rs#L513