### PR TITLE
fix(upload): return type on POST is now string

### DIFF
--- a/.changes/upload-returnval.md
+++ b/.changes/upload-returnval.md
@@ -1,0 +1,6 @@
+---
+"upload": patch
+"upload-js": patch
+---
+
+Return the upload response as a string and error out if the status code is not within 200-299.

--- a/plugins/upload/guest-js/index.ts
+++ b/plugins/upload/guest-js/index.ts
@@ -33,7 +33,7 @@ async function upload(
   filePath: string,
   progressHandler?: ProgressHandler,
   headers?: Map<string, string>,
-): Promise<void> {
+): Promise<string> {
   const ids = new Uint32Array(1);
   window.crypto.getRandomValues(ids);
   const id = ids[0];
@@ -44,7 +44,7 @@ async function upload(
 
   await listenToEventIfNeeded("upload://progress");
 
-  await invoke("plugin:upload|upload", {
+  return await invoke("plugin:upload|upload", {
     id,
     url,
     filePath,

--- a/plugins/upload/src/lib.rs
+++ b/plugins/upload/src/lib.rs
@@ -117,7 +117,10 @@ async fn upload<R: Runtime>(
     if response.status().is_success() {
         response.text().await.map_err(Into::into)
     } else {
-        Err(Error::HttpErrorCode(response.status().as_u16()))
+        Err(Error::HttpErrorCode(
+            response.status().as_u16(),
+            response.text().await.unwrap_or_default(),
+        ))
     }
 }
 

--- a/plugins/upload/src/lib.rs
+++ b/plugins/upload/src/lib.rs
@@ -115,9 +115,10 @@ async fn upload<R: Runtime>(
 
     let response = request.send().await?;
     if response.status().is_success() {
-        return response.text().await.map_err(Error::from);
+        response.text().await.map_err(Into::into)
+    } else {
+        Err(Error::HttpErrorCode(response.status().as_u16()))
     }
-    Err(Error::HttpErrorCode(response.status().as_u16()))
 }
 
 fn file_to_body<R: Runtime>(id: u32, window: Window<R>, file: File) -> reqwest::Body {

--- a/plugins/upload/src/lib.rs
+++ b/plugins/upload/src/lib.rs
@@ -96,10 +96,13 @@ async fn upload<R: Runtime>(
 ) -> Result<String> {
     // Read the file
     let file = File::open(file_path).await?;
+    let file_len = file.metadata().await.unwrap().len();
 
     // Create the request and attach the file to the body
     let client = reqwest::Client::new();
-    let mut request = client.post(url).body(file_to_body(id, window, file));
+    let mut request = client.post(url)
+        .header(reqwest::header::CONTENT_LENGTH, file_len)
+        .body(file_to_body(id, window, file));
 
     // Loop trought the headers keys and values
     // and add them to the request object.

--- a/plugins/upload/src/lib.rs
+++ b/plugins/upload/src/lib.rs
@@ -29,8 +29,8 @@ pub enum Error {
     Request(#[from] reqwest::Error),
     #[error("{0}")]
     ContentLength(String),
-    #[error("{0}")]
-    HttpErrorCode(u16),
+    #[error("request failed with status code {0}: {1}")]
+    HttpErrorCode(u16, String),
 }
 
 impl Serialize for Error {


### PR DESCRIPTION
A POST to a webserver can not always be expected to be a JSON response.

Success is now determined by the HTTP return code.

Upon success the body content is returned as a string.