### PR TITLE
docs: improve `tauri-plugin-store` readme and code example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6723,7 +6723,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-single-instance"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "log",
  "serde",

--- a/plugins/store/README.md
+++ b/plugins/store/README.md
@@ -105,9 +105,7 @@ fn main() {
             let mut store = StoreBuilder::new("app_data.bin").build(app.handle().clone());
 
             // Attempt to load the store, if it's saved already.
-            if let Err(error) = store.load() {
-                println!("Failed to load store from disk: {error}.");
-            }
+            store.load().expect("Failed to load store from disk");
 
             // Note that values must be serde_json::Value instances,
             // otherwise, they will not be compatible with the JavaScript bindings.
@@ -137,9 +135,7 @@ Rather than silently continuing like you may expect.
 You should always handle the error appropriately rather than unwrapping, or you may experience unexpected app crashes:
 
 ```rust
-if let Err(error) = store.load() {
-    println!("Failed to load store from disk: {error}.");
-}
+store.load().expect("Failed to load store from disk");
 ```
 
 ### Frontend Interoperability

--- a/plugins/store/README.md
+++ b/plugins/store/README.md
@@ -83,7 +83,7 @@ You can manually save a store with:
 await store.save();
 ```
 
-Stores are loaded automatically on creation when using the JavaScript bindings.  
+Stores are loaded automatically when used from the JavaScript bindings.  
 However, you can also load them manually later like so:
 
 ```javascript
@@ -139,20 +139,6 @@ You should always handle the error appropriately rather than unwrapping, or you 
 ```rust
 if let Err(error) = store.load() {
     println!("Failed to load store from disk: {error}.");
-}
-```
-
-Additionally, there is more than one kind of possible error when loading a store.
-
-If you want to ignore only the "file not found" error case, while propogating the rest, you can do this:
-
-```rust
-if let Err(error) = store.load() {
-    if let tauri_plugin_store::Error::NotFound(path) = error {
-        println!("File not found for store: {path:?}");
-    } else {
-        return Err(error)?;
-    }
 }
 ```
 

--- a/plugins/store/README.md
+++ b/plugins/store/README.md
@@ -69,19 +69,30 @@ await store.set("some-key", { value: 5 });
 const val = await store.get("some-key");
 assert(val, { value: 5 });
 
-await store.save(); // this manually saves the store, otherwise the store is only saved when your app is closed
+// This manually saves the store.
+await store.save();
 ```
 
-### Persisting values
+### Persisting Values
 
-Values added to the store are not persisted between application loads unless:
+As seen above, values added to the store are not persisted between application loads unless the application is closed gracefully.
 
-1. The application is closed gracefully (plugin automatically saves)
-2. The store is manually saved (using `store.save()`)
+You can manually save a store with:
+
+```javascript
+await store.save();
+```
+
+Stores are loaded automatically on creation when using the JavaScript bindings.  
+However, you can also load them manually later like so:
+
+```javascript
+await store.load();
+```
 
 ## Usage from Rust
 
-You can also access Stores from Rust, you can create new stores:
+You can also create `Store` instances directly in Rust:
 
 ```rust
 use tauri_plugin_store::StoreBuilder;
@@ -91,23 +102,70 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::default().build())
         .setup(|app| {
-            let mut store = StoreBuilder::new(app.handle(), "path/to/store.bin".parse()?).build();
+            let mut store = StoreBuilder::new("app_data.bin").build(app.handle().clone());
 
-            store.insert("a".to_string(), json!("b")) // note that values must be serd_json::Value to be compatible with JS
+            // Attempt to load the store, if it's saved already.
+            if let Err(error) = store.load() {
+                println!("Failed to load store from disk: {error}.");
+            }
+
+            // Note that values must be serde_json::Value instances,
+            // otherwise, they will not be compatible with the JavaScript bindings.
+            store.insert("a".to_string(), json!("b"));
+
+            // You can manually save the store after making changes.
+            // Otherwise, it will save upon graceful exit as described above.
+            store.save()
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
 ```
 
-As you may have noticed, the Store crated above isn't accessible to the frontend. To interoperate with stores created by JS use the exported `with_store` method:
+### Loading Gracefully
+
+If you call `load` on a `Store` that hasn't yet been written to the desk, it will return an error. You must handle this error if you want to gracefully continue and use the default store until you save it to the disk. The example above shows how to do this.
+
+For example, this would cause a panic if the store has not yet been created:
+
+```rust
+store.load().unwrap();
+```
+
+Rather than silently continuing like you may expect.
+
+You should always handle the error appropriately rather than unwrapping, or you may experience unexpected app crashes:
+
+```rust
+if let Err(error) = store.load() {
+    println!("Failed to load store from disk: {error}.");
+}
+```
+
+Additionally, there is more than one kind of possible error when loading a store.
+
+If you want to ignore only the "file not found" error case, while propogating the rest, you can do this:
+
+```rust
+if let Err(error) = store.load() {
+    if let tauri_plugin_store::Error::NotFound(path) = error {
+        println!("File not found for store: {path:?}");
+    } else {
+        return Err(error)?;
+    }
+}
+```
+
+### Frontend Interoperability
+
+As you may have noticed, the `Store` crated above isn't accessible to the frontend. To interoperate with stores created by JavaScript use the exported `with_store` method:
 
 ```rust
 use tauri::Wry;
 use tauri_plugin_store::with_store;
 
 let stores = app.state::<StoreCollection<Wry>>();
-let path = PathBuf::from("path/to/the/storefile");
+let path = PathBuf::from("app_data.bin");
 
 with_store(app_handle, stores, path, |store| store.insert("a".to_string(), json!("b")))
 ```


### PR DESCRIPTION
This brings `tauri-plugin-store`'s readme up to date with the the latest v2 beta, improves the wording of a few things, and adds a note about preventing crashes while loading from the Rust side of things.