### PR TITLE
fix(dialog): Remove Linux specific code for rfd 0.14 compatibility

### DIFF
--- a/.changes/dialog-linux-freeze.md
+++ b/.changes/dialog-linux-freeze.md
@@ -1,0 +1,5 @@
+---
+"dialog": "patch"
+---
+
+Fixed an issue where dialogs would not spawn but instead freeze the whole app.


### PR DESCRIPTION
fixes #956

After https://github.com/PolyMeilex/rfd/pull/152 it always freezes the app since we already have a gtk main loop running and try to run the dialog on it too. Since gtk allows to have multiple gtk event loops in the same app, as long as they run in seperate threads, i removed our special handling and let rfd spawn its own loop (see pr linked above). From my testing this works fine and allows us to keep upgrading rfd instead of locking it to 0.12(?).