### PR TITLE
fix(fs): Use tauri::Error instead of tauri::path::Error in tauri_plugin_fs::error::CannotResolvePath

### DIFF
--- a/plugins/fs/src/error.rs
+++ b/plugins/fs/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     #[error("forbidden path: {0}")]
     PathForbidden(PathBuf),
     #[error("failed to resolve path: {0}")]
-    CannotResolvePath(tauri::path::Error),
+    CannotResolvePath(tauri::Error),
     /// Invalid glob pattern.
     #[error("invalid glob pattern: {0}")]
     GlobPattern(#[from] glob::PatternError),


### PR DESCRIPTION
tauri-plugin-fs fails to build when using tauri 2.0.0-beta.9 with the following error:

```
error[E0603]: enum `Error` is private
  --> /home/myuser/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-plugin-fs-2.0.0-beta.1/src/error.rs:20:36
   |
20 |     CannotResolvePath(tauri::path::Error),
   |                                    ^^^^^ private enum
   |
note: the enum `Error` is defined here
  --> /home/myuser/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-2.0.0-beta.9/src/path/mod.rs:14:5
   |
14 | use crate::error::*;
   |     ^^^^^^^^^^^^
   |
  ::: /home/myuser/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-2.0.0-beta.9/src/error.rs:32:1
   |
32 | #[non_exhaustive]
   | ----------------- cannot be constructed because it is `#[non_exhaustive]`
help: consider importing this enum instead
   |
20 |     CannotResolvePath(tauri::Error),
   |                       ~~~~~~~~~~~~
help: import `Error` directly
   |
20 |     CannotResolvePath(tauri::error::Error),
```

the relevant code is in https://github.com/tauri-apps/plugins-workspace/blob/v2/plugins/fs/src/error.rs, specifically this enum:

```rs

#[derive(Debug, thiserror::Error)]
pub enum Error {
    #[error(transparent)]
    Json(#[from] serde_json::Error),
    #[error(transparent)]
    Tauri(#[from] tauri::Error),
    #[error(transparent)]
    Io(#[from] std::io::Error),
    #[error("forbidden path: {0}")]
    PathForbidden(PathBuf),
    #[error("failed to resolve path: {0}")]
    CannotResolvePath(tauri::path::Error), // <------------------------- this is the problem
    /// Invalid glob pattern.
    #[error("invalid glob pattern: {0}")]
    GlobPattern(#[from] glob::PatternError),
    /// Watcher error.
    #[cfg(feature = "watch")]
    #[error(transparent)]
    Watch(#[from] notify::Error),
}
```

the code is referencing tauri::path::Error but it seems that was tauri::path::Error maybe a mistaken reexport of tauri::error::Error, which has now been fixed, but the fix breaks this code.

this pr just makes the enum variant reference tauri::error::Error instead. with that change i can now use the plugin with tauri version 2.0.0-beta.9.