### PR TITLE
ci: Move cargo target dir to /mnt

### DIFF
--- a/.github/workflows/covector-version-or-publish-v2.yml
+++ b/.github/workflows/covector-version-or-publish-v2.yml
@@ -46,10 +46,17 @@ jobs:
           git config --global user.name "${{ github.event.pusher.name }}"
           git config --global user.email "${{ github.event.pusher.email }}"
 
+      - name: Setup target dir on /mnt
+        run: |
+          sudo mkdir /mnt/target
+          WORKSPACE_OWNER="$(stat -c '%U:%G' "${GITHUB_WORKSPACE}")"
+          sudo chown -R "${WORKSPACE_OWNER}" /mnt/target
+
       - name: covector version or publish (publish when no change files present)
         uses: jbolda/covector/packages/action@covector-v0
         id: covector
         env:
+          CARGO_TARGET_DIR: /mnt/target
           NODE_AUTH_TOKEN: ${{ secrets.ORG_NPM_TOKEN }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently our publishing workflow fails _twice_ because it runs out of disk space. https://github.com/tauri-apps/plugins-workspace/actions/runs/8182433330/job/22373757645#step:8:8499

A month ago github changed the azure vms for public repos which resulted in a size decrease of the root partition by ~10gb (though i kinda doubt this is the sole reason because it doesn't fail once, but twice). At the same time the /mnt partition was increased to a whopping 75gb, over 60gb of it unused, since the root partition only has ~20gb free space we'll let rust save its artifact into /mnt hoping that we're actually dealing with space issues and not something else...