### PR TITLE
chore(docs): Update positioner readme

### DIFF
--- a/plugins/positioner/README.md
+++ b/plugins/positioner/README.md
@@ -51,12 +51,19 @@ First you need to register the core plugin with Tauri:
 `src-tauri/src/main.rs`
 
 ```rust
+use tauri::tray::TrayIconBuilder;
+
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_positioner::init())
         // This is required to get tray-relative positions to work
-        .on_system_tray_event(|app, event| {
-           tauri_plugin_positioner::on_tray_event(app, &event);
+        .setup(|app| {
+            TrayIconBuilder::new()
+                .on_tray_icon_event(|app, event| {
+                    tauri_plugin_positioner::on_tray_event(app.app_handle(), &event);
+                })
+                .build(app)?;
+            Ok(())
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
`on_system_tray_event` is now reworked into `on_tray_icon_event` so we need to update readme accordingly.

https://beta.tauri.app/guides/upgrade-migrate/from-tauri-1/#migrate-to-tray-icon-module