### PR TITLE
ci: Change paths-filter's base to v2 branch

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
+          base: v2
           filters: |
             tauri-plugin-authenticator:
               - .github/workflows/test-rust.yml


### PR DESCRIPTION
Currently it compares it to the default branch (v1) which makes it always run all plugin checks. While i plan to change default branches soon i still need a bit more time for this.

Edit: The `base` parameter is ignored for pull_request events so only pushes to the v2 branch should be affected.

Edit2: The workflow didn't fail, i just cancelled it because i didn't want to wait for 120 jobs