### PR TITLE
docs(typo): Fix a minor typo in docs

### DIFF
--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -89,7 +89,7 @@ const result = await db.execute(
 );
 
 const result = await db.execute(
-  "UPDATE todos SET title = $1, completed = $2 WHERE id = $3",
+  "UPDATE todos SET title = $1, status = $2 WHERE id = $3",
   [todos.title, todos.status, todos.id],
 );
 
@@ -100,7 +100,7 @@ const result = await db.execute(
 );
 
 const result = await db.execute(
-  "UPDATE todos SET title = ?, completed = ? WHERE id = ?",
+  "UPDATE todos SET title = ?, status = ? WHERE id = ?",
   [todos.title, todos.status, todos.id],
 );
 ```


### PR DESCRIPTION
Fix a minor typo in docs related to Tauri Plugin SQL.

Description:
- Typo in Column name, should be fixed now.