### PR TITLE
fix(http): inconsistencies on urlpattern usage on scope

### DIFF
--- a/.changes/fix-http-scope-url-match.md
+++ b/.changes/fix-http-scope-url-match.md
@@ -1,0 +1,5 @@
+---
+"http": patch
+---
+
+Fixes scope not allowing subpaths, query parameters and hash when those values are empty.

--- a/plugins/http/src/scope.rs
+++ b/plugins/http/src/scope.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Deserializer};
 use url::Url;
-use urlpattern::{UrlPattern, UrlPatternInit, UrlPatternMatchInput};
+use urlpattern::{UrlPattern, UrlPatternMatchInput};
 
 #[allow(rustdoc::bare_urls)]
 #[derive(Debug)]
@@ -15,7 +15,21 @@ pub struct Entry {
 }
 
 fn parse_url_pattern(s: &str) -> Result<UrlPattern, urlpattern::quirks::Error> {
-    let init = UrlPatternInit::parse_constructor_string::<regex::Regex>(s, None)?;
+    let mut init = urlpattern::UrlPatternInit::parse_constructor_string::<regex::Regex>(s, None)?;
+    if init.search.as_ref().map(|p| p.is_empty()).unwrap_or(true) {
+        init.search.replace("*".to_string());
+    }
+    if init.hash.as_ref().map(|p| p.is_empty()).unwrap_or(true) {
+        init.hash.replace("*".to_string());
+    }
+    if init
+        .pathname
+        .as_ref()
+        .map(|p| p.is_empty() || p == "/")
+        .unwrap_or(true)
+    {
+        init.pathname.replace("*".to_string());
+    }
     UrlPattern::parse(init)
 }
 

--- a/plugins/http/src/scope.rs
+++ b/plugins/http/src/scope.rs
@@ -124,8 +124,8 @@ mod tests {
         assert!(scope.is_allowed(&"http://localhost:8080".parse().unwrap()));
         assert!(scope.is_allowed(&"http://localhost:8080/".parse().unwrap()));
 
-        assert!(!scope.is_allowed(&"http://localhost:8080/file".parse().unwrap()));
-        assert!(!scope.is_allowed(&"http://localhost:8080/path/to/asset.png".parse().unwrap()));
+        assert!(scope.is_allowed(&"http://localhost:8080/file".parse().unwrap()));
+        assert!(scope.is_allowed(&"http://localhost:8080/path/to/asset.png".parse().unwrap()));
         assert!(!scope.is_allowed(&"https://localhost:8080".parse().unwrap()));
         assert!(!scope.is_allowed(&"http://localhost:8081".parse().unwrap()));
         assert!(!scope.is_allowed(&"http://local:8080".parse().unwrap()));
@@ -161,7 +161,7 @@ mod tests {
         let scope = super::Scope::new(vec![&entry], Vec::new());
 
         assert!(scope.is_allowed(&"http://something.else".parse().unwrap()));
-        assert!(!scope.is_allowed(&"http://something.else/path/to/file".parse().unwrap()));
+        assert!(scope.is_allowed(&"http://something.else/path/to/file".parse().unwrap()));
         assert!(!scope.is_allowed(&"https://something.else".parse().unwrap()));
 
         let entry = Arc::new("http://*/*".parse().unwrap());
@@ -177,9 +177,9 @@ mod tests {
         let scope = super::Scope::new(vec![&entry], Vec::new());
 
         assert!(scope.is_allowed(&"http://something.else".parse().unwrap()));
-        assert!(!scope.is_allowed(&"http://something.else/path/to/file".parse().unwrap()));
+        assert!(scope.is_allowed(&"http://something.else/path/to/file".parse().unwrap()));
         assert!(scope.is_allowed(&"file://path".parse().unwrap()));
-        assert!(!scope.is_allowed(&"file://path/to/file".parse().unwrap()));
+        assert!(scope.is_allowed(&"file://path/to/file".parse().unwrap()));
         assert!(scope.is_allowed(&"https://something.else".parse().unwrap()));
 
         let entry = Arc::new("*://*/*".parse().unwrap());


### PR DESCRIPTION
Changes the HTTP scope URL parsing to match the behaivor of the JavaScript implementation of URLPattern.
A pattern like `http://localhost` should automatically allow any subpath, query params and hash.
To define a custom query param match rule, you must escape the `?` character e.g. `http://localhost/path\\?q=*&x=*`