### PR TITLE
fix(positioner): (v2) replace `Window` with `WebviewWindow` for Tauri 2.0

### DIFF
--- a/.changes/fix-positioner-webview-window.md
+++ b/.changes/fix-positioner-webview-window.md
@@ -1,0 +1,5 @@
+---
+"positioner": patch
+---
+
+Migrate `Window` to `WebviewWindow` for Tarui 2.0.

--- a/.changes/fix-positioner-webview-window.md
+++ b/.changes/fix-positioner-webview-window.md
@@ -2,4 +2,4 @@
 "positioner": patch
 ---
 
-Migrate `Window` to `WebviewWindow` for Tarui 2.0.
+Migrate `Window` to `WebviewWindow` for Tauri 2.0.

--- a/plugins/positioner/README.md
+++ b/plugins/positioner/README.md
@@ -73,17 +73,17 @@ fn main() {
 Afterwards all the plugin's APIs are available through the JavaScript guest bindings:
 
 ```javascript
-import { move_window, Position } from "@tauri-apps/plugin-positioner";
+import { moveWindow, Position } from "@tauri-apps/plugin-positioner";
 
-move_window(Position.TopRight);
+moveWindow(Position.TopRight);
 ```
 
 If you only intend on moving the window from rust code, you can import the Window trait extension instead of registering the plugin:
 
 ```rust
-use tauri_plugin_positioner::{WindowExt, Position};
+use tauri_plugin_positioner::{WebviewWindowExt, Position};
 
-let mut win = app.get_window("main").unwrap();
+let mut win = app.get_webview_window("main").unwrap();
 let _ = win.move_window(Position::TopRight);
 ```
 

--- a/plugins/positioner/README.md
+++ b/plugins/positioner/README.md
@@ -81,7 +81,7 @@ moveWindow(Position.TopRight);
 If you only intend on moving the window from rust code, you can import the Window trait extension instead of registering the plugin:
 
 ```rust
-use tauri_plugin_positioner::{WebviewWindowExt, Position};
+use tauri_plugin_positioner::{WindowExt, Position};
 
 let mut win = app.get_webview_window("main").unwrap();
 let _ = win.move_window(Position::TopRight);

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -37,15 +37,15 @@ pub enum Position {
     TrayBottomCenter,
 }
 
-/// A [`WebviewWindow`] extension that provides extra methods related to positioning.
-pub trait WebviewWindowExt {
-    /// Moves the [`WebviewWindow`] to the given [`Position`]
+/// A [`Window`] extension that provides extra methods related to positioning.
+pub trait WindowExt {
+    /// Moves the [`Window`] to the given [`Position`]
     ///
     /// All positions are relative to the **current** screen.
     fn move_window(&self, position: Position) -> Result<()>;
 }
 
-impl<R: Runtime> WebviewWindowExt for WebviewWindow<R> {
+impl<R: Runtime> WindowExt for WebviewWindow<R> {
     fn move_window(&self, pos: Position) -> Result<()> {
         use Position::*;
 

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -1,5 +1,5 @@
 // Copyright 2021 Jonas Kruckenberg
-// Copyright 2019-2023 Tauri Programme within The Commons Conservancy
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
@@ -8,7 +8,7 @@ use crate::Tray;
 use serde_repr::Deserialize_repr;
 #[cfg(feature = "tray-icon")]
 use tauri::Manager;
-use tauri::{PhysicalPosition, PhysicalSize, Result, Runtime, Window};
+use tauri::{PhysicalPosition, PhysicalSize, Result, Runtime, WebviewWindow};
 
 /// Well known window positions.
 #[derive(Debug, Deserialize_repr)]
@@ -37,15 +37,15 @@ pub enum Position {
     TrayBottomCenter,
 }
 
-/// A [`Window`] extension that provides extra methods related to positioning.
-pub trait WindowExt {
-    /// Moves the [`Window`] to the given [`Position`]
+/// A [`WebviewWindow`] extension that provides extra methods related to positioning.
+pub trait WebviewWindowExt {
+    /// Moves the [`WebviewWindow`] to the given [`Position`]
     ///
     /// All positions are relative to the **current** screen.
     fn move_window(&self, position: Position) -> Result<()>;
 }
 
-impl<R: Runtime> WindowExt for Window<R> {
+impl<R: Runtime> WebviewWindowExt for WebviewWindow<R> {
     fn move_window(&self, pos: Position) -> Result<()> {
         use Position::*;
 

--- a/plugins/positioner/src/lib.rs
+++ b/plugins/positioner/src/lib.rs
@@ -51,8 +51,11 @@ pub fn on_tray_event<R: Runtime>(app: &AppHandle<R>, event: &TrayIconEvent) {
 }
 
 #[tauri::command]
-async fn move_window<R: Runtime>(window: tauri::Window<R>, position: Position) -> Result<()> {
-    window.move_window(position)
+async fn move_window<R: Runtime>(
+    webview_window: tauri::WebviewWindow<R>,
+    position: Position,
+) -> Result<()> {
+    webview_window.move_window(position)
 }
 
 /// The Tauri plugin that exposes [`WindowExt::move_window`] to the webview.


### PR DESCRIPTION
We migrated `Window` to `WebviewWindow` in Tauri 2.0, need to update the API as well.