### PR TITLE
chore(shell): change schema property name `command` to `cmd`

### DIFF
--- a/.changes/shell-fix-schema-command-property-name.md
+++ b/.changes/shell-fix-schema-command-property-name.md
@@ -1,0 +1,5 @@
+---
+"shell": "patch"
+---
+
+Change shell's schema property name `command` to `cmd`.

--- a/plugins/shell/src/scope_entry.rs
+++ b/plugins/shell/src/scope_entry.rs
@@ -22,6 +22,7 @@ pub struct Entry {
     /// `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`,
     /// `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.
     // use default just so the schema doesn't flag it as required
+    #[serde(rename = "cmd")]
     pub command: PathBuf,
 
     /// The allowed arguments for the command execution.


### PR DESCRIPTION
It actually uses `cmd` to define the command scope. Without the `#[serde(rename = "cmd")]`, the generated schema will use `command` instead, confusing the user.