### PR TITLE
chore(docs): Update positioner readme

### DIFF
--- a/plugins/positioner/README.md
+++ b/plugins/positioner/README.md
@@ -73,9 +73,9 @@ fn main() {
 Afterwards all the plugin's APIs are available through the JavaScript guest bindings:
 
 ```javascript
-import { move_window, Position } from "@tauri-apps/plugin-positioner";
+import { moveWindow, Position } from "@tauri-apps/plugin-positioner";
 
-move_window(Position.TopRight);
+moveWindow(Position.TopRight);
 ```
 
 If you only intend on moving the window from rust code, you can import the Window trait extension instead of registering the plugin:


### PR DESCRIPTION
JavaScript function name is wrong, should be `moveWindow`.

https://github.com/tauri-apps/tauri-docs/pull/1933#discussion_r1522797977

Thanks @pewsheen for catching this!