### PR TITLE
fix(fs): rename `dir` field to `base_dir` in `WatchOptions`, fixes #1081

### DIFF
--- a/.changes/fix-fs-watcher-basedir.md
+++ b/.changes/fix-fs-watcher-basedir.md
@@ -1,0 +1,5 @@
+---
+"fs": patch
+---
+
+Fixes `watch` and `watchImmediate` which previously ignored the `baseDir` parameter.

--- a/plugins/fs/src/watcher.rs
+++ b/plugins/fs/src/watcher.rs
@@ -75,7 +75,7 @@ fn watch_debounced(on_event: Channel, rx: Receiver<DebounceEventResult>) {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WatchOptions {
-    dir: Option<BaseDirectory>,
+    base_dir: Option<BaseDirectory>,
     recursive: bool,
     delay_ms: Option<u64>,
 }
@@ -96,7 +96,7 @@ pub async fn watch<R: Runtime>(
             &global_scope,
             &command_scope,
             path,
-            options.dir,
+            options.base_dir,
         )?);
     }
 


### PR DESCRIPTION
Fixes #1081.