### PR TITLE
Fix LaunchAgent macOS autostart

### DIFF
--- a/.changes/fix-autolaunch-macos.md
+++ b/.changes/fix-autolaunch-macos.md
@@ -1,0 +1,5 @@
+---
+"autostart": patch
+---
+
+Fix LaunchAgent-based autostart for macOS.

--- a/plugins/autostart/src/lib.rs
+++ b/plugins/autostart/src/lib.rs
@@ -129,11 +129,12 @@ pub fn init<R: Runtime>(
                 // exe path to not break it.
                 let exe_path = current_exe.canonicalize()?.display().to_string();
                 let parts: Vec<&str> = exe_path.split(".app/").collect();
-                let app_path = if parts.len() == 2 {
-                    format!("{}.app", parts.first().unwrap())
-                } else {
-                    exe_path
-                };
+                let app_path =
+                    if parts.len() == 2 && matches!(macos_launcher, MacosLauncher::AppleScript) {
+                        format!("{}.app", parts.first().unwrap())
+                    } else {
+                        exe_path
+                    };
                 info!("auto_start path {}", &app_path);
                 builder.set_app_path(&app_path);
             }


### PR DESCRIPTION
This is just #841 but for v2, since I noticed the last v1 -> v2 merge mentioned it might be the last time we run that sort of merge.

Fixes #1115 