### PR TITLE
[v2::tauri_plugin_positioner] Fix window positioning relative to tray icon

### DIFF
--- a/plugins/positioner/src/lib.rs
+++ b/plugins/positioner/src/lib.rs
@@ -36,8 +36,8 @@ struct Tray(std::sync::Mutex<Option<(PhysicalPosition<f64>, PhysicalSize<f64>)>>
 #[cfg(feature = "tray-icon")]
 pub fn on_tray_event<R: Runtime>(app: &AppHandle<R>, event: &TrayIconEvent) {
     let position = PhysicalPosition {
-        x: event.x,
-        y: event.y,
+        x: event.icon_rect.left,
+        y: event.icon_rect.top,
     };
     let size = PhysicalSize {
         width: event.icon_rect.right - event.icon_rect.left,


### PR DESCRIPTION
Hi,

I suppose that `event.{x, y}` received with `TrayIconEvent` corresponds to the mouse click position on screen, so if we want to position the window relative to the tray item, then we should rely on `icon_rect.{left, top}` instead. 

It's worth to note that when positioning for `TrayBottomCenter` the `y` coordinate for window must be pinned to `icon_rect.bottom` but that doesn't work because `icon_rect` has invalid coordinates to begin with, for example:

```
icon_rect: Rectangle {
  left: 2364.0,
  top: 48.0,
  right: 2422.0,
  bottom: 96.0,
},
```

I suppose that the tray icon should actually have a top coordinate set to 0 and with the height of 22, double it on my retina and it comes down to:

```
{
  top: 0,
  bottom: 48.0
}
```

Which means that `icon_rect.top` corresponds to the bottom of menubar on macOS.

So unless there is some funny business going on in AppKit, which is possible but unlikely, I'd say that the layer that converts menubar icon frame to screen coordinates on macOS has a bug, so that's something to look into down the road.