### PR TITLE
[v2][log]: Add generic fern::Dispatch TargetKind to log

### DIFF
--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -181,6 +181,10 @@ pub enum TargetKind {
     ///
     /// This requires the webview to subscribe to log events, via this plugins `attachConsole` function.
     Webview,
+    /// Send logs to a fern::Dispatch
+    ///
+    /// You can use this to construct arbitrary log targets.
+    Dispatch(fern::Dispatch),
 }
 
 /// A log target.
@@ -478,6 +482,7 @@ impl Builder {
                                 });
                             })
                         }
+                        TargetKind::Dispatch(dispatch) => dispatch.into(),
                     };
                     target_dispatch = target_dispatch.chain(logger);
 


### PR DESCRIPTION
Closes #1113. I've tested this out in our app, and it works as expected.
