### PR TITLE
Add `WebviewWindow` to code docs and template

### DIFF
--- a/plugins/barcode-scanner/src/lib.rs
+++ b/plugins/barcode-scanner/src/lib.rs
@@ -27,7 +27,7 @@ pub struct BarcodeScanner<R: Runtime>(PluginHandle<R>);
 
 impl<R: Runtime> BarcodeScanner<R> {}
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the barcode scanner APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the barcode scanner APIs.
 pub trait BarcodeScannerExt<R: Runtime> {
     fn barcode_scanner(&self) -> &BarcodeScanner<R>;
 }

--- a/plugins/barcode-scanner/src/lib.rs
+++ b/plugins/barcode-scanner/src/lib.rs
@@ -27,7 +27,7 @@ pub struct BarcodeScanner<R: Runtime>(PluginHandle<R>);
 
 impl<R: Runtime> BarcodeScanner<R> {}
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the barcode scanner APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`], [`tauri::Webview`] and [`tauri::Window`] to access the barcode scanner APIs.
 pub trait BarcodeScannerExt<R: Runtime> {
     fn barcode_scanner(&self) -> &BarcodeScanner<R>;
 }

--- a/plugins/barcode-scanner/src/lib.rs
+++ b/plugins/barcode-scanner/src/lib.rs
@@ -27,7 +27,7 @@ pub struct BarcodeScanner<R: Runtime>(PluginHandle<R>);
 
 impl<R: Runtime> BarcodeScanner<R> {}
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the barcode scanner APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the barcode scanner APIs.
 pub trait BarcodeScannerExt<R: Runtime> {
     fn barcode_scanner(&self) -> &BarcodeScanner<R>;
 }

--- a/plugins/biometric/src/lib.rs
+++ b/plugins/biometric/src/lib.rs
@@ -45,7 +45,7 @@ impl<R: Runtime> Biometric<R> {
     }
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the biometric APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the biometric APIs.
 pub trait BiometricExt<R: Runtime> {
     fn biometric(&self) -> &Biometric<R>;
 }

--- a/plugins/biometric/src/lib.rs
+++ b/plugins/biometric/src/lib.rs
@@ -45,7 +45,7 @@ impl<R: Runtime> Biometric<R> {
     }
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the biometric APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the biometric APIs.
 pub trait BiometricExt<R: Runtime> {
     fn biometric(&self) -> &Biometric<R>;
 }

--- a/plugins/biometric/src/lib.rs
+++ b/plugins/biometric/src/lib.rs
@@ -45,7 +45,7 @@ impl<R: Runtime> Biometric<R> {
     }
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the biometric APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`], [`tauri::Webview`] and [`tauri::Window`] to access the biometric APIs.
 pub trait BiometricExt<R: Runtime> {
     fn biometric(&self) -> &Biometric<R>;
 }

--- a/plugins/clipboard-manager/src/lib.rs
+++ b/plugins/clipboard-manager/src/lib.rs
@@ -34,7 +34,7 @@ use desktop::Clipboard;
 #[cfg(mobile)]
 use mobile::Clipboard;
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the clipboard APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`], [`tauri::Webview`] and [`tauri::Window`] to access the clipboard APIs.
 pub trait ClipboardExt<R: Runtime> {
     fn clipboard(&self) -> &Clipboard<R>;
 }

--- a/plugins/clipboard-manager/src/lib.rs
+++ b/plugins/clipboard-manager/src/lib.rs
@@ -34,7 +34,7 @@ use desktop::Clipboard;
 #[cfg(mobile)]
 use mobile::Clipboard;
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the clipboard APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the clipboard APIs.
 pub trait ClipboardExt<R: Runtime> {
     fn clipboard(&self) -> &Clipboard<R>;
 }

--- a/plugins/clipboard-manager/src/lib.rs
+++ b/plugins/clipboard-manager/src/lib.rs
@@ -34,7 +34,7 @@ use desktop::Clipboard;
 #[cfg(mobile)]
 use mobile::Clipboard;
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the clipboard APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the clipboard APIs.
 pub trait ClipboardExt<R: Runtime> {
     fn clipboard(&self) -> &Clipboard<R>;
 }

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -114,7 +114,7 @@ mod imp {
 
 pub use imp::DeepLink;
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the deep-link APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the deep-link APIs.
 pub trait DeepLinkExt<R: Runtime> {
     fn deep_link(&self) -> &DeepLink<R>;
 }

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -114,7 +114,7 @@ mod imp {
 
 pub use imp::DeepLink;
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the deep-link APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`], [`tauri::Webview`] and [`tauri::Window`] to access the deep-link APIs.
 pub trait DeepLinkExt<R: Runtime> {
     fn deep_link(&self) -> &DeepLink<R>;
 }

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -114,7 +114,7 @@ mod imp {
 
 pub use imp::DeepLink;
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the deep-link APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the deep-link APIs.
 pub trait DeepLinkExt<R: Runtime> {
     fn deep_link(&self) -> &DeepLink<R>;
 }

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -51,7 +51,7 @@ macro_rules! blocking_fn {
     }};
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the dialog APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the dialog APIs.
 pub trait DialogExt<R: Runtime> {
     fn dialog(&self) -> &Dialog<R>;
 }

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -51,7 +51,7 @@ macro_rules! blocking_fn {
     }};
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the dialog APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the dialog APIs.
 pub trait DialogExt<R: Runtime> {
     fn dialog(&self) -> &Dialog<R>;
 }

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -51,7 +51,7 @@ macro_rules! blocking_fn {
     }};
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the dialog APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`], [`tauri::Webview`] and [`tauri::Window`] to access the dialog APIs.
 pub trait DialogExt<R: Runtime> {
     fn dialog(&self) -> &Dialog<R>;
 }

--- a/plugins/nfc/src/lib.rs
+++ b/plugins/nfc/src/lib.rs
@@ -57,7 +57,7 @@ impl<R: Runtime> Nfc<R> {
     }
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the nfc APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`], [`tauri::Webview`] and [`tauri::Window`] to access the NFC APIs.
 pub trait NfcExt<R: Runtime> {
     fn nfc(&self) -> &Nfc<R>;
 }

--- a/plugins/nfc/src/lib.rs
+++ b/plugins/nfc/src/lib.rs
@@ -57,7 +57,7 @@ impl<R: Runtime> Nfc<R> {
     }
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the nfc APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the nfc APIs.
 pub trait NfcExt<R: Runtime> {
     fn nfc(&self) -> &Nfc<R>;
 }

--- a/plugins/nfc/src/lib.rs
+++ b/plugins/nfc/src/lib.rs
@@ -57,7 +57,7 @@ impl<R: Runtime> Nfc<R> {
     }
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the nfc APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the nfc APIs.
 pub trait NfcExt<R: Runtime> {
     fn nfc(&self) -> &Nfc<R>;
 }

--- a/plugins/notification/src/lib.rs
+++ b/plugins/notification/src/lib.rs
@@ -211,7 +211,7 @@ impl<R: Runtime> NotificationBuilder<R> {
     }
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the notification APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the notification APIs.
 pub trait NotificationExt<R: Runtime> {
     fn notification(&self) -> &Notification<R>;
 }

--- a/plugins/notification/src/lib.rs
+++ b/plugins/notification/src/lib.rs
@@ -211,7 +211,7 @@ impl<R: Runtime> NotificationBuilder<R> {
     }
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the notification APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`], [`tauri::Webview`] and [`tauri::Window`] to access the notification APIs.
 pub trait NotificationExt<R: Runtime> {
     fn notification(&self) -> &Notification<R>;
 }

--- a/plugins/notification/src/lib.rs
+++ b/plugins/notification/src/lib.rs
@@ -211,7 +211,7 @@ impl<R: Runtime> NotificationBuilder<R> {
     }
 }
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the notification APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the notification APIs.
 pub trait NotificationExt<R: Runtime> {
     fn notification(&self) -> &Notification<R>;
 }

--- a/plugins/updater/src/lib.rs
+++ b/plugins/updater/src/lib.rs
@@ -29,7 +29,7 @@ pub use config::Config;
 pub use error::{Error, Result};
 pub use updater::*;
 
-/// Extension trait to use the updater on [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`].
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`], [`tauri::Webview`] and [`tauri::Window`] to access the updater APIs.
 pub trait UpdaterExt<R: Runtime> {
     /// Gets the updater builder to build and updater
     /// that can manually check if an update is available.

--- a/plugins/updater/src/lib.rs
+++ b/plugins/updater/src/lib.rs
@@ -29,7 +29,7 @@ pub use config::Config;
 pub use error::{Error, Result};
 pub use updater::*;
 
-/// Extension trait to use the updater on [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`].
+/// Extension trait to use the updater on [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`].
 pub trait UpdaterExt<R: Runtime> {
     /// Gets the updater builder to build and updater
     /// that can manually check if an update is available.

--- a/plugins/updater/src/lib.rs
+++ b/plugins/updater/src/lib.rs
@@ -29,7 +29,7 @@ pub use config::Config;
 pub use error::{Error, Result};
 pub use updater::*;
 
-/// Extension trait to use the updater on [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`].
+/// Extension trait to use the updater on [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`].
 pub trait UpdaterExt<R: Runtime> {
     /// Gets the updater builder to build and updater
     /// that can manually check if an update is available.

--- a/shared/template/src/lib.rs
+++ b/shared/template/src/lib.rs
@@ -25,7 +25,7 @@ use desktop::{{ plugin_name_pascal_case }};
 #[cfg(mobile)]
 use mobile::{{ plugin_name_pascal_case }};
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the {{ plugin_name }} APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the {{ plugin_name }} APIs.
 pub trait {{ plugin_name_pascal_case }}Ext<R: Runtime> {
   fn {{ plugin_name_snake_case }}(&self) -> &{{ plugin_name_pascal_case }}<R>;
 }

--- a/shared/template/src/lib.rs
+++ b/shared/template/src/lib.rs
@@ -25,7 +25,7 @@ use desktop::{{ plugin_name_pascal_case }};
 #[cfg(mobile)]
 use mobile::{{ plugin_name_pascal_case }};
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::webview::WebviewWindow`] and [`tauri::Window`] to access the {{ plugin_name }} APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the {{ plugin_name }} APIs.
 pub trait {{ plugin_name_pascal_case }}Ext<R: Runtime> {
   fn {{ plugin_name_snake_case }}(&self) -> &{{ plugin_name_pascal_case }}<R>;
 }

--- a/shared/template/src/lib.rs
+++ b/shared/template/src/lib.rs
@@ -25,7 +25,7 @@ use desktop::{{ plugin_name_pascal_case }};
 #[cfg(mobile)]
 use mobile::{{ plugin_name_pascal_case }};
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`] and [`tauri::Window`] to access the {{ plugin_name }} APIs.
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`], [`tauri::Webview`] and [`tauri::Window`] to access the {{ plugin_name }} APIs.
 pub trait {{ plugin_name_pascal_case }}Ext<R: Runtime> {
   fn {{ plugin_name_snake_case }}(&self) -> &{{ plugin_name_pascal_case }}<R>;
 }


### PR DESCRIPTION
As Tauri 2.0 uses `WebviewWindow`, we should also add a reference to it in the docs along with `Window` 