### PR TITLE
feat(shell) raw-encoded pipe reader directly outputs buffer (no newline scan)

### DIFF
--- a/.changes/enhance-shell-raw-out.md
+++ b/.changes/enhance-shell-raw-out.md
@@ -1,0 +1,6 @@
+---
+"shell": patch
+---
+
+When the "raw" encoding option is specified for a shell process, all bytes from the child's output streams are passed to the data handlers. 
+This makes it possible to read output from programs that write unencoded byte streams to stdout (like ffmpeg)

--- a/plugins/shell/src/commands.rs
+++ b/plugins/shell/src/commands.rs
@@ -154,7 +154,10 @@ pub fn execute<R: Runtime>(
     let encoding = match options.encoding {
         Option::None => EncodingWrapper::Text(None),
         Some(encoding) => match encoding.as_str() {
-            "raw" => EncodingWrapper::Raw,
+            "raw" => {
+                command = command.set_raw_out(true);
+                EncodingWrapper::Raw
+            },
             _ => {
                 if let Some(text_encoding) = Encoding::for_label(encoding.as_bytes()) {
                     EncodingWrapper::Text(Some(text_encoding))

--- a/plugins/shell/src/commands.rs
+++ b/plugins/shell/src/commands.rs
@@ -157,7 +157,7 @@ pub fn execute<R: Runtime>(
             "raw" => {
                 command = command.set_raw_out(true);
                 EncodingWrapper::Raw
-            },
+            }
             _ => {
                 if let Some(text_encoding) = Encoding::for_label(encoding.as_bytes()) {
                     EncodingWrapper::Text(Some(text_encoding))


### PR DESCRIPTION
One of the things that I've had to change in both the previous v1 shell and again in the v2 shell plugin is the way that the pipe reader handles output from a process. I'm working with a process that outputs binary, so breaking at the newline character disrupts the binary output. I think others have also encountered this.

I'm new to rust, but this seems like a somewhat reasonable approach that would preserve the original line-based behavior but present "raw" streams without changing anything between the process and the front end. This is, technically, a breaking change, but I propose that this is worth it going forward for the v2 release.