### PR TITLE
fix(fs): missing debouncer rename cache

### DIFF
--- a/.changes/watcher-debouncer-rename.md
+++ b/.changes/watcher-debouncer-rename.md
@@ -2,4 +2,4 @@
 "fs": patch
 ---
 
-Fixes `RenameMode::From` and `RenameMode::To` never getting converted to `RenameMode::Both` when using watch with a debounce on Windows
+Fixes `RenameMode::From` and `RenameMode::To` never getting converted to `RenameMode::Both` when using `watch` with a debounce on Windows

--- a/.changes/watcher-debouncer-rename.md
+++ b/.changes/watcher-debouncer-rename.md
@@ -1,0 +1,5 @@
+---
+"fs": patch
+---
+
+Fixes `RenameMode::From` and `RenameMode::To` never getting converted to `RenameMode::Both` when using watch with a debounce on Windows

--- a/plugins/fs/src/watcher.rs
+++ b/plugins/fs/src/watcher.rs
@@ -100,7 +100,7 @@ pub async fn watch<R: Runtime>(
         )?);
     }
 
-    let mode = if options.recursive {
+    let recursive_mode = if options.recursive {
         RecursiveMode::Recursive
     } else {
         RecursiveMode::NonRecursive
@@ -110,7 +110,8 @@ pub async fn watch<R: Runtime>(
         let (tx, rx) = channel();
         let mut debouncer = new_debouncer(Duration::from_millis(delay), None, tx)?;
         for path in &resolved_paths {
-            debouncer.watcher().watch(path.as_ref(), mode)?;
+            debouncer.watcher().watch(path.as_ref(), recursive_mode)?;
+            debouncer.cache().add_root(path, recursive_mode);
         }
         watch_debounced(on_event, rx);
         WatcherKind::Debouncer(debouncer)
@@ -118,7 +119,7 @@ pub async fn watch<R: Runtime>(
         let (tx, rx) = channel();
         let mut watcher = RecommendedWatcher::new(tx, Config::default())?;
         for path in &resolved_paths {
-            watcher.watch(path.as_ref(), mode)?;
+            watcher.watch(path.as_ref(), recursive_mode)?;
         }
         watch_raw(on_event, rx);
         WatcherKind::Watcher(watcher)


### PR DESCRIPTION
Cache is required for debouncer to pick up rename events on Windows on current version of notify
Without this, `RenameMode::From` and `RenameMode::To` will not get converted to `RenameMode::Both`

> https://github.com/notify-rs/notify/blob/notify-6.1.1/notify-debouncer-full/src/lib.rs#L50

> This is now part of the new watch function in the notify repo
> https://github.com/notify-rs/notify/blob/3df0f65152c8585cfb29d231c880b86b9164dcfd/notify-debouncer-full/src/lib.rs#L583-L591