### PR TITLE
fix(window-state): restore window state for stubbed zerord state

### DIFF
--- a/.changes/restore-default-window-state.md
+++ b/.changes/restore-default-window-state.md
@@ -1,0 +1,5 @@
+---
+"window-state": patch
+---
+
+Fix `restore_window` doesn't work with `skip_initial_state` when no previous cache was found

--- a/plugins/window-state/src/lib.rs
+++ b/plugins/window-state/src/lib.rs
@@ -148,12 +148,10 @@ impl<R: Runtime> WindowExt for Window<R> {
 
         let mut should_show = true;
 
-        if let Some(state) = c.get(self.label()) {
-            // avoid restoring the default zeroed state
-            if *state == WindowState::default() {
-                return Ok(());
-            }
-
+        if let Some(state) = c
+            .get(self.label())
+            .filter(|state| state != &&WindowState::default())
+        {
             if flags.contains(StateFlags::DECORATIONS) {
                 self.set_decorations(state.decorated)?;
             }


### PR DESCRIPTION
We currently ignore default all zero state in `restore_state`, but this will prevent `skip_initial_state` + calling `restore_state` manually to show the window if no previous cache was found, we should treat default all zero state as no cache found