### PR TITLE
feat(dialog): set `len` and `modified_at` fields in `FileResponse` on desktop

### DIFF
--- a/.changes/dialog-metadata.md
+++ b/.changes/dialog-metadata.md
@@ -1,0 +1,6 @@
+---
+"dialog": "patch"
+"dialog-js": "patch"
+---
+
+Fill file `len` and `modified_at` fields of `FileResponse` when using the open dialog.

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -18,6 +18,7 @@ use tauri::{
 };
 
 use std::{
+    fs,
     path::{Path, PathBuf},
     sync::mpsc::sync_channel,
 };
@@ -230,6 +231,8 @@ pub struct FileResponse {
 impl FileResponse {
     #[cfg(desktop)]
     fn new(path: PathBuf) -> Self {
+        let metadata = fs::metadata(&path).unwrap();
+
         Self {
             base64_data: None,
             duration: None,
@@ -239,7 +242,7 @@ impl FileResponse {
             modified_at: None,
             name: path.file_name().map(|f| f.to_string_lossy().into_owned()),
             path,
-            size: 0,
+            size: metadata.len(),
         }
     }
 }

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -214,7 +214,7 @@ impl<R: Runtime> MessageDialogBuilder<R> {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct FileResponse {
     pub base64_data: Option<String>,
@@ -231,18 +231,18 @@ pub struct FileResponse {
 impl FileResponse {
     #[cfg(desktop)]
     fn new(path: PathBuf) -> Self {
-        let metadata = fs::metadata(&path).unwrap();
-
+        let metadata = fs::metadata(&path);
+        let metadata = metadata.as_ref();
         Self {
             base64_data: None,
             duration: None,
             height: None,
             width: None,
             mime_type: None,
-            modified_at: None,
+            modified_at: metadata.ok().and_then(|m| to_msec(m.modified())),
             name: path.file_name().map(|f| f.to_string_lossy().into_owned()),
             path,
-            size: metadata.len(),
+            size: metadata.map(|m| m.len()).unwrap_or(0),
         }
     }
 }
@@ -575,5 +575,20 @@ impl<R: Runtime> FileDialogBuilder<R> {
     #[cfg(desktop)]
     pub fn blocking_save_file(self) -> Option<PathBuf> {
         blocking_fn!(self, save_file)
+    }
+}
+
+// taken from deno source code: https://github.com/denoland/deno/blob/ffffa2f7c44bd26aec5ae1957e0534487d099f48/runtime/ops/fs.rs#L913
+#[inline]
+fn to_msec(maybe_time: std::result::Result<std::time::SystemTime, std::io::Error>) -> Option<u64> {
+    match maybe_time {
+        Ok(time) => {
+            let msec = time
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|t| t.as_millis() as u64)
+                .unwrap_or_else(|err| err.duration().as_millis() as u64);
+            Some(msec)
+        }
+        Err(_) => None,
     }
 }


### PR DESCRIPTION
### Description:

This pull request introduces a feature enhancement to the FileResponse struct in the Tauri project. The enhancement allows the FileResponse struct to automatically compute and include the size of the file in bytes when creating a new instance.

### Changes:
- Added functionality to retrieve the size of a file in bytes.
- Implemented logic to calculate the size of the file using the standard library's std::fs::metadata method.
- Updated the FileResponse struct's new function to include the size of the file as a field.

### Benefits:
- Users of the FileResponse struct can now easily access the size of a file without needing to manually compute it.
- Simplifies code for developers by providing a convenient way to include file size information in FileResponse instances.

### Considerations:
- Error handling for file metadata retrieval is implemented using unwrap(). Further improvements can be made to handle errors more gracefully.
- File size is reported in bytes. No unit conversion (e.g., kilobytes or megabytes) is performed at this stage.