### PR TITLE
feat(sql): preserve column order from query with indexmap

### DIFF
--- a/.changes/sql-column-order.md
+++ b/.changes/sql-column-order.md
@@ -1,0 +1,5 @@
+---
+"sql": patch
+---
+
+Preserve column order from SELECT query with indexmap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -2872,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -4221,7 +4221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9d34169e64b3c7a80c8621a48adaf44e0cf62c78a9b25dd9dd35f1881a17cf9"
 dependencies = [
  "base64 0.21.7",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "line-wrap",
  "quick-xml 0.31.0",
  "serde",
@@ -5189,7 +5189,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5488,7 +5488,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "log",
  "memchr",
  "once_cell",
@@ -6424,6 +6424,7 @@ name = "tauri-plugin-sql"
 version = "2.0.0-beta.4"
 dependencies = [
  "futures-core",
+ "indexmap 2.2.6",
  "log",
  "serde",
  "serde_json",
@@ -6927,7 +6928,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6940,7 +6941,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -6951,7 +6952,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -6962,7 +6963,7 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/plugins/sql/Cargo.toml
+++ b/plugins/sql/Cargo.toml
@@ -33,4 +33,3 @@ indexmap = { version = "2.2.6", features = ["serde"] }
 sqlite = [ "sqlx/sqlite", "sqlx/runtime-tokio" ]
 mysql = [ "sqlx/mysql", "sqlx/runtime-tokio-rustls" ]
 postgres = [ "sqlx/postgres", "sqlx/runtime-tokio-rustls" ]
-default = ["sqlite"]

--- a/plugins/sql/Cargo.toml
+++ b/plugins/sql/Cargo.toml
@@ -27,8 +27,10 @@ futures-core = "0.3"
 sqlx = { version = "0.7", features = [ "json", "time" ] }
 time = "0.3"
 tokio = { version = "1", features = [ "sync" ] }
+indexmap = { version = "2.2.6", features = ["serde"] }
 
 [features]
 sqlite = [ "sqlx/sqlite", "sqlx/runtime-tokio" ]
 mysql = [ "sqlx/mysql", "sqlx/runtime-tokio-rustls" ]
 postgres = [ "sqlx/postgres", "sqlx/runtime-tokio-rustls" ]
+default = ["sqlite"]

--- a/plugins/sql/src/plugin.rs
+++ b/plugins/sql/src/plugin.rs
@@ -19,6 +19,7 @@ use tauri::{
 };
 use tokio::sync::Mutex;
 
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 #[cfg(feature = "sqlite")]
@@ -233,7 +234,7 @@ async fn select(
     db: String,
     query: String,
     values: Vec<JsonValue>,
-) -> Result<Vec<HashMap<String, JsonValue>>> {
+) -> Result<Vec<IndexMap<String, JsonValue>>> {
     let mut instances = db_instances.0.lock().await;
     let db = instances.get_mut(&db).ok_or(Error::DatabaseNotLoaded(db))?;
     let mut query = sqlx::query(&query);
@@ -251,7 +252,7 @@ async fn select(
     let rows = query.fetch_all(&*db).await?;
     let mut values = Vec::new();
     for row in rows {
-        let mut value = HashMap::default();
+        let mut value = IndexMap::default();
         for (i, column) in row.columns().iter().enumerate() {
             let v = row.try_get_raw(i)?;
 


### PR DESCRIPTION
When using the `select` command in the `sql` plugin, the field order in each row isn't maintained due to the use of a hashmap. This update ensures that the field order remains consistent.

Example:

```sql
SELECT name, age FROM users;
```

Previously, the returned rows could have inconsistent order, such as 
```
{"name": ..., "age": ...}
```
 or 
```
{"age": ..., "name": ...}
```
With this modification, the order will consistently follow the query, i.e., `name` followed by `age`.