### PR TITLE
chore(updater): remove `/NS`

### DIFF
--- a/plugins/updater/src/config.rs
+++ b/plugins/updater/src/config.rs
@@ -32,6 +32,9 @@ impl WindowsUpdateInstallMode {
 
     /// Returns the associated nsis arguments.
     pub fn nsis_args(&self) -> &'static [&'static str] {
+        // `/P`: Passive
+        // `/S`: Silent
+        // `/R`: Restart
         match self {
             Self::Passive => &["/P", "/R"],
             Self::Quiet => &["/S", "/R"],

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -556,7 +556,6 @@ impl Update {
         match updater_type {
             WindowsUpdaterType::Nsis => {
                 installer_args.extend(install_mode.nsis_args().iter().map(OsStr::new));
-                installer_args.push(OsStr::new("/NS"));
                 installer_args.push(OsStr::new("/UPDATE"));
             }
             WindowsUpdaterType::Msi => {


### PR DESCRIPTION
References: https://github.com/tauri-apps/plugins-workspace/pull/1162, https://github.com/tauri-apps/tauri/pull/9559

`/UPDATE` alone is enough to prevent it from re-creating the shortcut

(I really wish we had better name than `P`, `/S`, `/R`, `NS` 😂)