### PR TITLE
fix(clipboard-manager): match Rust method parameters with native methods

### DIFF
--- a/.changes/clipboard-mobile.md
+++ b/.changes/clipboard-mobile.md
@@ -1,0 +1,5 @@
+---
+"clipboard-manager": "patch"
+---
+
+Fix reading and writing text on Android and iOS. 

--- a/plugins/clipboard-manager/src/mobile.rs
+++ b/plugins/clipboard-manager/src/mobile.rs
@@ -37,7 +37,7 @@ impl<R: Runtime> Clipboard<R> {
     pub fn write_text<'a, T: Into<Cow<'a, str>>>(&self, text: T) -> crate::Result<()> {
         let text = text.into().to_string();
         self.0
-            .run_mobile_plugin("write", ClipKind::PlainText { text, label: None })
+            .run_mobile_plugin("writeText", ClipKind::PlainText { text, label: None })
             .map_err(Into::into)
     }
 
@@ -50,7 +50,7 @@ impl<R: Runtime> Clipboard<R> {
         let label = label.into().to_string();
         self.0
             .run_mobile_plugin(
-                "write",
+                "writeText",
                 ClipKind::PlainText {
                     text,
                     label: Some(label),
@@ -67,7 +67,7 @@ impl<R: Runtime> Clipboard<R> {
 
     pub fn read_text(&self) -> crate::Result<String> {
         self.0
-            .run_mobile_plugin("read", ())
+            .run_mobile_plugin("readText", ())
             .map(|c| match c {
                 ClipboardContents::PlainText { text } => text,
             })


### PR DESCRIPTION
Ensured that the parameters for the run_mobile_plugin method in Rust code's readText and writeText methods match the expected native method names.

Below is a screenshot of one of the errors fixed:
![image](https://github.com/tauri-apps/plugins-workspace/assets/70356757/ad198105-3997-4f71-bb15-2cb0e11b29bd)

Leaving the other error here as a reference for anyone text searching anything similar:
No command write found for plugin clipboard-manager
