### PR TITLE
feat(sql): allow open absolute sqlite path

### DIFF
--- a/.changes/sql-open-absolute-sqlite-path.md
+++ b/.changes/sql-open-absolute-sqlite-path.md
@@ -1,0 +1,5 @@
+---
+"sql": patch
+---
+
+Open SQLite files from any absolute path while keep default behavior for relative path.

--- a/plugins/sql/src/plugin.rs
+++ b/plugins/sql/src/plugin.rs
@@ -70,20 +70,25 @@ fn app_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
 #[cfg(feature = "sqlite")]
 /// Maps the user supplied DB connection string to a connection string
 /// with a fully qualified file path to the App's designed "app_path"
-fn path_mapper(mut app_path: PathBuf, connection_string: &str) -> String {
-    app_path.push(
-        connection_string
-            .split_once(':')
-            .expect("Couldn't parse the connection string for DB!")
-            .1,
-    );
+fn path_mapper<R: Runtime>(app: &AppHandle<R>, connection_string: &str) -> String {
+    let path = connection_string
+        .split_once(":")
+        .expect("Couldn't parse the connection string for DB!")
+        .1;
 
-    format!(
-        "sqlite:{}",
-        app_path
+    let pathbuf = PathBuf::from(path);
+
+    // Allow open sqlite file outside of app directory
+    if pathbuf.is_absolute() {
+        format!("sqlite:{}", path)
+    } else {
+        // Open sqlite file relative to app directory
+        let pathbuf = app_path(app).join(path);
+        let path = pathbuf
             .to_str()
-            .expect("Problem creating fully qualified path to Database file!")
-    )
+            .expect("Problem creating fully qualified path to Database file!");
+        format!("sqlite:{}", path)
+    }
 }
 
 #[derive(Default)]
@@ -151,7 +156,7 @@ async fn load<R: Runtime>(
     db: String,
 ) -> Result<String> {
     #[cfg(feature = "sqlite")]
-    let fqdb = path_mapper(app_path(&app), &db);
+    let fqdb = path_mapper(&app, &db);
     #[cfg(not(feature = "sqlite"))]
     let fqdb = db.clone();
 
@@ -301,7 +306,7 @@ impl Builder {
                     let mut lock = instances.0.lock().await;
                     for db in config.preload {
                         #[cfg(feature = "sqlite")]
-                        let fqdb = path_mapper(app_path(app), &db);
+                        let fqdb = path_mapper(app, &db);
                         #[cfg(not(feature = "sqlite"))]
                         let fqdb = db.clone();
 


### PR DESCRIPTION
This PR updates the sql plugin in plugins-workspace for v2. It now allows opening SQLite files from any absolute path. If the path is not absolute, it still defaults to opening files relative to the app directory.

Examples of possible connection strings:

```rust
sqlite:/absolute/path/to/file.db
```

```rust
sqlite:relative_to_app_dir.db
```