### PR TITLE
feat(sql): made DbInstances public for managing directly from Rust

### DIFF
--- a/.changes/sql-public-db-instances.md
+++ b/.changes/sql-public-db-instances.md
@@ -1,0 +1,5 @@
+---
+"sql": patch
+---
+
+Made `DbInstances` public for managing database instances directly from `Rust`.

--- a/plugins/sql/src/plugin.rs
+++ b/plugins/sql/src/plugin.rs
@@ -87,7 +87,7 @@ fn path_mapper(mut app_path: PathBuf, connection_string: &str) -> String {
 }
 
 #[derive(Default)]
-struct DbInstances(Mutex<HashMap<String, Pool<Db>>>);
+pub struct DbInstances(pub Mutex<HashMap<String, Pool<Db>>>);
 
 struct Migrations(Mutex<HashMap<String, MigrationList>>);
 


### PR DESCRIPTION
This PR expands the functionality of the `SQL` plugin in the `plugins-workspace` for `v2` by exposing database instances for direct `Rust` access.

Example useage:

```rust
use tauri_plugin_sql::DbInstances;

let instances = app_handle.state::<DbInstances>();
let instances = instances.inner().0.lock().await;
println!("instances: {:?}", instances);
```