### PR TITLE
fix: deep-link is desktop compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | [biometric](plugins/biometric)                  | Prompt the user for biometric authentication on Android and iOS.                                                                                                       | ?   | ?   | ?   | ✅  | ✅  |
 | [cli](plugins/cli)                              | Parse arguments from your Command Line Interface       | ✅  | ✅  | ✅  | ?   | ?   |
 | [clipboard-manager](plugins/clipboard-manager)  | Read and write to the system clipboard.                | ✅  | ✅  | ✅  | ✅  | ✅  |
-| [deep-link](plugins/deep-link)                  | Set your Tauri application as the default handler for an URL.                                                                                                       | ?   | ?   | ?   | ✅   | ✅  |
+| [deep-link](plugins/deep-link)                  | Set your Tauri application as the default handler for an URL.                                                                                                       | ✅   | ✅   | ✅   | ✅   | ✅  |
 | [dialog](plugins/dialog)                        | Native system dialogs for opening and saving files along with message dialogs.                                                                                                   | ✅  | ✅  | ✅  | ✅  | ✅ |
 | [fs](plugins/fs)                                | Access the file system.                                | ✅   | ✅   | ✅   | ?   | ?  |
 | [global-shortcut](plugins/global-shortcut)      | Register global shortcuts.                             | ✅  | ✅  | ✅  | ?   | ?  |


### PR DESCRIPTION
According to all available documentation the plugin is desktop compatible.