### PR TITLE
feat(sql) Sql batch insert

### DIFF
--- a/.changes/sql-batch-insert.md
+++ b/.changes/sql-batch-insert.md
@@ -1,0 +1,5 @@
+---
+"sql": minor
+---
+
+Add support for batch inserting a large number of values in the database.

--- a/plugins/sql/build.rs
+++ b/plugins/sql/build.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-const COMMANDS: &[&str] = &["load", "execute", "select", "close"];
+const COMMANDS: &[&str] = &["load", "execute", "select", "close", "batch_insert"];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS)

--- a/plugins/sql/guest-js/index.ts
+++ b/plugins/sql/guest-js/index.ts
@@ -121,6 +121,43 @@ export default class Database {
   }
 
   /**
+     * **insertMultiple**
+     *
+     * Insert multiple entry in a single request
+     *
+     * @example
+     * ```ts
+     * // BATCH INSERT example
+     * const result = await db.batchInsert(
+     *    "INSERT into todos (id, title, status) ",
+     *    [ 
+     *        [0, "TODO 0", "Done"], 
+     *        [1, "TODO 1", "Done"],
+     *        [2, "TODO 2", "Done"],
+     *    ]
+     * );     
+     * ```
+     */
+  async batchInsert(query: string, bindValues?: unknown[]): Promise<QueryResult> {
+    if (bindValues?.length == 0 || !bindValues)
+      return false
+  const values_length = bindValues[0].length
+  const chunkSize = Math.floor(999 / values_length);
+  for (let i = 0; i < bindValues.length; i += chunkSize) {
+      const chunk = bindValues.slice(i, i + chunkSize);
+      const [_rowsAffected, _lastInsertId] = await invoke<[number, number]>(
+          "plugin:sql|execute_multiple",
+          {
+              db: db.path,
+              query,
+              values: chunk ?? [],
+          },
+      );
+      // do whatever
+  }
+  
+
+  /**
    * **select**
    *
    * Passes in a SELECT query to the database for execution.

--- a/plugins/sql/guest-js/index.ts
+++ b/plugins/sql/guest-js/index.ts
@@ -140,32 +140,23 @@ export default class Database {
    */
   async batchInsert(
     query: string,
-    bindValues?: unknown[][],
+    bindValues: unknown[][],
   ): Promise<QueryResult> {
-    if (bindValues?.length == 0 || !bindValues) {
+    if (bindValues.length == 0 || !bindValues) {
       console.warn("Batch insert does not contains any values");
       return {
         lastInsertId: 0,
         rowsAffected: 0,
       };
     }
-    const values_length = bindValues[0].length;
-    const chunkSize = Math.floor(999 / values_length);
-    let rowsAffected = 0;
-    let lastInsertId = 0;
-    for (let i = 0; i < bindValues.length; i += chunkSize) {
-      const chunk = bindValues.slice(i, i + chunkSize);
-      const [rowsAffectedQuery, lastInsertIdQuery] = await invoke<
-        [number, number]
-      >("plugin:sql|batch_insert", {
+    const [rowsAffected, lastInsertId] = await invoke<[number, number]>(
+      "plugin:sql|batch_insert",
+      {
         db: this.path,
         query,
-        values: chunk ?? [],
-      });
-      rowsAffected += rowsAffectedQuery;
-      lastInsertId = lastInsertIdQuery;
-      // do whatever
-    }
+        values: bindValues,
+      },
+    );
     return {
       lastInsertId: lastInsertId,
       rowsAffected: rowsAffected,

--- a/plugins/sql/guest-js/index.ts
+++ b/plugins/sql/guest-js/index.ts
@@ -121,41 +121,56 @@ export default class Database {
   }
 
   /**
-     * **insertMultiple**
-     *
-     * Insert multiple entry in a single request
-     *
-     * @example
-     * ```ts
-     * // BATCH INSERT example
-     * const result = await db.batchInsert(
-     *    "INSERT into todos (id, title, status) ",
-     *    [ 
-     *        [0, "TODO 0", "Done"], 
-     *        [1, "TODO 1", "Done"],
-     *        [2, "TODO 2", "Done"],
-     *    ]
-     * );     
-     * ```
-     */
-  async batchInsert(query: string, bindValues?: unknown[]): Promise<QueryResult> {
-    if (bindValues?.length == 0 || !bindValues)
-      return false
-  const values_length = bindValues[0].length
-  const chunkSize = Math.floor(999 / values_length);
-  for (let i = 0; i < bindValues.length; i += chunkSize) {
+   * **insertMultiple**
+   *
+   * Insert multiple entry in a single request
+   *
+   * @example
+   * ```ts
+   * // BATCH INSERT example
+   * const result = await db.batchInsert(
+   *    "INSERT into todos (id, title, status) ",
+   *    [
+   *        [0, "TODO 0", "Done"],
+   *        [1, "TODO 1", "Done"],
+   *        [2, "TODO 2", "Done"],
+   *    ]
+   * );
+   * ```
+   */
+  async batchInsert(
+    query: string,
+    bindValues?: unknown[][],
+  ): Promise<QueryResult> {
+    if (bindValues?.length == 0 || !bindValues) {
+      console.warn("Batch insert does not contains any values");
+      return {
+        lastInsertId: 0,
+        rowsAffected: 0,
+      };
+    }
+    const values_length = bindValues[0].length;
+    const chunkSize = Math.floor(999 / values_length);
+    let rowsAffected = 0;
+    let lastInsertId = 0;
+    for (let i = 0; i < bindValues.length; i += chunkSize) {
       const chunk = bindValues.slice(i, i + chunkSize);
-      const [_rowsAffected, _lastInsertId] = await invoke<[number, number]>(
-          "plugin:sql|execute_multiple",
-          {
-              db: db.path,
-              query,
-              values: chunk ?? [],
-          },
-      );
+      const [rowsAffectedQuery, lastInsertIdQuery] = await invoke<
+        [number, number]
+      >("plugin:sql|batch_insert", {
+        db: this.path,
+        query,
+        values: chunk ?? [],
+      });
+      rowsAffected += rowsAffectedQuery;
+      lastInsertId = lastInsertIdQuery;
       // do whatever
+    }
+    return {
+      lastInsertId: lastInsertId,
+      rowsAffected: rowsAffected,
+    };
   }
-  
 
   /**
    * **select**

--- a/plugins/sql/src/plugin.rs
+++ b/plugins/sql/src/plugin.rs
@@ -6,11 +6,9 @@ use futures_core::future::BoxFuture;
 use serde::{ser::Serializer, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use sqlx::{
-    error::BoxDynError,
-    migrate::{
+    error::BoxDynError, migrate::{
         MigrateDatabase, Migration as SqlxMigration, MigrationSource, MigrationType, Migrator,
-    },
-    Column, Pool, Row,
+    }, Column, Pool, QueryBuilder, Row
 };
 use tauri::{
     command,
@@ -218,6 +216,42 @@ async fn execute(
             query = query.bind(value);
         }
     }
+    let result = query.execute(&*db).await?;
+    #[cfg(feature = "sqlite")]
+    let r = Ok((result.rows_affected(), result.last_insert_rowid()));
+    #[cfg(feature = "mysql")]
+    let r = Ok((result.rows_affected(), result.last_insert_id()));
+    #[cfg(feature = "postgres")]
+    let r = Ok((result.rows_affected(), 0));
+    r
+}
+
+/// Execute multiple query (Useful to do batch insertion)
+#[command]
+async fn batch_insert(
+    db_instances: State<'_, DbInstances>,
+    db: String,
+    query: String,
+    values: Vec<Vec<JsonValue>>,
+) -> Result<(u64, LastInsertId)> {
+    let mut builder = QueryBuilder::new(query.clone());
+    let mut instances = db_instances.0.lock().await;
+
+    let db = instances.get_mut(&db).ok_or(Error::DatabaseNotLoaded(db))?;
+    builder.push_values(values, |mut b, value| {
+        for v in value {
+            if v.is_null() {
+                b.push_bind(None::<JsonValue>);
+            } else if v.is_string() {
+                b.push_bind(v.as_str().unwrap().to_owned());
+            } else if v.is_number() {
+                b.push_bind(v.as_f64().unwrap_or_default());
+            } else {
+                b.push_bind(v);
+            }
+        }
+    });
+    let mut query = builder.build();
     let result = query.execute(&*db).await?;
     #[cfg(feature = "sqlite")]
     let r = Ok((result.rows_affected(), result.last_insert_rowid()));

--- a/plugins/sql/src/plugin.rs
+++ b/plugins/sql/src/plugin.rs
@@ -6,9 +6,11 @@ use futures_core::future::BoxFuture;
 use serde::{ser::Serializer, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use sqlx::{
-    error::BoxDynError, migrate::{
+    error::BoxDynError,
+    migrate::{
         MigrateDatabase, Migration as SqlxMigration, MigrationSource, MigrationType, Migrator,
-    }, Column, Pool, QueryBuilder, Row
+    },
+    Column, Pool, QueryBuilder, Row,
 };
 use tauri::{
     command,
@@ -251,7 +253,7 @@ async fn batch_insert(
             }
         }
     });
-    let mut query = builder.build();
+    let query = builder.build();
     let result = query.execute(&*db).await?;
     #[cfg(feature = "sqlite")]
     let r = Ok((result.rows_affected(), result.last_insert_rowid()));
@@ -323,7 +325,13 @@ impl Builder {
 
     pub fn build<R: Runtime>(mut self) -> TauriPlugin<R, Option<PluginConfig>> {
         PluginBuilder::<R, Option<PluginConfig>>::new("sql")
-            .invoke_handler(tauri::generate_handler![load, execute, select, close])
+            .invoke_handler(tauri::generate_handler![
+                load,
+                execute,
+                select,
+                close,
+                batch_insert
+            ])
             .setup(|app, api| {
                 let config = api.config().clone().unwrap_or_default();
 


### PR DESCRIPTION
Hello,

This a pull request for implementing an additional method for batch inserting into a SqlLite database (should also work for other sql databases).

It is based on the [QueryBuild push_values method](https://docs.rs/sqlx/latest/sqlx/struct.QueryBuilder.html#method.push_values) of sqlx rust module.

It is possible to push any number of values but the JS function will split the request into batches of values that does not exceed 999 values since it seems to be the limit for sqlite.

From my benchmark it is 100 times faster than looping through execute commands (with 10000 values, but maybe my benchmark code is not the best). Here is the code I use for testing : 

```js
let db = await Database.load('sqlite:mydatabase.db')
let data = []
for(let i= 0;i<10000;i++){
data.push([(Math.random() + 1).toString(36).substring(7)])
}
let startTime = Date.now()
await db.batchInsert("INSERT into users (name) ", data)
console.log("Batch insert time ", Date.now()-startTime)

startTime = Date.now()
await Promise.all(data.map(v=> db.execute("INSERT into users (name) VALUES ($1)", v)))
console.log("Loop insert time ", Date.now()-startTime)
```
```console
Batch insert time  190
Loop insert time  31462
```

The results for 1000 values:
```
Batch insert time  11
Loop insert time  557
```
