### PR TITLE
feat(clipboard-manager): implement `clear` on iOS and Android

### DIFF
--- a/.changes/clear-clipboard.md
+++ b/.changes/clear-clipboard.md
@@ -1,0 +1,5 @@
+---
+"clipboard-manager": "minor"
+---
+
+Add support for clearing clipboard text on iOS and Android. 

--- a/plugins/clipboard-manager/android/src/main/java/ClipboardPlugin.kt
+++ b/plugins/clipboard-manager/android/src/main/java/ClipboardPlugin.kt
@@ -129,9 +129,7 @@ class ClipboardPlugin(private val activity: Activity) : Plugin(activity) {
   fun clear(invoke: Invoke) {
       if (manager.hasPrimaryClip()) {
           manager.clearPrimaryClip()
-          invoke.resolve()
-      } else {
-          invoke.reject("Clipboard is empty")
       }
+      invoke.resolve()
   }
 }

--- a/plugins/clipboard-manager/android/src/main/java/ClipboardPlugin.kt
+++ b/plugins/clipboard-manager/android/src/main/java/ClipboardPlugin.kt
@@ -92,7 +92,11 @@ class ClipboardPlugin(private val activity: Activity) : Plugin(activity) {
     val clipData = when (args) {
       is WriteOptions.PlainText -> {
         ClipData.newPlainText(args.label, args.text)
+      } else -> {
+        invoke.reject("Invalid write options provided")
+        return
       }
+
     }
 
     manager.setPrimaryClip(clipData)
@@ -119,5 +123,15 @@ class ClipboardPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     invoke.resolveObject(data)
+  }
+
+  @Command
+  fun clear(invoke: Invoke) {
+      if (manager.hasPrimaryClip()) {
+          manager.clearPrimaryClip()
+          invoke.resolve()
+      } else {
+          invoke.reject("Clipboard is empty")
+      }
   }
 }

--- a/plugins/clipboard-manager/ios/Sources/ClipboardPlugin.swift
+++ b/plugins/clipboard-manager/ios/Sources/ClipboardPlugin.swift
@@ -38,6 +38,16 @@ class ClipboardPlugin: Plugin {
       invoke.reject("Clipboard is empty")
     }
   }
+    
+  @objc public func clear(_ invoke: Invoke) throws {
+      let clipboard = UIPasteboard.general
+      if clipboard.items.isEmpty {
+          invoke.reject("Clipboard is empty")
+      } else {
+          clipboard.items = []
+          invoke.resolve()
+      }
+    }
 }
 
 @_cdecl("init_plugin_clipboard")

--- a/plugins/clipboard-manager/ios/Sources/ClipboardPlugin.swift
+++ b/plugins/clipboard-manager/ios/Sources/ClipboardPlugin.swift
@@ -41,12 +41,8 @@ class ClipboardPlugin: Plugin {
     
   @objc public func clear(_ invoke: Invoke) throws {
       let clipboard = UIPasteboard.general
-      if clipboard.items.isEmpty {
-          invoke.reject("Clipboard is empty")
-      } else {
-          clipboard.items = []
-          invoke.resolve()
-      }
+      clipboard.items = []
+      invoke.resolve()
     }
 }
 

--- a/plugins/clipboard-manager/src/mobile.rs
+++ b/plugins/clipboard-manager/src/mobile.rs
@@ -92,9 +92,9 @@ impl<R: Runtime> Clipboard<R> {
     }
 
     pub fn clear(&self) -> crate::Result<()> {
-        Err(crate::Error::Clipboard(
-            "Unsupported on this platform".to_string(),
-        ))
+        self.0
+            .run_mobile_plugin("clear", ())
+            .map_err(Into::into)
     }
 }
 

--- a/plugins/clipboard-manager/src/mobile.rs
+++ b/plugins/clipboard-manager/src/mobile.rs
@@ -92,9 +92,7 @@ impl<R: Runtime> Clipboard<R> {
     }
 
     pub fn clear(&self) -> crate::Result<()> {
-        self.0
-            .run_mobile_plugin("clear", ())
-            .map_err(Into::into)
+        self.0.run_mobile_plugin("clear", ()).map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
This PR contains iOS and Android clear clipboard functionality that I use in my own project and shared here. Below is a screenshot that contains iOS simulator demonstration (as best as console logs could demonstrate) that it functions in the intended manner, and below that is the Android emulator version.

iOS simulator test:

<img width="1275" alt="image" src="https://github.com/tauri-apps/plugins-workspace/assets/70356757/8ff785ba-6d71-437e-9133-383e0a0f7782">


Android emulator test:

<img width="624" alt="image" src="https://github.com/tauri-apps/plugins-workspace/assets/70356757/37cb73d7-90cf-4eb2-b35e-4e2adaf4e1ff">

Also, the below when missed the else part. Not that it was causing errors for now, other than the IDE error, but it might in the future. Thinking it might not be worth a separate PR, I included it in this one. If I should open another one for that, I can send it in a separate PR and take it out of this one.

```kotlin
    val clipData = when (args) {
      is WriteOptions.PlainText -> {
        ClipData.newPlainText(args.label, args.text)
      } else -> {
        invoke.reject("Invalid write options provided")
        return
      }
```