### PR TITLE
chore(docs): fix typo

### DIFF
--- a/plugins/store/README.md
+++ b/plugins/store/README.md
@@ -127,7 +127,7 @@ fn main() {
 
 ### Loading Gracefully
 
-If you call `load` on a `Store` that hasn't yet been written to the desk, it will return an error. You must handle this error if you want to gracefully continue and use the default store until you save it to the disk. The example above shows how to do this.
+If you call `load` on a `Store` that hasn't yet been written to the disk, it will return an error. You must handle this error if you want to gracefully continue and use the default store until you save it to the disk. The example above shows how to do this.
 
 For example, this would cause a panic if the store has not yet been created:
 


### PR DESCRIPTION
This PR renames "desk" to "disk".