### PR TITLE
feat(window-state): add `Builder::map_label` method

### DIFF
--- a/.changes/window-state-map-label.md
+++ b/.changes/window-state-map-label.md
@@ -2,4 +2,4 @@
 "window-state": patch
 ---
 
-Add `map_label` option to transform the window label before using it internally, based on [amrbashir's suggestion](https://github.com/tauri-apps/plugins-workspace/pull/531#pullrequestreview-1566282300).
+Add `Builder::map_label` option to transform the window label when saving the window state, this could be used to group different windows to use the same state.

--- a/.changes/window-state-map-label.md
+++ b/.changes/window-state-map-label.md
@@ -1,0 +1,5 @@
+---
+"window-state": patch
+---
+
+Add `map_label` option to transform the window label before using it internally, based on [amrbashir's suggestion](https://github.com/tauri-apps/plugins-workspace/pull/531#pullrequestreview-1566282300).

--- a/plugins/window-state/src/lib.rs
+++ b/plugins/window-state/src/lib.rs
@@ -28,6 +28,8 @@ use std::{
 
 mod cmd;
 
+type LabelMapperFn = Fn(&str) -> &str + Send + Sync;
+
 /// Default filename used to store window state.
 ///
 /// If using a custom filename, you should probably use [`AppHandleExt::filename`] instead.
@@ -65,7 +67,7 @@ impl Default for StateFlags {
 
 struct PluginState {
     filename: String,
-    map_label: Option<Box<dyn Fn(&str) -> &str + Send + Sync>>,
+    map_label: Option<Box<dyn LabelMapperFn>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -326,7 +328,7 @@ pub struct Builder {
     denylist: HashSet<String>,
     skip_initial_state: HashSet<String>,
     state_flags: StateFlags,
-    map_label: Option<Box<dyn Fn(&str) -> &str + Send + Sync>>,
+    map_label: Option<Box<dyn LabelMapperFn>>,
     filename: Option<String>,
 }
 

--- a/plugins/window-state/src/lib.rs
+++ b/plugins/window-state/src/lib.rs
@@ -28,7 +28,7 @@ use std::{
 
 mod cmd;
 
-type LabelMapperFn = Fn(&str) -> &str + Send + Sync;
+type LabelMapperFn = dyn Fn(&str) -> &str + Send + Sync;
 
 /// Default filename used to store window state.
 ///
@@ -67,7 +67,7 @@ impl Default for StateFlags {
 
 struct PluginState {
     filename: String,
-    map_label: Option<Box<dyn LabelMapperFn>>,
+    map_label: Option<Box<LabelMapperFn>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -328,7 +328,7 @@ pub struct Builder {
     denylist: HashSet<String>,
     skip_initial_state: HashSet<String>,
     state_flags: StateFlags,
-    map_label: Option<Box<dyn LabelMapperFn>>,
+    map_label: Option<Box<LabelMapperFn>>,
     filename: Option<String>,
 }
 

--- a/plugins/window-state/src/lib.rs
+++ b/plugins/window-state/src/lib.rs
@@ -67,7 +67,7 @@ impl Default for StateFlags {
 
 struct PluginState {
     filename: String,
-    map_label: Option<Box<dyn LabelMapperFn>,
+    map_label: Option<Box<dyn LabelMapperFn>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]

--- a/plugins/window-state/src/lib.rs
+++ b/plugins/window-state/src/lib.rs
@@ -65,6 +65,7 @@ impl Default for StateFlags {
 
 struct PluginState {
     filename: String,
+    map_label: Option<Box<dyn (Fn(&str) -> &str) + Send + Sync>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -148,13 +149,20 @@ impl<R: Runtime> WindowExt for WebviewWindow<R> {
 }
 impl<R: Runtime> WindowExt for Window<R> {
     fn restore_state(&self, flags: StateFlags) -> tauri::Result<()> {
+        let plugin_state = self.app_handle().state::<PluginState>();
+        let label = plugin_state
+            .map_label
+            .as_ref()
+            .map(|map| map(self.label()))
+            .unwrap_or_else(|| self.label());
+
         let cache = self.state::<WindowStateCache>();
         let mut c = cache.0.lock().unwrap();
 
         let mut should_show = true;
 
         if let Some(state) = c
-            .get(self.label())
+            .get(label)
             .filter(|state| state != &&WindowState::default())
         {
             if flags.contains(StateFlags::DECORATIONS) {
@@ -235,7 +243,7 @@ impl<R: Runtime> WindowExt for Window<R> {
                 metadata.fullscreen = self.is_fullscreen()?;
             }
 
-            c.insert(self.label().into(), metadata);
+            c.insert(label.into(), metadata);
         }
 
         if flags.contains(StateFlags::VISIBLE) && should_show {
@@ -309,6 +317,7 @@ pub struct Builder {
     denylist: HashSet<String>,
     skip_initial_state: HashSet<String>,
     state_flags: StateFlags,
+    map_label: Option<Box<dyn (Fn(&str) -> &str) + Send + Sync>>,
     filename: Option<String>,
 }
 
@@ -342,9 +351,15 @@ impl Builder {
         self
     }
 
+    pub fn map_label(mut self, map_fn: fn(&str) -> &str) -> Self {
+        self.map_label = Some(Box::new(map_fn));
+        self
+    }
+
     pub fn build<R: Runtime>(self) -> TauriPlugin<R> {
         let flags = self.state_flags;
         let filename = self.filename.unwrap_or_else(|| DEFAULT_FILENAME.into());
+        let map_label = self.map_label;
 
         PluginBuilder::new("window-state")
             .invoke_handler(tauri::generate_handler![
@@ -372,21 +387,28 @@ impl Builder {
                         Default::default()
                     };
                 app.manage(WindowStateCache(cache));
-                app.manage(PluginState { filename });
+                app.manage(PluginState { filename, map_label });
                 Ok(())
             })
             .on_window_ready(move |window| {
-                if self.denylist.contains(window.label()) {
+                let plugin_state = window.app_handle().state::<PluginState>();
+                let label = plugin_state
+                    .map_label
+                    .as_ref()
+                    .map(|map| map(window.label()))
+                    .unwrap_or_else(|| window.label());
+
+                if self.denylist.contains(label) {
                     return;
                 }
 
-                if !self.skip_initial_state.contains(window.label()) {
+                if !self.skip_initial_state.contains(label) {
                     let _ = window.restore_state(self.state_flags);
                 }
 
                 let cache = window.state::<WindowStateCache>();
                 let cache = cache.0.clone();
-                let label = window.label().to_string();
+                let label = label.to_string();
                 let window_clone = window.clone();
                 let flags = self.state_flags;
 


### PR DESCRIPTION
This PR implements [amrbashir's suggestion](https://github.com/tauri-apps/plugins-workspace/pull/531#pullrequestreview-1566282300) made when reviewing [this other PR](https://github.com/tauri-apps/plugins-workspace/pull/531).

My use case is incredibly similar to that of the [author of that other PR](https://github.com/tauri-apps/plugins-workspace/issues/507#issuecomment-1644857633), as I'm also working on a comic reader app.

This is my first code PR to the project, so I probably did some mistakes.

This change is already being tested on my WIP app, as can be seen [here](https://github.com/ferreira-tb/kotori/blob/ab6fe9bd1f0d52e5a34d7047b09fda6235e5c241/src-tauri/src/main.rs#L36).