### PR TITLE
docs: use join in readDir documentation example

### DIFF
--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -641,6 +641,7 @@ interface DirEntry {
  * @example
  * ```typescript
  * import { readDir, BaseDirectory } from '@tauri-apps/plugin-fs';
+ * import { join } from '@tauri-apps/api/path';
  * const dir = "users"
  * const entries = await readDir('users', { baseDir: BaseDirectory.App });
  * processEntriesRecursive(dir, entries);
@@ -648,7 +649,7 @@ interface DirEntry {
  *   for (const entry of entries) {
  *     console.log(`Entry: ${entry.name}`);
  *     if (entry.isDirectory) {
- *        const dir = parent + entry.name;
+ *        const dir = await join(parent, entry.name);
  *       processEntriesRecursive(dir, await readDir(dir, { baseDir: BaseDirectory.App }))
  *     }
  *   }


### PR DESCRIPTION
parent + entry.name just mashes two names together without path delimiters. adding join() in makes the dir a proper path