### PR TITLE
fix(notification): Fix is-installed logic to prevent issue when a custom build.target-dir is set

### DIFF
--- a/.changes/fix-notification-install-detection.md
+++ b/.changes/fix-notification-install-detection.md
@@ -1,0 +1,5 @@
+---
+notification: patch
+---
+
+Fixed an issue that prevented notifications from showing up on Windows in dev mode when a custom `build.target-dir` was set.


### PR DESCRIPTION
The old logic failed because exe_dir was `A:\_target\debug` on my system.

I also tried to read to read the `shell:AppsFolder` folder to support more custom installers but couldn't figure out how to read a virtual folder.

Ideally i'd like to look into lifting the installation requirement but that seems to be a bit more work than this simple PR.