### PR TITLE
chore(deps): migrate `dirs-next` to `dirs` for updater plugin

### DIFF
--- a/.changes/updater-dirs.md
+++ b/.changes/updater-dirs.md
@@ -1,0 +1,5 @@
+---
+"updater": patch
+---
+
+Switch from `dirs_next` to `dirs` as `dirs_next` is now unmaintained while `dirs` is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6758,7 +6758,7 @@ name = "tauri-plugin-updater"
 version = "2.0.0-beta.8"
 dependencies = [
  "base64 0.22.1",
- "dirs-next",
+ "dirs 5.0.1",
  "flate2",
  "futures-util",
  "http",

--- a/plugins/updater/Cargo.toml
+++ b/plugins/updater/Cargo.toml
@@ -38,7 +38,7 @@ zip = { version = "2", default-features = false, optional = true }
 windows-sys = { version = "0.52.0", features = [ "Win32_Foundation", "Win32_UI_WindowsAndMessaging" ] }
 
 [target."cfg(target_os = \"linux\")".dependencies]
-dirs-next = "2"
+dirs = "5"
 tar = { version = "0.4", optional = true }
 flate2 = { version = "1", optional = true }
 

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -733,7 +733,7 @@ impl Update {
 
         let tmp_dir_locations = vec![
             Box::new(|| Some(std::env::temp_dir())) as Box<dyn FnOnce() -> Option<PathBuf>>,
-            Box::new(dirs_next::cache_dir),
+            Box::new(dirs::cache_dir),
             Box::new(|| Some(self.extract_path.parent().unwrap().to_path_buf())),
         ];
 


### PR DESCRIPTION
Follow up of https://github.com/tauri-apps/tauri/pull/9929

Looks like `iota_stronghold` used by stronghold plugin still uses `dirs-next`, probably needs upstream update if we want to avoid duplicated dependency there