### PR TITLE
change!(updater): disable zip feature by default

### DIFF
--- a/.changes/updater-zip-default-false.md
+++ b/.changes/updater-zip-default-false.md
@@ -1,0 +1,5 @@
+---
+"updater": "patch:breaking"
+---
+
+Disable zip feature by default, enable this if you need it to be able to use v1 compatible zipped updaters

--- a/plugins/updater/Cargo.toml
+++ b/plugins/updater/Cargo.toml
@@ -47,7 +47,7 @@ tar = "0.4"
 flate2 = "1"
 
 [features]
-default = [ "rustls-tls", "zip" ]
+default = [ "rustls-tls" ]
 zip = [ "dep:zip", "dep:tar", "dep:flate2" ]
 native-tls = [ "reqwest/native-tls" ]
 native-tls-vendored = [ "reqwest/native-tls-vendored" ]

--- a/plugins/updater/README.md
+++ b/plugins/updater/README.md
@@ -76,7 +76,7 @@ if (update?.available) {
 }
 ```
 
-Note: if you're migrating from v1 and are using `"bundler": { "createUpdaterArtifact": "v1Compatible" }` then you need to enable `zip` feature for it to be able to update from legacy v1 compatible zipped updaters
+Note: if you're migrating from v1 and are using `"bundle": { "createUpdaterArtifacts": "v1Compatible" }` then you need to enable `zip` feature for it to be able to update from legacy v1 compatible zipped updaters
 
 ## Contributing
 

--- a/plugins/updater/README.md
+++ b/plugins/updater/README.md
@@ -76,6 +76,8 @@ if (update?.available) {
 }
 ```
 
+Note: if you're migrating from v1 and are using `"bundler": { "createUpdaterArtifact": "v1Compatible" }` then you need to enable `zip` feature for it to be able to update from lagacy v1 compatible zipped updaters
+
 ## Contributing
 
 PRs accepted. Please make sure to read the Contributing Guide before making a pull request.

--- a/plugins/updater/README.md
+++ b/plugins/updater/README.md
@@ -76,7 +76,7 @@ if (update?.available) {
 }
 ```
 
-Note: if you're migrating from v1 and are using `"bundler": { "createUpdaterArtifact": "v1Compatible" }` then you need to enable `zip` feature for it to be able to update from lagacy v1 compatible zipped updaters
+Note: if you're migrating from v1 and are using `"bundler": { "createUpdaterArtifact": "v1Compatible" }` then you need to enable `zip` feature for it to be able to update from legacy v1 compatible zipped updaters
 
 ## Contributing
 


### PR DESCRIPTION
As we made a new option in tauri CLI in https://github.com/tauri-apps/tauri/pull/9883, I think we should remove zip from updater plugin's default features, and make people opt-in instead of opt-out