### PR TITLE
feat(biometrics): Improve Rust API docs

### DIFF
--- a/.changes/biometric-auth-options-docs.md
+++ b/.changes/biometric-auth-options-docs.md
@@ -1,0 +1,5 @@
+---
+"biometric": patch
+---
+
+Provide more context to the `AuthOptions` in the Biometric Plugin for Rust API documentation.

--- a/plugins/biometric/src/models.rs
+++ b/plugins/biometric/src/models.rs
@@ -7,16 +7,17 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthOptions {
+    /// Enables authentication using the device's password. This feature is available on both Android and iOS.
     pub allow_device_credential: bool,
-    /// iOS only.
-    pub fallback_title: Option<String>,
-    /// iOS only.
+    /// Label for the Cancel button. This feature is available on both Android and iOS.
     pub cancel_title: Option<String>,
-    /// Android only.
+    /// Specifies the text displayed on the fallback button if biometric authentication fails. This feature is available iOS only.
+    pub fallback_title: Option<String>,
+    /// Title indicating the purpose of biometric verification. This feature is available Android only.
     pub title: Option<String>,
-    /// Android only.
+    /// SubTitle providing contextual information of biometric verification. This feature is available Android only.
     pub subtitle: Option<String>,
-    /// Android only.
+    /// Specifies whether additional user confirmation is required, such as pressing a button after successful biometric authentication. This feature is available Android only.
     pub confirmation_required: Option<bool>,
 }
 


### PR DESCRIPTION
This PR provides more context to `AuthOptions` in the Biometrics Plugin