### PR TITLE
Fixing readme docs for v2

### DIFF
--- a/plugins/single-instance/README.md
+++ b/plugins/single-instance/README.md
@@ -42,8 +42,7 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
             println!("{}, {argv:?}, {cwd}", app.package_info().name);
-
-            app.emit_all("single-instance", Payload { args: argv, cwd }).unwrap();
+            app.emit("single-instance", Payload { args: argv, cwd }).unwrap();
         }))
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
Updating docs for Tauri v2. 

See migration guide:
https://v2.tauri.app/start/migrate/from-tauri-1/#event-system

`emit_all -> emit`