### PR TITLE
refactor: call self.is_maximized if and only if MAXIMIZE is set in StateFlags

### DIFF
--- a/.changes/fix-state.md
+++ b/.changes/fix-state.md
@@ -1,0 +1,5 @@
+---
+"window-state": patch
+---
+
+Modify the condition for calling `window.is_maximized()` in the `update_state` method, ensuring it's only called when the `MAXIMIZED` flag is set in `StateFlags`.

--- a/plugins/window-state/src/lib.rs
+++ b/plugins/window-state/src/lib.rs
@@ -232,7 +232,7 @@ trait WindowExtInternal {
 
 impl<R: Runtime> WindowExtInternal for Window<R> {
     fn update_state(&self, state: &mut WindowState, flags: StateFlags) -> tauri::Result<()> {
-        let is_maximized = match flags.intersects(StateFlags::MAXIMIZED | StateFlags::SIZE) {
+        let is_maximized = match flags.intersects(StateFlags::MAXIMIZED) {
             true => self.is_maximized()?,
             false => false,
         };


### PR DESCRIPTION
This PR refactors `update_state`  implementation to call `window.is_maximized` if and only if `MAXIMIZED` flag set in the `StateFlags`.

Please refer to this issue for further context:
https://github.com/tauri-apps/plugins-workspace/issues/1546