### PR TITLE
docs(sql): add `preload` config example for migrations

### DIFF
--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -158,7 +158,26 @@ fn main() {
 
 ### Applying Migrations
 
-Migrations are applied automatically when the plugin is initialized. The plugin runs these migrations against the database specified by the connection string. Ensure that the migrations are defined in the correct order and are idempotent (safe to run multiple times).
+To apply the migrations when the plugin is initialized, add the connection string to the `tauri.conf.json` file:
+
+```json
+{
+  "plugins": {
+    "sql": {
+      "preload": ["sqlite:mydatabase.db"]
+    }
+  }
+}
+```
+
+Alternatively, the client side `load()` also runs the migrations for a given connection string:
+
+```ts
+import Database from "@tauri-apps/plugin-sql";
+const db = await Database.load("sqlite:mydatabase.db");
+```
+
+Ensure that the migrations are defined in the correct order and are idempotent (safe to run multiple times).
 
 ### Migration Management
 

--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -177,7 +177,7 @@ import Database from "@tauri-apps/plugin-sql";
 const db = await Database.load("sqlite:mydatabase.db");
 ```
 
-Ensure that the migrations are defined in the correct order and are idempotent (safe to run multiple times).
+Ensure that the migrations are defined in the correct order and are safe to run multiple times.
 
 ### Migration Management
 


### PR DESCRIPTION
Adds missing `preload` configuration info for the sql plugin v2.

Closes #509.
Closes #1555.