### PR TITLE
[doc] update README for push notification plugin

### DIFF
--- a/plugins/notification/README.md
+++ b/plugins/notification/README.md
@@ -57,10 +57,40 @@ fn main() {
 }
 ```
 
+Then you need to add the permissions to your capabilities file:
+
+`src-tauri/capabilities/main.json`
+
+```json
+{
+  ...
+  "permissions": [
+    ...
+    "notification:default"
+  ],
+  ...
+}
+```
+
+
 Afterwards all the plugin's APIs are available through the JavaScript guest bindings:
 
 ```javascript
+import { isPermissionGranted, requestPermission, sendNotification } from '@tauri-apps/plugin-notification';
 
+async function checkPermission() {
+  if (!(await isPermissionGranted())) {
+    return (await requestPermission()) === 'granted';
+  }
+  return true;
+}
+
+export async function enqueueNotification(title, body) {
+  if (!(await checkPermission())) {
+    return;
+  }
+  sendNotification({ title, body });
+}
 ```
 
 ## Contributing


### PR DESCRIPTION
- There is no mention of needing to grant permission for the notification plugin in capabilities.

![スクリーンショット 2024-07-21 23 45 57](https://github.com/user-attachments/assets/a70463b8-afad-41ad-aaae-8116c22359ee)

```
Unhandled Promise Rejection: notification.is_permission_granted not allowed. Permissions associated with this command: notification:allow-is-permission-granted, notification:default
```

- The implementation example for JavaScript is empty.