### PR TITLE
ci: npm publish with provenance

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -9,7 +9,17 @@
           "url": "https://registry.npmjs.com/${ pkg.pkgFile.pkg.name }/${ pkg.pkgFile.version }"
         }
       },
-      "publish": ["pnpm build", "pnpm publish --access public --no-git-checks"]
+      "publish": [
+        {
+          "command": "pnpm build",
+          "dryRunCommand": "pnpm build"
+        },
+        {
+          "command": "npm publish --provenance --access public",
+          "dryRunCommand": "npm publish --provenance --access public --dry-run",
+          "pipe": true
+        }
+      ]
     },
     "rust": {
       "version": true,

--- a/.github/workflows/covector-version-or-publish-v2.yml
+++ b/.github/workflows/covector-version-or-publish-v2.yml
@@ -9,6 +9,14 @@ on:
     branches:
       - v2
 
+permissions:
+  # required for npm provenance
+  id-token: write
+  # required to create the GitHub Release
+  contents: write
+  # required for creating the Version Packages Release
+  pull-requests: write
+
 jobs:
   version-or-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -9,6 +9,14 @@ on:
     branches:
       - v1
 
+permissions:
+  # required for npm provenance
+  id-token: write
+  # required to create the GitHub Release
+  contents: write
+  # required for creating the Version Packages Release
+  pull-requests: write
+
 jobs:
   version-or-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

We want to [publish our plugins with provenance](https://docs.npmjs.com/generating-provenance-statements).

/cc @tweidinger @nothingismagick as I think you both will appreciate this.

## Approach

It doesn't appear that `pnpm` has an option for publishing with provenance, but `npm` should be safe for this specific use case.
