### PR TITLE
feat(dialog, fs): Save file on android

### DIFF
--- a/plugins/dialog/android/src/main/java/DialogPlugin.kt
+++ b/plugins/dialog/android/src/main/java/DialogPlugin.kt
@@ -41,6 +41,11 @@ class MessageOptions {
   var cancelButtonLabel: String? = null
 }
 
+@InvokeArg
+class SaveFileDialogOptions {
+  var title: String = ""
+}
+
 @TauriPlugin
 class DialogPlugin(private val activity: Activity): Plugin(activity) {
   var filePickerOptions: FilePickerOptions? = null
@@ -203,5 +208,47 @@ class DialogPlugin(private val activity: Activity): Plugin(activity) {
         val dialog = builder.create()
         dialog.show()
       }
+  }
+
+  @Command
+  fun saveFileDialog(invoke: Invoke) {
+    try {
+      val args = invoke.parseArgs(SaveFileDialogOptions::class.java)
+
+      val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
+      intent.addCategory(Intent.CATEGORY_OPENABLE)
+      intent.setType("text/plain")
+      intent.putExtra(Intent.EXTRA_TITLE, args.title)
+      startActivityForResult(invoke, intent, "saveFileDialogResult")
+    } catch (ex: Exception) {
+      val message = ex.message ?: "Failed to pick save file"
+      Logger.error(message)
+      invoke.reject(message)
+    }
+  }
+
+  @ActivityCallback
+  fun saveFileDialogResult(invoke: Invoke, result: ActivityResult) {
+    try {
+      when (result.resultCode) {
+        Activity.RESULT_OK -> {
+          val callResult = JSObject()
+          val intent: Intent? = result.data
+          if (intent != null) {
+            val uri = intent.getData()
+            if (uri != null) {
+              callResult.put("file", uri.toString())
+            }
+          }
+          invoke.resolve(callResult)
+        }
+        Activity.RESULT_CANCELED -> invoke.reject("File picker cancelled")
+        else -> invoke.reject("Failed to pick files")
+      }
+    } catch (ex: java.lang.Exception) {
+      val message = ex.message ?: "Failed to read file pick result"
+      Logger.error(message)
+      invoke.reject(message)
+    }
   }
 }

--- a/plugins/dialog/src/commands.rs
+++ b/plugins/dialog/src/commands.rs
@@ -193,9 +193,9 @@ pub(crate) async fn save<R: Runtime>(
     dialog: State<'_, Dialog<R>>,
     options: SaveDialogOptions,
 ) -> Result<Option<PathBuf>> {
-    #[cfg(mobile)]
+    #[cfg(any(target_os = "ios"))]
     return Err(crate::Error::FileSaveDialogNotImplemented);
-    #[cfg(desktop)]
+    #[cfg(any(desktop, target_os = "android"))]
     {
         let mut dialog_builder = dialog.file();
         #[cfg(any(windows, target_os = "macos"))]

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -576,7 +576,6 @@ impl<R: Runtime> FileDialogBuilder<R> {
     pub fn blocking_save_file(self) -> Option<PathBuf> {
         blocking_fn!(self, save_file)
     }
-
 }
 
 // taken from deno source code: https://github.com/denoland/deno/blob/ffffa2f7c44bd26aec5ae1957e0534487d099f48/runtime/ops/fs.rs#L913

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -17,8 +17,10 @@ use tauri::{
     Manager, Runtime,
 };
 
+#[cfg(any(desktop, target_os = "ios"))]
+use std::fs;
+
 use std::{
-    fs,
     path::{Path, PathBuf},
     sync::mpsc::sync_channel,
 };
@@ -471,7 +473,6 @@ impl<R: Runtime> FileDialogBuilder<R> {
     ///     })
     ///   })
     /// ```
-    #[cfg(desktop)]
     pub fn save_file<F: FnOnce(Option<PathBuf>) + Send + 'static>(self, f: F) {
         save_file(self, f)
     }
@@ -572,14 +573,15 @@ impl<R: Runtime> FileDialogBuilder<R> {
     ///   // the file path is `None` if the user closed the dialog
     /// }
     /// ```
-    #[cfg(desktop)]
     pub fn blocking_save_file(self) -> Option<PathBuf> {
         blocking_fn!(self, save_file)
     }
+
 }
 
 // taken from deno source code: https://github.com/denoland/deno/blob/ffffa2f7c44bd26aec5ae1957e0534487d099f48/runtime/ops/fs.rs#L913
 #[inline]
+#[allow(unused)]
 fn to_msec(maybe_time: std::result::Result<std::time::SystemTime, std::io::Error>) -> Option<u64> {
     match maybe_time {
         Ok(time) => {

--- a/plugins/dialog/src/mobile.rs
+++ b/plugins/dialog/src/mobile.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2023 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
+use std::path::PathBuf;
 
 use serde::{de::DeserializeOwned, Deserialize};
 use tauri::{
@@ -49,6 +50,11 @@ struct FilePickerResponse {
     files: Vec<FileResponse>,
 }
 
+#[derive(Debug, Deserialize)]
+struct SaveFileResponse {
+    file: PathBuf,
+}
+
 pub fn pick_file<R: Runtime, F: FnOnce(Option<FileResponse>) + Send + 'static>(
     dialog: FileDialogBuilder<R>,
     f: F,
@@ -77,6 +83,23 @@ pub fn pick_files<R: Runtime, F: FnOnce(Option<Vec<FileResponse>>) + Send + 'sta
             .run_mobile_plugin::<FilePickerResponse>("showFilePicker", dialog.payload(true));
         if let Ok(response) = res {
             f(Some(response.files))
+        } else {
+            f(None)
+        }
+    });
+}
+
+pub fn save_file<R: Runtime, F: FnOnce(Option<PathBuf>) + Send + 'static>(
+    dialog: FileDialogBuilder<R>,
+    f: F,
+) {
+    std::thread::spawn(move || {
+        let res = dialog
+            .dialog
+            .0
+            .run_mobile_plugin::<SaveFileResponse>("saveFileDialog", dialog.payload(true));
+        if let Ok(response) = res {
+            f(Some(response.file))
         } else {
             f(None)
         }

--- a/plugins/fs/android/.gitignore
+++ b/plugins/fs/android/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.tauri

--- a/plugins/fs/android/build.gradle.kts
+++ b/plugins/fs/android/build.gradle.kts
@@ -1,0 +1,45 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.plugin.fs"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 21
+        targetSdk = 34
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+
+    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.appcompat:appcompat:1.6.0")
+    implementation("com.google.android.material:material:1.7.0")
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    implementation(project(":tauri-android"))
+}

--- a/plugins/fs/android/proguard-rules.pro
+++ b/plugins/fs/android/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/plugins/fs/android/settings.gradle
+++ b/plugins/fs/android/settings.gradle
@@ -1,0 +1,31 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        google()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            switch (requested.id.id) {
+                case "com.android.library":
+                    useVersion("8.0.2")
+                    break
+                case "org.jetbrains.kotlin.android":
+                    useVersion("1.8.20")
+                    break
+            }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        google()
+
+    }
+}
+
+include ':tauri-android'
+project(':tauri-android').projectDir = new File('./.tauri/tauri-api')

--- a/plugins/fs/android/src/androidTest/java/ExampleInstrumentedTest.kt
+++ b/plugins/fs/android/src/androidTest/java/ExampleInstrumentedTest.kt
@@ -1,0 +1,24 @@
+package com.plugin.fs
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.junit.Assert.*
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class ExampleInstrumentedTest {
+    @Test
+    fun useAppContext() {
+        // Context of the app under test.
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        assertEquals("com.plugin.fs", appContext.packageName)
+    }
+}

--- a/plugins/fs/android/src/main/AndroidManifest.xml
+++ b/plugins/fs/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/plugins/fs/android/src/main/java/FsPlugin.kt
+++ b/plugins/fs/android/src/main/java/FsPlugin.kt
@@ -1,0 +1,39 @@
+package com.plugin.fs
+
+import android.app.Activity
+import android.net.Uri
+import android.util.Log
+import app.tauri.annotation.Command
+import app.tauri.annotation.InvokeArg
+import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.JSObject
+import app.tauri.plugin.Plugin
+import app.tauri.plugin.Invoke
+
+@InvokeArg
+class WriteTextFileArgs {
+  val uri: String = ""
+  val content: String = ""
+}
+
+@TauriPlugin
+class FsPlugin(private val activity: Activity): Plugin(activity) {
+    @Command
+    fun writeTextFile(invoke: Invoke) {
+        val args = invoke.parseArgs(WriteTextFileArgs::class.java)
+        val uri = Uri.parse(args.uri)
+        val content = args.content
+
+        if(uri != null){
+          activity.getContentResolver().openOutputStream(uri).use { ost ->
+            if(ost != null && content != null){
+              ost.write(content.toByteArray());
+            }
+          }
+        }
+
+        val ret = JSObject()
+        invoke.resolve(ret)
+    }
+}
+

--- a/plugins/fs/android/src/test/java/ExampleUnitTest.kt
+++ b/plugins/fs/android/src/test/java/ExampleUnitTest.kt
@@ -1,0 +1,17 @@
+package com.plugin.fs
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+class ExampleUnitTest {
+    @Test
+    fun addition_isCorrect() {
+        assertEquals(4, 2 + 2)
+    }
+}

--- a/plugins/fs/build.rs
+++ b/plugins/fs/build.rs
@@ -190,5 +190,6 @@ permissions = [
     tauri_plugin::Builder::new(COMMANDS)
         .global_api_script_path("./api-iife.js")
         .global_scope_schema(schemars::schema_for!(FsScopeEntry))
+        .android_path("android")
         .build();
 }

--- a/plugins/fs/src/mobile.rs
+++ b/plugins/fs/src/mobile.rs
@@ -1,0 +1,58 @@
+use serde::de::DeserializeOwned;
+use tauri::{
+  plugin::{PluginApi, PluginHandle},
+  AppHandle, Runtime,
+};
+
+#[cfg(target_os = "android")]
+use crate::models::{WriteTextFilePayload, WriteTextFileResponse};
+
+#[cfg(target_os = "android")]
+use crate::Error::Tauri;
+
+#[cfg(target_os = "android")]
+const PLUGIN_IDENTIFIER: &str = "com.plugin.fs";
+
+#[cfg(target_os = "ios")]
+tauri::ios_plugin_binding!(init_plugin_fs);
+
+// initializes the Kotlin or Swift plugin classes
+pub fn init<R: Runtime, C: DeserializeOwned>(
+  _app: &AppHandle<R>,
+  api: PluginApi<R, C>,
+) -> crate::Result<Fs<R>> {
+  #[cfg(target_os = "android")]
+  let handle = api.register_android_plugin(PLUGIN_IDENTIFIER, "FsPlugin").unwrap();
+  #[cfg(target_os = "ios")]
+  let handle = api.register_ios_plugin(init_plugin_android-intent-send)?;
+  Ok(Fs(handle))
+}
+
+/// Access to the android-intent-send APIs.
+pub struct Fs<R: Runtime>(PluginHandle<R>);
+
+impl<R: Runtime> Fs<R> {
+    pub fn write_text_file(&self, payload: WriteTextFilePayload) -> crate::Result<WriteTextFileResponse> {
+        #[cfg(target_os = "android")]
+        {
+            let result = self
+                .0
+                .run_mobile_plugin::<WriteTextFileResponse>("writeTextFile", payload);
+            match result {
+                Ok(_) => Ok(WriteTextFileResponse{error: None}),
+                Err(_) => Err(Tauri(tauri::Error::InvokeKey)),
+            }
+        }
+        #[cfg(any(desktop, target_os = "ios"))]
+        {
+            write_file_inner(
+                webview,
+                &global_scope,
+                &command_scope,
+                path,
+                data.as_bytes(),
+                options,
+            )
+        }
+    }
+}

--- a/plugins/fs/src/models.rs
+++ b/plugins/fs/src/models.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WriteTextFilePayload {
+    pub uri: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WriteTextFileResponse {
+    pub error: Option<String>,
+}
+


### PR DESCRIPTION
This is part of #1494. (Implementation of save dialog and save text file for Android)

I implemented the save dialog for the dialog plugin and save_text_file for the fs plugin.

As mentioned in the following two comments, saving files on Android requires the use of `activity.getContentResolver().openOutputStream(uri)`, so I use Uri instead of file path in the communication between the app and the plugin.

Also, since the fs plugin requires the use of `activity.getContentResolver().openOutputStream(uri)`, I've added an Android implementation to the fs plugin.

- https://github.com/tauri-apps/plugins-workspace/issues/1494#issuecomment-2248352810
- https://github.com/tauri-apps/plugins-workspace/issues/1494#issuecomment-2250623258

![tauri-plugin-dialog-android_002](https://github.com/user-attachments/assets/361e5820-aab6-4be6-9024-ce5232e97704)
