### PR TITLE
[log] Fix typo in docs of lib.rs

### DIFF
--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -180,7 +180,7 @@ pub enum TargetKind {
         path: PathBuf,
         file_name: Option<String>,
     },
-    /// Write logs to the OS specififc logs directory.
+    /// Write logs to the OS specific logs directory.
     ///
     /// ### Platform-specific
     ///


### PR DESCRIPTION
Fixed typo in docs of lib.rs of log plugin

https://github.com/tauri-apps/plugins-workspace/blob/279698700a12a2293b6fc18358601afef7e63f9a/plugins/log/src/lib.rs#L183

Btw, the table underneath also doesn't show the correct example values.

https://github.com/tauri-apps/plugins-workspace/blob/279698700a12a2293b6fc18358601afef7e63f9a/plugins/log/src/lib.rs#L187-L191

I tried it and mine on windows went into (example value style) `C:\Users\Alice\AppData\Local\{bundleIdentifier}\logs` instead of the `C:\Users\Alice\AppData\Roaming\{bundleIdentifier}` like the example value shows.

The table says that the value is `{configDir}/{bundleIdentifier}`, but the code that actually gets the path uses `app_handle.path().app_log_dir()?`

Source:
https://github.com/tauri-apps/plugins-workspace/blob/279698700a12a2293b6fc18358601afef7e63f9a/plugins/log/src/lib.rs#L466C32-L466C64

I do not know what should be the correct text in the table, so my PR is open for edits from maintainers.
*Or please suggest what it should be and I will add another commit.*


P.s. when I was editing it didn't really seem to have worked, so that is why the first commit has changed nothing. Please if possible just do a squash merge...