### PR TITLE
refactor(android): Remove targetSdk = 34 from every gradle build files

### DIFF
--- a/.changes/remove-target-sdk.md
+++ b/.changes/remove-target-sdk.md
@@ -1,0 +1,15 @@
+---
+"barcode-scanner": rc
+"biometric": rc
+"clipboard-manager": rc
+"deep-link": rc
+"dialog": rc
+"geolocation": rc
+"haptics": rc
+"nfc": rc
+"notification": rc
+"shell": rc
+"store": rc
+---
+
+Remove targetSdk from build.kts files as it is deprecated and will be removed from DSL v9.0

--- a/.changes/remove-target-sdk.md
+++ b/.changes/remove-target-sdk.md
@@ -1,5 +1,5 @@
 ---
-"bapatchode-scanner": patch:changes
+"barcode-scanner": patch:changes
 "biometric": patch:changes
 "clipboard-manager": patch:changes
 "deep-link": patch:changes
@@ -10,6 +10,17 @@
 "notification": patch:changes
 "shell": patch:changes
 "store": patch:changes
+"barcode-scanner-js": patch:changes
+"biometric-js": patch:changes
+"clipboard-manager-js": patch:changes
+"deep-link-js": patch:changes
+"dialog-js": patch:changes
+"geolocation-js": patch:changes
+"haptics-js": patch:changes
+"nfc-js": patch:changes
+"notification-js": patch:changes
+"shell-js": patch:changes
+"store-js": patch:changes
 ---
 
 Remove targetSdk from build.kts files as it is deprecated and will be removed from DSL v9.0

--- a/.changes/remove-target-sdk.md
+++ b/.changes/remove-target-sdk.md
@@ -1,15 +1,15 @@
 ---
-"barcode-scanner": rc
-"biometric": rc
-"clipboard-manager": rc
-"deep-link": rc
-"dialog": rc
-"geolocation": rc
-"haptics": rc
-"nfc": rc
-"notification": rc
-"shell": rc
-"store": rc
+"bapatchode-scanner": patch:changes
+"biometric": patch:changes
+"clipboard-manager": patch:changes
+"deep-link": patch:changes
+"dialog": patch:changes
+"geolocation": patch:changes
+"haptics": patch:changes
+"nfc": patch:changes
+"notification": patch:changes
+"shell": patch:changes
+"store": patch:changes
 ---
 
 Remove targetSdk from build.kts files as it is deprecated and will be removed from DSL v9.0

--- a/.changes/remove-target-sdk.md
+++ b/.changes/remove-target-sdk.md
@@ -10,17 +10,6 @@
 "notification": patch:changes
 "shell": patch:changes
 "store": patch:changes
-"barcode-scanner-js": patch:changes
-"biometric-js": patch:changes
-"clipboard-manager-js": patch:changes
-"deep-link-js": patch:changes
-"dialog-js": patch:changes
-"geolocation-js": patch:changes
-"haptics-js": patch:changes
-"nfc-js": patch:changes
-"notification-js": patch:changes
-"shell-js": patch:changes
-"store-js": patch:changes
 ---
 
 Remove targetSdk from build.kts files as it is deprecated and will be removed from DSL v9.0

--- a/examples/api/src-tauri/gen/android/app/build.gradle.kts
+++ b/examples/api/src-tauri/gen/android/app/build.gradle.kts
@@ -19,8 +19,7 @@ android {
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
         applicationId = "com.tauri.api"
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")
     }

--- a/plugins/barcode-scanner/android/build.gradle.kts
+++ b/plugins/barcode-scanner/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/biometric/android/build.gradle.kts
+++ b/plugins/biometric/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/clipboard-manager/android/build.gradle.kts
+++ b/plugins/clipboard-manager/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/deep-link/android/build.gradle.kts
+++ b/plugins/deep-link/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/deep-link/examples/app/src-tauri/gen/android/app/build.gradle.kts
+++ b/plugins/deep-link/examples/app/src-tauri/gen/android/app/build.gradle.kts
@@ -10,8 +10,7 @@ android {
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
         applicationId = "com.tauri.deep_link_example"
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
         versionCode = 1
         versionName = "1.0"
     }

--- a/plugins/dialog/android/build.gradle.kts
+++ b/plugins/dialog/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/geolocation/android/build.gradle.kts
+++ b/plugins/geolocation/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/haptics/android/build.gradle.kts
+++ b/plugins/haptics/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/nfc/android/build.gradle.kts
+++ b/plugins/nfc/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/notification/android/build.gradle.kts
+++ b/plugins/notification/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/shell/android/build.gradle.kts
+++ b/plugins/shell/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/store/android/build.gradle.kts
+++ b/plugins/store/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/shared/template/android/build.gradle.kts
+++ b/shared/template/android/build.gradle.kts
@@ -8,8 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
-        targetSdk = 34
+        minSdk = 24        
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
This PR aims to fix the following warning
```
w: file:///C:/Users/Windows/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-2.0.0-rc.2/mobile/android/build.gradle.kts:12:9: 'targetSdk: Int?' is deprecated. Will be removed from library DSL in v9.0. Use testOptions.targetSdk or/and lint.targetSdk instead
```

It removes targetSdk from the gradle kts files as it is deprecated and will be removed in DSL v9.0