### PR TITLE
refacator(dialog): mark `FileResponse` as `#[non_exhaustive]`

### DIFF
--- a/.changes/dialog-file-response-non-exhaustive.md
+++ b/.changes/dialog-file-response-non-exhaustive.md
@@ -1,0 +1,5 @@
+---
+"dialog": "patch"
+---
+
+Mark `FileResponse` as `non_exhaustive`.

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -218,6 +218,7 @@ impl<R: Runtime> MessageDialogBuilder<R> {
 
 #[derive(Debug, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct FileResponse {
     pub base64_data: Option<String>,
     pub duration: Option<u64>,


### PR DESCRIPTION
closes #1623