### PR TITLE
Update import package name to V2

### DIFF
--- a/plugins/store/README.md
+++ b/plugins/store/README.md
@@ -60,7 +60,7 @@ fn main() {
 Afterwards all the plugin's APIs are available through the JavaScript guest bindings:
 
 ```typescript
-import { Store } from "tauri-plugin-store-api";
+import { Store } from "@tauri-apps/plugin-store";
 
 const store = new Store(".settings.dat");
 


### PR DESCRIPTION
V2 docs still referenced V1 npm package name.

Original PR [here](https://github.com/tauri-apps/tauri-plugin-store/pull/143).