### PR TITLE
fix(http): remove unexpectedly changing origin header when unsafe-headers feature enabled

### DIFF
--- a/plugins/http/src/commands.rs
+++ b/plugins/http/src/commands.rs
@@ -254,15 +254,6 @@ pub async fn fetch<R: Runtime>(
                     request = request.header(header::USER_AGENT, HTTP_USER_AGENT);
                 }
 
-                if cfg!(feature = "unsafe-headers")
-                    && !headers.contains_key(header::ORIGIN.as_str())
-                {
-                    if let Ok(url) = webview.url() {
-                        request =
-                            request.header(header::ORIGIN, url.origin().ascii_serialization());
-                    }
-                }
-
                 if let Some(data) = data {
                     request = request.body(data);
                 }


### PR DESCRIPTION
When you use the unsafe-headers feature flag, the website displays CORS-related errors, because when you turn on the unsafe-headers feature flag, tauri automatically set the Origin header to localhost.
This is very confusing, and it is impossible to debug unless you look at the source code.
It will have to be up to developer to set up Origin header value not tauri.
And it doesn't even fit the name "unsafe-headers".

In the first place, why tauri filter the headers by the unsafe-headers feature?
When I first used plugin-http, I had a hard time because a specific header was not recognized by tauri.
May I know why this feature was introduced?
If it's a security issue, it should be fully explained in documentation.