### PR TITLE
fix(fs): can't use Windows path

### DIFF
--- a/.changes/fs-windows-path.md
+++ b/.changes/fs-windows-path.md
@@ -1,0 +1,5 @@
+---
+"fs": patch
+---
+
+Fix can't use Windows paths like `C:/Users/UserName/file.txt`

--- a/plugins/fs/src/commands.rs
+++ b/plugins/fs/src/commands.rs
@@ -1202,10 +1202,10 @@ fn get_stat(metadata: std::fs::Metadata) -> FileInfo {
 }
 
 mod test {
-    use super::*;
-
     #[test]
     fn safe_file_path_parse() {
+        use super::SafeFilePath;
+
         assert!(matches!(
             serde_json::from_str::<SafeFilePath>("\"C:/Users\""),
             Ok(SafeFilePath::Path(_))

--- a/plugins/fs/src/commands.rs
+++ b/plugins/fs/src/commands.rs
@@ -1205,24 +1205,14 @@ mod test {
     use super::*;
 
     #[test]
-    fn windows_path() {
-        assert_eq!(
-            matches!(
-                serde_json::from_str::<SafeFilePath>("\"C:/Users\""),
-                Ok(SafeFilePath::Path(_))
-            ),
-            true
-        );
-    }
-
-    #[test]
-    fn url() {
-        assert_eq!(
-            matches!(
-                serde_json::from_str::<SafeFilePath>("\"file:///C:/Users\""),
-                Ok(SafeFilePath::Url(_))
-            ),
-            true
-        );
+    fn safe_file_path_parse() {
+        assert!(matches!(
+            serde_json::from_str::<SafeFilePath>("\"C:/Users\""),
+            Ok(SafeFilePath::Path(_))
+        ));
+        assert!(matches!(
+            serde_json::from_str::<SafeFilePath>("\"file:///C:/Users\""),
+            Ok(SafeFilePath::Url(_))
+        ));
     }
 }

--- a/plugins/fs/src/commands.rs
+++ b/plugins/fs/src/commands.rs
@@ -23,6 +23,7 @@ use std::{
 
 use crate::{scope::Entry, Error, FilePath, FsExt};
 
+// TODO: Combine this with FilePath
 #[derive(Debug)]
 pub enum SafeFilePath {
     Url(url::Url),
@@ -1197,5 +1198,31 @@ fn get_stat(metadata: std::fs::Metadata) -> FileInfo {
         rdev: usm!(rdev),
         blksize: usm!(blksize),
         blocks: usm!(blocks),
+    }
+}
+
+mod test {
+    use super::*;
+
+    #[test]
+    fn windows_path() {
+        assert_eq!(
+            matches!(
+                serde_json::from_str::<SafeFilePath>("\"C:/Users\""),
+                Ok(SafeFilePath::Path(_))
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn url() {
+        assert_eq!(
+            matches!(
+                serde_json::from_str::<SafeFilePath>("\"file:///C:/Users\""),
+                Ok(SafeFilePath::Url(_))
+            ),
+            true
+        );
     }
 }

--- a/plugins/fs/src/lib.rs
+++ b/plugins/fs/src/lib.rs
@@ -50,6 +50,7 @@ pub use scope::{Event as ScopeEvent, Scope};
 
 type Result<T> = std::result::Result<T, Error>;
 
+// TODO: Combine this with SafeFilePath
 /// Represents either a filesystem path or a URI pointing to a file
 /// such as `file://` URIs or Android `content://` URIs.
 #[derive(Debug)]

--- a/plugins/fs/src/lib.rs
+++ b/plugins/fs/src/lib.rs
@@ -63,9 +63,9 @@ impl<'de> serde::Deserialize<'de> for FilePath {
     where
         D: serde::Deserializer<'de>,
     {
-        struct SafeFilePathVisitor;
+        struct FilePathVisitor;
 
-        impl<'de> serde::de::Visitor<'de> for SafeFilePathVisitor {
+        impl<'de> serde::de::Visitor<'de> for FilePathVisitor {
             type Value = FilePath;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -85,7 +85,7 @@ impl<'de> serde::Deserialize<'de> for FilePath {
             }
         }
 
-        deserializer.deserialize_str(SafeFilePathVisitor)
+        deserializer.deserialize_str(FilePathVisitor)
     }
 }
 


### PR DESCRIPTION
Url deserializes Windows drive letter to url scheme which is not what we wanted, since we don't use single letter schemes anyways, we can just assume a single letter scheme url to be a path not a url

Fix #1704