### PR TITLE
chore(barcode): remove unused Android dependencies

### DIFF
--- a/.changes/barcode-dependencies.md
+++ b/.changes/barcode-dependencies.md
@@ -1,0 +1,5 @@
+---
+"barcode-scanner": patch
+---
+
+Remove unused Android dependencies.

--- a/plugins/barcode-scanner/android/build.gradle.kts
+++ b/plugins/barcode-scanner/android/build.gradle.kts
@@ -47,9 +47,5 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    implementation("com.journeyapps:zxing-android-embedded:4.3.0") {
-        isTransitive = false
-    }
-    implementation("com.google.zxing:core:3.3.0")
     implementation(project(":tauri-android"))
 }

--- a/plugins/barcode-scanner/android/src/main/AndroidManifest.xml
+++ b/plugins/barcode-scanner/android/src/main/AndroidManifest.xml
@@ -2,10 +2,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:hardwareAccelerated="true">
 
-    <!-- Paste the following line into the AndroidManifest.xml of your project -->
-    <!-- See also: https://capacitorjs.com/docs/plugins/android#manifest -->
-    <!-- <uses-feature android:name="android.hardware.camera" android:required="false" /> -->
-
-    <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
+    <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.VIBRATE" />
+
+    <uses-feature android:name="android.hardware.camera.any"/>
 </manifest>

--- a/plugins/barcode-scanner/android/src/main/java/BarcodeScannerPlugin.kt
+++ b/plugins/barcode-scanner/android/src/main/java/BarcodeScannerPlugin.kt
@@ -42,7 +42,6 @@ import app.tauri.annotation.Permission
 import app.tauri.annotation.PermissionCallback
 import app.tauri.annotation.TauriPlugin
 import app.tauri.plugin.Invoke
-import app.tauri.plugin.JSArray
 import app.tauri.plugin.JSObject
 import app.tauri.plugin.Plugin
 import com.google.common.util.concurrent.ListenableFuture
@@ -50,7 +49,6 @@ import com.google.mlkit.vision.barcode.BarcodeScannerOptions
 import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.common.InputImage
-import org.json.JSONException
 import java.util.Collections
 import java.util.concurrent.ExecutionException
 

--- a/plugins/nfc/android/src/main/AndroidManifest.xml
+++ b/plugins/nfc/android/src/main/AndroidManifest.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.NFC" />
-    <!-- TODO: if the app doesn't rely on nfc the uses-feature line could be removed. The app store uses this prop to decide whether or not to show the app. -->
-    <!-- TODO: Move that info somewhere else since users usually can't see this file. -->
-    <!-- Paste the following line into the AndroidManifest.xml of your project -->
-    <!-- See also: https://capacitorjs.com/docs/plugins/android#manifest -->
-    <!-- <uses-feature android:name="android.hardware.nfc" android:required="true" /> -->
 </manifest>


### PR DESCRIPTION
Plugin barcode-scanner has two unused Android dependencies:
- `com.google.zxing:core`
- `com.journeyapps:zxing-android-embedded`

However, these dependency's `AndroidManifest.xml` were merged, and contained required parameters (to get camera's permissions).

See the merged manifests:
- https://github.com/zxing/zxing/blob/zxing-3.3.0/android/AndroidManifest.xml
- https://github.com/journeyapps/zxing-android-embedded/blob/v4.3.0/zxing-android-embedded/AndroidManifest.xml

This commit removes the unused dependencies (and unused Java imports) and updates the Android manifest.