### PR TITLE
feat(barcode-scanner): validate missing Info.plist configuration

### DIFF
--- a/.changes/barcode-scanner-validate-plist.md
+++ b/.changes/barcode-scanner-validate-plist.md
@@ -1,0 +1,5 @@
+---
+"barcode-scanner": patch
+---
+
+Validate missing `NSCameraUsageDescription` Info.plist value.

--- a/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
+++ b/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
@@ -262,6 +262,13 @@ class BarcodeScannerPlugin: Plugin, AVCaptureMetadataOutputObjectsDelegate {
 
     self.invoke = invoke
 
+    let entry = Bundle.main.infoDictionary?["NSCameraUsageDescription"] as? String
+
+    if entry == nil || entry?.count == 0 {
+      invoke.reject("NSCameraUsageDescription is not in the app Info.plist")
+      return
+    }
+
     var iOS14min: Bool = false
     if #available(iOS 14.0, *) { iOS14min = true }
     if !iOS14min && self.getPermissionState() != "granted" {


### PR DESCRIPTION
When the `NSCameraUsageDescription` value is missing, the app crashes with an error message from Apple; let's add our own validation similar to how the NFC and Biometric plugin works