### PR TITLE
feat(deep-link): implement getCurrent on Windows/Linux

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -268,7 +268,8 @@
     },
     "single-instance": {
       "path": "./plugins/single-instance",
-      "manager": "rust"
+      "manager": "rust",
+      "dependencies": ["deep-link"]
     },
     "sql": {
       "path": "./plugins/sql",

--- a/.changes/deep-link-get-current-desktop.md
+++ b/.changes/deep-link-get-current-desktop.md
@@ -1,0 +1,5 @@
+---
+"deep-link": patch
+---
+
+Implement `get_current` on Linux and Windows.

--- a/.changes/deep-link-register-all.md
+++ b/.changes/deep-link-register-all.md
@@ -1,0 +1,5 @@
+---
+"deep-link": patch
+---
+
+Added `register_all` to register all desktop schemes - useful for Linux to not require a formal AppImage installation.

--- a/.changes/single-instance-deep-link.md
+++ b/.changes/single-instance-deep-link.md
@@ -1,0 +1,5 @@
+---
+"single-instance": patch
+---
+
+Integrate with the deep link plugin out of the box.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-deep-link",
  "tauri-plugin-log",
+ "tauri-plugin-single-instance",
 ]
 
 [[package]]
@@ -6754,6 +6755,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tauri-plugin-deep-link",
  "thiserror",
  "windows-sys 0.59.0",
  "zbus",

--- a/plugins/deep-link/examples/app/.gitignore
+++ b/plugins/deep-link/examples/app/.gitignore
@@ -21,3 +21,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+dist/

--- a/plugins/deep-link/examples/app/src-tauri/Cargo.toml
+++ b/plugins/deep-link/examples/app/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = { workspace = true }
 tauri = { workspace = true, features = ["wry", "compression"] }
 tauri-plugin-deep-link = { path = "../../../" }
 tauri-plugin-log = { path = "../../../../log" }
+tauri-plugin-single-instance = { path = "../../../../single-instance" }
 log = "0.4"
 
 [features]

--- a/plugins/deep-link/examples/app/src-tauri/src/lib.rs
+++ b/plugins/deep-link/examples/app/src-tauri/src/lib.rs
@@ -30,22 +30,7 @@ pub fn run() {
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
 
-                let schemes = app
-                    .config()
-                    .plugins
-                    .0
-                    .get("deep-link")
-                    .unwrap()
-                    .get("desktop")
-                    .unwrap()
-                    .get("schemes")
-                    .unwrap()
-                    .as_array()
-                    .unwrap();
-
-                for scheme in schemes {
-                    app.deep_link().register(scheme.as_str().unwrap())?;
-                }
+                app.deep_link().register_all()?;
             }
 
             app.listen("deep-link://new-url", |url| {

--- a/plugins/deep-link/examples/app/src-tauri/src/lib.rs
+++ b/plugins/deep-link/examples/app/src-tauri/src/lib.rs
@@ -13,6 +13,9 @@ fn greet(name: &str) -> String {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|_app, argv, _cwd| {
+            println!("single instance triggered: {argv:?}");
+        }))
         .plugin(tauri_plugin_deep_link::init())
         .plugin(
             tauri_plugin_log::Builder::default()
@@ -20,6 +23,31 @@ pub fn run() {
                 .build(),
         )
         .setup(|app| {
+            // ensure deep links are registered on the system
+            // this is useful because AppImages requires additional setup to be available in the system
+            // and calling register() makes the deep links immediately available - without any user input
+            #[cfg(target_os = "linux")]
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+
+                let schemes = app
+                    .config()
+                    .plugins
+                    .0
+                    .get("deep-link")
+                    .unwrap()
+                    .get("desktop")
+                    .unwrap()
+                    .get("schemes")
+                    .unwrap()
+                    .as_array()
+                    .unwrap();
+
+                for scheme in schemes {
+                    app.deep_link().register(scheme.as_str().unwrap())?;
+                }
+            }
+
             app.listen("deep-link://new-url", |url| {
                 dbg!(url);
             });

--- a/plugins/deep-link/examples/app/src-tauri/tauri.conf.json
+++ b/plugins/deep-link/examples/app/src-tauri/tauri.conf.json
@@ -29,11 +29,21 @@
     },
     "deep-link": {
       "mobile": [
-        { "host": "fabianlars.de", "pathPrefix": ["/intent"] },
-        { "host": "tauri.app" }
+        {
+          "host": "fabianlars.de",
+          "pathPrefix": [
+            "/intent"
+          ]
+        },
+        {
+          "host": "tauri.app"
+        }
       ],
       "desktop": {
-        "schemes": ["fabianlars", "my-tauri-app"]
+        "schemes": [
+          "fabianlars",
+          "my-tauri-app"
+        ]
       }
     }
   },

--- a/plugins/deep-link/examples/app/src-tauri/tauri.conf.json
+++ b/plugins/deep-link/examples/app/src-tauri/tauri.conf.json
@@ -31,19 +31,14 @@
       "mobile": [
         {
           "host": "fabianlars.de",
-          "pathPrefix": [
-            "/intent"
-          ]
+          "pathPrefix": ["/intent"]
         },
         {
           "host": "tauri.app"
         }
       ],
       "desktop": {
-        "schemes": [
-          "fabianlars",
-          "my-tauri-app"
-        ]
+        "schemes": ["fabianlars", "my-tauri-app"]
       }
     }
   },

--- a/plugins/deep-link/src/config.rs
+++ b/plugins/deep-link/src/config.rs
@@ -65,4 +65,14 @@ impl DesktopProtocol {
                 .any(|protocol| protocol.schemes.contains(scheme)),
         }
     }
+
+    pub fn schemes(&self) -> Vec<String> {
+        match self {
+            Self::One(protocol) => protocol.schemes.clone(),
+            Self::List(protocols) => protocols
+                .iter()
+                .flat_map(|protocol| protocol.schemes.clone())
+                .collect(),
+        }
+    }
 }

--- a/plugins/deep-link/src/config.rs
+++ b/plugins/deep-link/src/config.rs
@@ -66,6 +66,7 @@ impl DesktopProtocol {
         }
     }
 
+    #[allow(dead_code)]
     pub fn schemes(&self) -> Vec<String> {
         match self {
             Self::One(protocol) => protocol.schemes.clone(),

--- a/plugins/deep-link/src/config.rs
+++ b/plugins/deep-link/src/config.rs
@@ -7,7 +7,7 @@
 use serde::{Deserialize, Deserializer};
 use tauri_utils::config::DeepLinkProtocol;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct AssociatedDomain {
     #[serde(deserialize_with = "deserialize_associated_host")]
     pub host: String,
@@ -29,7 +29,7 @@ where
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct Config {
     /// Mobile requires `https://<host>` urls.
     #[serde(default)]
@@ -41,7 +41,7 @@ pub struct Config {
     pub desktop: DesktopProtocol,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[serde(untagged)]
 #[allow(unused)] // Used in tauri-bundler
 pub enum DesktopProtocol {
@@ -52,5 +52,17 @@ pub enum DesktopProtocol {
 impl Default for DesktopProtocol {
     fn default() -> Self {
         Self::List(Vec::new())
+    }
+}
+
+impl DesktopProtocol {
+    #[allow(dead_code)]
+    pub fn contains_scheme(&self, scheme: &String) -> bool {
+        match self {
+            Self::One(protocol) => protocol.schemes.contains(scheme),
+            Self::List(protocols) => protocols
+                .iter()
+                .any(|protocol| protocol.schemes.contains(scheme)),
+        }
     }
 }

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -214,7 +214,6 @@ mod imp {
         ///
         /// This function updates the [`Self::get_current`] value and emits a `deep-link://new-url` event.
         #[cfg(desktop)]
-        #[doc(hidden)]
         pub fn handle_cli_arguments<S: AsRef<str>, I: Iterator<Item = S>>(&self, mut args: I) {
             use tauri::Emitter;
 

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -78,11 +78,7 @@ fn init_deep_link<R: Runtime>(
 
         Ok(DeepLink {
             app: app.clone(),
-            current: std::sync::Mutex::new(if let Some(url) = current {
-                Some(vec![url])
-            } else {
-                None
-            }),
+            current: std::sync::Mutex::new(current.map(|url| vec![url])),
             config: api.config().clone(),
         })
     }
@@ -214,7 +210,7 @@ mod imp {
         ///
         /// This function updates the [`Self::get_current`] value and emits a `deep-link://new-url` event.
         #[cfg(desktop)]
-        pub fn handle_cli_arguments<S: AsRef<str>, I: Iterator<Item = S>>(&self, mut args: I) {
+        pub fn handle_cli_arguments<S: AsRef<str>, I: Iterator<Item = S>>(&self, args: I) {
             use tauri::Emitter;
 
             let Some(config) = &self.config else {
@@ -241,8 +237,8 @@ mod imp {
 
         /// Registers all schemes defined in the configuration file.
         ///
-        /// This is useful to ensure the schemes are registered even if the user unregistered it
-        /// or did not install the app properly (e.g. an AppImage that was not properly registered with an AppImage launcher).
+        /// This is useful to ensure the schemes are registered even if the user did not install the app properly
+        /// (e.g. an AppImage that was not properly registered with an AppImage launcher).
         pub fn register_all(&self) -> crate::Result<()> {
             let Some(config) = &self.config else {
                 return Ok(());

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -240,6 +240,22 @@ mod imp {
             return Ok(self.current.lock().unwrap().clone());
         }
 
+        /// Registers all schemes defined in the configuration file.
+        ///
+        /// This is useful to ensure the schemes are registered even if the user unregistered it
+        /// or did not install the app properly (e.g. an AppImage that was not properly registered with an AppImage launcher).
+        pub fn register_all(&self) -> crate::Result<()> {
+            let Some(config) = &self.config else {
+                return Ok(());
+            };
+
+            for scheme in config.desktop.schemes() {
+                self.register(scheme)?;
+            }
+
+            Ok(())
+        }
+
         /// Register the app as the default handler for the specified protocol.
         ///
         /// - `protocol`: The name of the protocol without `://`. For example, if you want your app to handle `tauri://` links, call this method with `tauri` as the protocol.

--- a/plugins/single-instance/Cargo.toml
+++ b/plugins/single-instance/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { workspace = true }
 tauri = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
+tauri-plugin-deep-link = { path = "../deep-link", version = "2.0.0-rc.3" }
 semver = { version = "1", optional = true }
 
 [target."cfg(target_os = \"windows\")".dependencies.windows-sys]

--- a/plugins/single-instance/src/lib.rs
+++ b/plugins/single-instance/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg(not(any(target_os = "android", target_os = "ios")))]
 
 use tauri::{plugin::TauriPlugin, AppHandle, Manager, Runtime};
+use tauri_plugin_deep_link::DeepLink;
 
 #[cfg(target_os = "windows")]
 #[path = "platform_impl/windows.rs"]
@@ -31,9 +32,14 @@ pub(crate) type SingleInstanceCallback<R> =
     dyn FnMut(&AppHandle<R>, Vec<String>, String) + Send + Sync + 'static;
 
 pub fn init<R: Runtime, F: FnMut(&AppHandle<R>, Vec<String>, String) + Send + Sync + 'static>(
-    f: F,
+    mut f: F,
 ) -> TauriPlugin<R> {
-    platform_impl::init(Box::new(f))
+    platform_impl::init(Box::new(move |app, args, cwd| {
+        if let Some(deep_link) = app.try_state::<DeepLink<R>>() {
+            deep_link.handle_cli_arguments(args.iter());
+        }
+        f(app, args, cwd)
+    }))
 }
 
 pub fn destroy<R: Runtime, M: Manager<R>>(manager: &M) {


### PR DESCRIPTION
checks std::env::args() on initialization, also includes integration with the single-instance plugin