### PR TITLE
Add Metadata for Plugin Compatibility

### DIFF
--- a/plugins/autostart/Cargo.toml
+++ b/plugins/autostart/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-autostart"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/barcode-scanner/Cargo.toml
+++ b/plugins/barcode-scanner/Cargo.toml
@@ -14,6 +14,14 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-linux-android"]
 
+[package.metadata.platforms.support]
+windows = { level = "none", notes = "" }
+linux = { level = "none", notes = "" }
+macos = { level = "none", notes = "" }
+android = { level = "full", notes = "" }
+ios = { level = "full", notes = "" }
+
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/biometric/Cargo.toml
+++ b/plugins/biometric/Cargo.toml
@@ -13,6 +13,14 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-linux-android"]
 
+[package.metadata.platforms.support]
+windows = { level = "none", notes = "" }
+linux = { level = "none", notes = "" }
+macos = { level = "none", notes = "" }
+android = { level = "full", notes = "" }
+ios = { level = "full", notes = "" }
+
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/cli/Cargo.toml
+++ b/plugins/cli/Cargo.toml
@@ -13,6 +13,14 @@ links = "tauri-plugin-cli"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/clipboard-manager/Cargo.toml
+++ b/plugins/clipboard-manager/Cargo.toml
@@ -14,6 +14,14 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-linux-android"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "partial", notes = "Only plain-text content support" }
+ios = { level = "partial", notes = "Only plain-text content support" }
+
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/deep-link/Cargo.toml
+++ b/plugins/deep-link/Cargo.toml
@@ -17,9 +17,9 @@ targets = ["x86_64-linux-android"]
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }
 linux = { level = "full", notes = "" }
-macos = { level = "full", notes = "" }
-android = { level = "full", notes = "" }
-ios = { level = "full", notes = "" }
+macos = { level = "partial", notes = "Runtime deep link registration is not supported" }
+android = { level = "partial", notes = "Runtime deep link registration is not supported" }
+ios = { level = "partial", notes = "Runtime deep link registration is not supported" }
 
 [build-dependencies]
 serde = { workspace = true }

--- a/plugins/deep-link/Cargo.toml
+++ b/plugins/deep-link/Cargo.toml
@@ -14,6 +14,13 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-linux-android"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "full", notes = "" }
+ios = { level = "full", notes = "" }
+
 [build-dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/plugins/dialog/Cargo.toml
+++ b/plugins/dialog/Cargo.toml
@@ -14,6 +14,13 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-linux-android"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "full", notes = "" }
+ios = { level = "full", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/dialog/Cargo.toml
+++ b/plugins/dialog/Cargo.toml
@@ -18,8 +18,8 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-linux-android"]
 windows = { level = "full", notes = "" }
 linux = { level = "full", notes = "" }
 macos = { level = "full", notes = "" }
-android = { level = "full", notes = "" }
-ios = { level = "full", notes = "" }
+android = { level = "partial", notes = "Does not support folder picker" }
+ios = { level = "partial", notes = "Does not support folder picker" }
 
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }

--- a/plugins/fs/Cargo.toml
+++ b/plugins/fs/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-fs"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "No write access to `$RESOURCES` folder" }
+android = { level = "partial", notes = "Access is restricted to Application folder by default" }
+ios = { level = "partial", notes = "Access is restricted to Application folder by default" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 schemars = { workspace = true }

--- a/plugins/fs/Cargo.toml
+++ b/plugins/fs/Cargo.toml
@@ -15,7 +15,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }
-linux = { level = "full", notes = "" }
+linux = { level = "full", notes = "No write access to `$RESOURCES` folder" }
 macos = { level = "full", notes = "No write access to `$RESOURCES` folder" }
 android = { level = "partial", notes = "Access is restricted to Application folder by default" }
 ios = { level = "partial", notes = "Access is restricted to Application folder by default" }

--- a/plugins/geolocation/Cargo.toml
+++ b/plugins/geolocation/Cargo.toml
@@ -13,6 +13,13 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-linux-android"]
 
+[package.metadata.platforms.support]
+windows = { level = "unknown", notes = "" }
+linux = { level = "unknown", notes = "" }
+macos = { level = "unknown", notes = "" }
+android = { level = "full", notes = "" }
+ios = { level = "full", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/geolocation/Cargo.toml
+++ b/plugins/geolocation/Cargo.toml
@@ -14,9 +14,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-linux-android"]
 
 [package.metadata.platforms.support]
-windows = { level = "unknown", notes = "" }
-linux = { level = "unknown", notes = "" }
-macos = { level = "unknown", notes = "" }
+windows = { level = "none", notes = "" }
+linux = { level = "none", notes = "" }
+macos = { level = "none", notes = "" }
 android = { level = "full", notes = "" }
 ios = { level = "full", notes = "" }
 

--- a/plugins/global-shortcut/Cargo.toml
+++ b/plugins/global-shortcut/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-global-shortcut"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/haptics/Cargo.toml
+++ b/plugins/haptics/Cargo.toml
@@ -13,6 +13,13 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-linux-android"]
 
+[package.metadata.platforms.support]
+windows = { level = "none", notes = "" }
+linux = { level = "none", notes = "" }
+macos = { level = "none", notes = "" }
+android = { level = "full", notes = "" }
+ios = { level = "full", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/http/Cargo.toml
+++ b/plugins/http/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-http"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 schemars = { workspace = true }

--- a/plugins/localhost/Cargo.toml
+++ b/plugins/localhost/Cargo.toml
@@ -12,6 +12,13 @@ repository = { workspace = true }
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/plugins/log/Cargo.toml
+++ b/plugins/log/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-log"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "unknown", notes = "" }
+ios = { level = "unknown", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/nfc/Cargo.toml
+++ b/plugins/nfc/Cargo.toml
@@ -13,6 +13,13 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-linux-android"]
 
+[package.metadata.platforms.support]
+windows = { level = "none", notes = "" }
+linux = { level = "none", notes = "" }
+macos = { level = "none", notes = "" }
+android = { level = "full", notes = "" }
+ios = { level = "full", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/notification/Cargo.toml
+++ b/plugins/notification/Cargo.toml
@@ -14,6 +14,13 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-linux-android"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "full", notes = "" }
+ios = { level = "full", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/os/Cargo.toml
+++ b/plugins/os/Cargo.toml
@@ -17,8 +17,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 windows = { level = "full", notes = "" }
 linux = { level = "full", notes = "" }
 macos = { level = "full", notes = "" }
-android = { level = "none", notes = "" }
-ios = { level = "none", notes = "" }
+android = { level = "full", notes = "" }
+ios = { level = "full", notes = "" }
 
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }

--- a/plugins/os/Cargo.toml
+++ b/plugins/os/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-os"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/persisted-scope/Cargo.toml
+++ b/plugins/persisted-scope/Cargo.toml
@@ -12,6 +12,13 @@ repository = { workspace = true }
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/plugins/positioner/Cargo.toml
+++ b/plugins/positioner/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-positioner"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/process/Cargo.toml
+++ b/plugins/process/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-process"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/shell/Cargo.toml
+++ b/plugins/shell/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-shell"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "partial", notes = "Only allows to open URLs via `open`" }
+ios = { level = "partial", notes = "Only allows to open URLs via `open`" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 schemars = { workspace = true }

--- a/plugins/single-instance/Cargo.toml
+++ b/plugins/single-instance/Cargo.toml
@@ -13,6 +13,13 @@ exclude = ["/examples"]
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/plugins/sql/Cargo.toml
+++ b/plugins/sql/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 windows = { level = "full", notes = "" }
 linux = { level = "full", notes = "" }
 macos = { level = "full", notes = "" }
-android = { level = "none", notes = "" }
+android = { level = "full", notes = "" }
 ios = { level = "none", notes = "" }
 
 [build-dependencies]

--- a/plugins/sql/Cargo.toml
+++ b/plugins/sql/Cargo.toml
@@ -14,6 +14,13 @@ features = ["sqlite"]
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/store/Cargo.toml
+++ b/plugins/store/Cargo.toml
@@ -17,8 +17,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 windows = { level = "full", notes = "" }
 linux = { level = "full", notes = "" }
 macos = { level = "full", notes = "" }
-android = { level = "none", notes = "" }
-ios = { level = "none", notes = "" }
+android = { level = "full", notes = "" }
+ios = { level = "full", notes = "" }
 
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }

--- a/plugins/store/Cargo.toml
+++ b/plugins/store/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-store"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/stronghold/Cargo.toml
+++ b/plugins/stronghold/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-stronghold"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/updater/Cargo.toml
+++ b/plugins/updater/Cargo.toml
@@ -15,6 +15,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 no-default-features = true
 features = ["zip"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/upload/Cargo.toml
+++ b/plugins/upload/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-upload"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/websocket/Cargo.toml
+++ b/plugins/websocket/Cargo.toml
@@ -14,6 +14,13 @@ exclude = ["/examples"]
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/plugins/window-state/Cargo.toml
+++ b/plugins/window-state/Cargo.toml
@@ -13,6 +13,13 @@ links = "tauri-plugin-window-state"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.platforms.support]
+windows = { level = "full", notes = "" }
+linux = { level = "full", notes = "" }
+macos = { level = "full", notes = "" }
+android = { level = "none", notes = "" }
+ios = { level = "none", notes = "" }
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 

--- a/shared/template/Cargo.toml
+++ b/shared/template/Cargo.toml
@@ -11,6 +11,17 @@ links = "tauri-plugin-PLUGIN_NAME"
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+# Platforms supported by the plugin
+# Support levels are "full", "partial", "none", "unknown"
+# Details of the support level are left to plugin maintainer
+[package.metadata.platforms]
+windows = { level = "unknown", notes = "" }
+linux = { level = "unknown", notes = "" }
+macos = { level = "unknown", notes = "" }
+android = { level = "unknown", notes = "" }
+ios = { level = "unknown", notes = "" }
+
+
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
 


### PR DESCRIPTION
This PR aims to add metadata into the `Cargo.toml` of the plugin to allow automated documentation generation and to showcase platform compatibility in an automated fashion.

```toml
# Platforms supported by the plugin
# Support levels are "full", "partial", "none", "unknown"
# Details of the support level are left to plugin maintainer
[package.metadata.platforms]
windows = { level = "unknown", notes = "" }
linux = { level = "unknown", notes = "" }
macos = { level = "unknown", notes = "" }
android = { level = "unknown", notes = "" }
ios = { level = "unknown", notes = "" }
```

These values can be extracted via `cargo metadata` and then be rendered in `tauri-docs` on the plugin page, overview and maybe even with icons in the sidebar. The notes are intended for more insight into what does not work or why something is just partially supported.

Also needed for https://github.com/tauri-apps/tauri/issues/10618
