### PR TITLE
fix(fs): ignore OS specific paths in scope deserialization

### DIFF
--- a/.changes/fix-fs-scope-unknown-path.md
+++ b/.changes/fix-fs-scope-unknown-path.md
@@ -2,4 +2,4 @@
 fs: patch
 ---
 
-Fixed an issue causing any `fs` APIs to throw an `error deserializing scope: unknown path` error when the permissions/scopes allowed OS specific paths that aren't available on the currently running OS.
+Fix failing to deserialize capability file when using an OS specific path in the scope that is not available on the current OS.

--- a/.changes/fix-fs-scope-unknown-path.md
+++ b/.changes/fix-fs-scope-unknown-path.md
@@ -1,0 +1,5 @@
+---
+fs: patch
+---
+
+Fixed an issue causing any `fs` APIs to throw an `error deserializing scope: unknown path` error when the permissions/scopes allowed OS specific paths that aren't available on the currently running OS.

--- a/plugins/fs/src/commands.rs
+++ b/plugins/fs/src/commands.rs
@@ -993,8 +993,8 @@ pub fn resolve_path<R: Runtime>(
                 .unwrap()
                 .clone()
                 .into_iter()
-                .chain(global_scope.allows().iter().map(|e| e.path.clone()))
-                .chain(command_scope.allows().iter().map(|e| e.path.clone()))
+                .chain(global_scope.allows().iter().filter_map(|e| e.path.clone()))
+                .chain(command_scope.allows().iter().filter_map(|e| e.path.clone()))
                 .collect(),
             deny: webview
                 .fs_scope()
@@ -1003,8 +1003,8 @@ pub fn resolve_path<R: Runtime>(
                 .unwrap()
                 .clone()
                 .into_iter()
-                .chain(global_scope.denies().iter().map(|e| e.path.clone()))
-                .chain(command_scope.denies().iter().map(|e| e.path.clone()))
+                .chain(global_scope.denies().iter().filter_map(|e| e.path.clone()))
+                .chain(command_scope.denies().iter().filter_map(|e| e.path.clone()))
                 .collect(),
             require_literal_leading_dot: webview.fs_scope().require_literal_leading_dot,
         },

--- a/plugins/fs/src/lib.rs
+++ b/plugins/fs/src/lib.rs
@@ -360,6 +360,7 @@ impl ScopeObject for scope::Entry {
 
         match app.path().parse(path) {
             Ok(path) => Ok(Self { path: Some(path) }),
+            #[cfg(not(target_os = "android"))]
             Err(tauri::Error::UnknownPath) => Ok(Self { path: None }),
             Err(err) => Err(err.into()),
         }

--- a/plugins/fs/src/lib.rs
+++ b/plugins/fs/src/lib.rs
@@ -353,17 +353,16 @@ impl ScopeObject for scope::Entry {
         app: &AppHandle<R>,
         raw: Value,
     ) -> std::result::Result<Self, Self::Error> {
-        let entry = serde_json::from_value(raw.into()).map(|raw| {
-            let path = match raw {
-                scope::EntryRaw::Value(path) => path,
-                scope::EntryRaw::Object { path } => path,
-            };
-            Self { path }
+        let path = serde_json::from_value(raw.into()).map(|raw| match raw {
+            scope::EntryRaw::Value(path) => path,
+            scope::EntryRaw::Object { path } => path,
         })?;
 
-        Ok(Self {
-            path: app.path().parse(entry.path)?,
-        })
+        match app.path().parse(path) {
+            Ok(path) => Ok(Self { path: Some(path) }),
+            Err(tauri::Error::UnknownPath) => Ok(Self { path: None }),
+            Err(err) => Err(err.into()),
+        }
     }
 }
 

--- a/plugins/fs/src/scope.rs
+++ b/plugins/fs/src/scope.rs
@@ -23,7 +23,7 @@ pub enum EntryRaw {
 
 #[derive(Debug)]
 pub struct Entry {
-    pub path: PathBuf,
+    pub path: Option<PathBuf>,
 }
 
 pub type EventId = u32;


### PR DESCRIPTION
fixes https://github.com/tauri-apps/tauri/issues/9205

ngl never really looked into the ACL stuff so this is probably not the best solution but it's what i came up with 🤷 