### PR TITLE
refactor(dialog)!: use enum instead of label for buttons

### DIFF
--- a/.changes/native-dialog-button-text.md
+++ b/.changes/native-dialog-button-text.md
@@ -1,0 +1,5 @@
+---
+"dialog": patch:breaking
+---
+
+Changed `MessageDialogBuilder::ok_button_label` and `MessageDialogBuilder::cancel_button_label` to `MessageDialogBuilder::buttons` which takes an enum now

--- a/plugins/dialog/src/desktop.rs
+++ b/plugins/dialog/src/desktop.rs
@@ -13,10 +13,7 @@ use rfd::{AsyncFileDialog, AsyncMessageDialog};
 use serde::de::DeserializeOwned;
 use tauri::{plugin::PluginApi, AppHandle, Runtime};
 
-use crate::{models::*, FileDialogBuilder, FilePath, MessageDialogBuilder};
-
-pub(crate) const OK: &str = "Ok";
-pub(crate) const CANCEL: &str = "Cancel";
+use crate::{models::*, FileDialogBuilder, FilePath, MessageDialogBuilder, OK};
 
 pub fn init<R: Runtime, C: DeserializeOwned>(
     app: &AppHandle<R>,

--- a/plugins/dialog/src/desktop.rs
+++ b/plugins/dialog/src/desktop.rs
@@ -15,7 +15,8 @@ use tauri::{plugin::PluginApi, AppHandle, Runtime};
 
 use crate::{models::*, FileDialogBuilder, FilePath, MessageDialogBuilder};
 
-const OK: &str = "Ok";
+pub(crate) const OK: &str = "Ok";
+pub(crate) const CANCEL: &str = "Cancel";
 
 pub fn init<R: Runtime, C: DeserializeOwned>(
     app: &AppHandle<R>,
@@ -109,22 +110,24 @@ impl<R: Runtime> From<FileDialogBuilder<R>> for AsyncFileDialog {
     }
 }
 
+impl From<MessageDialogButtons> for rfd::MessageButtons {
+    fn from(value: MessageDialogButtons) -> Self {
+        match value {
+            MessageDialogButtons::Ok => Self::Ok,
+            MessageDialogButtons::OkCancel => Self::OkCancel,
+            MessageDialogButtons::OkCustom(ok) => Self::OkCustom(ok),
+            MessageDialogButtons::OkCancelCustom(ok, cancel) => Self::OkCancelCustom(ok, cancel),
+        }
+    }
+}
+
 impl<R: Runtime> From<MessageDialogBuilder<R>> for AsyncMessageDialog {
     fn from(d: MessageDialogBuilder<R>) -> Self {
         let mut dialog = AsyncMessageDialog::new()
             .set_title(&d.title)
             .set_description(&d.message)
-            .set_level(d.kind.into());
-
-        let buttons = match (d.ok_button_label, d.cancel_button_label) {
-            (Some(ok), Some(cancel)) => Some(rfd::MessageButtons::OkCancelCustom(ok, cancel)),
-            (Some(ok), None) => Some(rfd::MessageButtons::OkCustom(ok)),
-            (None, Some(cancel)) => Some(rfd::MessageButtons::OkCancelCustom(OK.into(), cancel)),
-            (None, None) => None,
-        };
-        if let Some(buttons) = buttons {
-            dialog = dialog.set_buttons(buttons);
-        }
+            .set_level(d.kind.into())
+            .set_buttons(d.buttons.into());
 
         if let Some(parent) = d.parent {
             dialog = dialog.set_parent(&parent);
@@ -213,7 +216,11 @@ pub fn show_message_dialog<R: Runtime, F: FnOnce(bool) + Send + 'static>(
 ) {
     use rfd::MessageDialogResult;
 
-    let ok_label = dialog.ok_button_label.clone();
+    let ok_label = match &dialog.buttons {
+        MessageDialogButtons::OkCustom(ok) => Some(ok.clone()),
+        MessageDialogButtons::OkCancelCustom(ok, _) => Some(ok.clone()),
+        _ => None,
+    };
     let f = move |res| {
         f(match res {
             MessageDialogResult::Ok | MessageDialogResult::Yes => true,

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -41,6 +41,9 @@ use desktop::*;
 #[cfg(mobile)]
 use mobile::*;
 
+pub(crate) const OK: &str = "Ok";
+pub(crate) const CANCEL: &str = "Cancel";
+
 macro_rules! blocking_fn {
     ($self:ident, $fn:ident) => {{
         let (tx, rx) = sync_channel(0);

--- a/plugins/dialog/src/lib.rs
+++ b/plugins/dialog/src/lib.rs
@@ -89,14 +89,13 @@ impl<R: Runtime> Dialog<R> {
     /// - Ask dialog:
     ///
     /// ```
-    /// use tauri_plugin_dialog::DialogExt;
+    /// use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
     ///
     /// tauri::Builder::default()
     ///   .setup(|app| {
     ///     app.dialog()
     ///       .message("Are you sure?")
-    ///       .ok_button_label("Yes")
-    ///       .cancel_button_label("No")
+    ///       .buttons(MessageDialogButtons::OkCancelCustom("Yes", "No"))
     ///       .show(|yes| {
     ///         println!("user said {}", if yes { "yes" } else { "no" });
     ///       });
@@ -107,13 +106,13 @@ impl<R: Runtime> Dialog<R> {
     /// - Message dialog with OK button:
     ///
     /// ```
-    /// use tauri_plugin_dialog::DialogExt;
+    /// use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
     ///
     /// tauri::Builder::default()
     ///   .setup(|app| {
     ///     app.dialog()
     ///       .message("Job completed successfully")
-    ///       .ok_button_label("Ok")
+    ///       .buttons(MessageDialogButtons::Ok)
     ///       .show(|_| {
     ///         println!("dialog closed");
     ///       });
@@ -129,7 +128,7 @@ impl<R: Runtime> Dialog<R> {
     /// but note that it cannot be executed on the main thread as it will freeze your application.
     ///
     /// ```
-    /// use tauri_plugin_dialog::DialogExt;
+    /// use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
     ///
     /// tauri::Builder::default()
     ///   .setup(|app| {
@@ -137,8 +136,7 @@ impl<R: Runtime> Dialog<R> {
     ///     std::thread::spawn(move || {
     ///       let yes = handle.dialog()
     ///         .message("Are you sure?")
-    ///         .ok_button_label("Yes")
-    ///         .cancel_button_label("No")
+    ///         .buttons(MessageDialogButtons::OkCancelCustom("Yes", "No"))
     ///         .blocking_show();
     ///     });
     ///
@@ -196,8 +194,7 @@ pub struct MessageDialogBuilder<R: Runtime> {
     pub(crate) title: String,
     pub(crate) message: String,
     pub(crate) kind: MessageDialogKind,
-    pub(crate) ok_button_label: Option<String>,
-    pub(crate) cancel_button_label: Option<String>,
+    pub(crate) buttons: MessageDialogButtons,
     #[cfg(desktop)]
     pub(crate) parent: Option<crate::desktop::WindowHandle>,
 }
@@ -210,8 +207,8 @@ pub(crate) struct MessageDialogPayload<'a> {
     title: &'a String,
     message: &'a String,
     kind: &'a MessageDialogKind,
-    ok_button_label: &'a Option<String>,
-    cancel_button_label: &'a Option<String>,
+    ok_button_label: Option<&'a str>,
+    cancel_button_label: Option<&'a str>,
 }
 
 // raw window handle :(
@@ -225,8 +222,7 @@ impl<R: Runtime> MessageDialogBuilder<R> {
             title: title.into(),
             message: message.into(),
             kind: Default::default(),
-            ok_button_label: None,
-            cancel_button_label: None,
+            buttons: Default::default(),
             #[cfg(desktop)]
             parent: None,
         }
@@ -234,12 +230,20 @@ impl<R: Runtime> MessageDialogBuilder<R> {
 
     #[cfg(mobile)]
     pub(crate) fn payload(&self) -> MessageDialogPayload<'_> {
+        let (ok_button_label, cancel_button_label) = match &self.buttons {
+            MessageDialogButtons::Ok => (Some(OK), None),
+            MessageDialogButtons::OkCancel => (Some(OK), Some(CANCEL)),
+            MessageDialogButtons::OkCustom(ok) => (Some(ok.as_str()), Some(CANCEL)),
+            MessageDialogButtons::OkCancelCustom(ok, cancel) => {
+                (Some(ok.as_str()), Some(cancel.as_str()))
+            }
+        };
         MessageDialogPayload {
             title: &self.title,
             message: &self.message,
             kind: &self.kind,
-            ok_button_label: &self.ok_button_label,
-            cancel_button_label: &self.cancel_button_label,
+            ok_button_label,
+            cancel_button_label,
         }
     }
 
@@ -266,15 +270,9 @@ impl<R: Runtime> MessageDialogBuilder<R> {
         self
     }
 
-    /// Sets the label for the OK button.
-    pub fn ok_button_label(mut self, label: impl Into<String>) -> Self {
-        self.ok_button_label.replace(label.into());
-        self
-    }
-
-    /// Sets the label for the Cancel button.
-    pub fn cancel_button_label(mut self, label: impl Into<String>) -> Self {
-        self.cancel_button_label.replace(label.into());
+    /// Sets the dialog buttons.
+    pub fn buttons(mut self, buttons: MessageDialogButtons) -> Self {
+        self.buttons = buttons;
         self
     }
 

--- a/plugins/dialog/src/models.rs
+++ b/plugins/dialog/src/models.rs
@@ -50,7 +50,7 @@ impl Serialize for MessageDialogKind {
     }
 }
 
-/// Set the set of button that will be displayed on the dialog
+/// Set of button that will be displayed on the dialog
 #[non_exhaustive]
 #[derive(Debug, Default, Clone)]
 pub enum MessageDialogButtons {

--- a/plugins/dialog/src/models.rs
+++ b/plugins/dialog/src/models.rs
@@ -49,3 +49,18 @@ impl Serialize for MessageDialogKind {
         }
     }
 }
+
+/// Set the set of button that will be displayed on the dialog
+#[non_exhaustive]
+#[derive(Debug, Default, Clone)]
+pub enum MessageDialogButtons {
+    #[default]
+    /// A single `Ok` button with OS default dialog text
+    Ok,
+    /// 2 buttons `Ok` and `Cancel` with OS default dialog texts
+    OkCancel,
+    /// A single `Ok` button with custom text
+    OkCustom(String),
+    /// 2 buttons `Ok` and `Cancel` with custom texts
+    OkCancelCustom(String, String),
+}


### PR DESCRIPTION
This allows the user to use the default OS dialog buttons texts instead of always defaulting to `Ok` and `Cancel`