### PR TITLE
fix: make package.json licenses SPDX compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugins-workspace",
   "private": true,
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "type": "module",
   "scripts": {
     "build": "pnpm run -r --parallel --filter !plugins-workspace --filter !\"./plugins/*/examples/**\" --filter !\"./examples/*\" build",

--- a/plugins/autostart/package.json
+++ b/plugins/autostart/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-autostart",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/barcode-scanner/package.json
+++ b/plugins/barcode-scanner/package.json
@@ -2,7 +2,7 @@
   "name": "@tauri-apps/plugin-barcode-scanner",
   "version": "2.0.0-rc.2",
   "description": "Scan QR codes, EAN-13 and other kinds of barcodes on Android and iOS",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/biometric/package.json
+++ b/plugins/biometric/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-biometric",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/cli/package.json
+++ b/plugins/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-cli",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/clipboard-manager/package.json
+++ b/plugins/clipboard-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-clipboard-manager",
   "version": "2.0.0-rc.2",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/deep-link/package.json
+++ b/plugins/deep-link/package.json
@@ -2,7 +2,7 @@
   "name": "@tauri-apps/plugin-deep-link",
   "version": "2.0.0-rc.2",
   "description": "Set your Tauri application as the default handler for an URL",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/dialog/package.json
+++ b/plugins/dialog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-dialog",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/fs/package.json
+++ b/plugins/fs/package.json
@@ -2,7 +2,7 @@
   "name": "@tauri-apps/plugin-fs",
   "version": "2.0.0-rc.2",
   "description": "Access the file system.",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/geolocation/package.json
+++ b/plugins/geolocation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-geolocation",
   "version": "2.0.0-rc.2",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/global-shortcut/package.json
+++ b/plugins/global-shortcut/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-global-shortcut",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/haptics/package.json
+++ b/plugins/haptics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-haptics",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/http/package.json
+++ b/plugins/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-http",
   "version": "2.0.0-rc.2",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/log/package.json
+++ b/plugins/log/package.json
@@ -2,7 +2,7 @@
   "name": "@tauri-apps/plugin-log",
   "version": "2.0.0-rc.1",
   "description": "Configurable logging for your Tauri app.",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/nfc/package.json
+++ b/plugins/nfc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-nfc",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/notification/package.json
+++ b/plugins/notification/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-notification",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/os/package.json
+++ b/plugins/os/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-os",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/positioner/package.json
+++ b/plugins/positioner/package.json
@@ -2,7 +2,7 @@
   "name": "@tauri-apps/plugin-positioner",
   "version": "2.0.0-rc.2",
   "description": "Position your windows at well-known locations.",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/process/package.json
+++ b/plugins/process/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-process",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/shell/package.json
+++ b/plugins/shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-shell",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/sql/package.json
+++ b/plugins/sql/package.json
@@ -2,7 +2,7 @@
   "name": "@tauri-apps/plugin-sql",
   "version": "2.0.0-rc.1",
   "description": "Interface with SQL databases",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/store/package.json
+++ b/plugins/store/package.json
@@ -2,7 +2,7 @@
   "name": "@tauri-apps/plugin-store",
   "version": "2.0.0-rc.2",
   "description": "Simple, persistent key-value store.",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/stronghold/package.json
+++ b/plugins/stronghold/package.json
@@ -2,7 +2,7 @@
   "name": "@tauri-apps/plugin-stronghold",
   "version": "2.0.0-rc.1",
   "description": "Store secrets and keys using the IOTA Stronghold encrypted database.",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/updater/package.json
+++ b/plugins/updater/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-updater",
   "version": "2.0.0-rc.2",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/upload/package.json
+++ b/plugins/upload/package.json
@@ -2,7 +2,7 @@
   "name": "@tauri-apps/plugin-upload",
   "version": "2.0.0-rc.1",
   "description": "Upload files from disk to a remote server over HTTP.",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/websocket/package.json
+++ b/plugins/websocket/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-websocket",
   "version": "2.0.0-rc.1",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/plugins/window-state/package.json
+++ b/plugins/window-state/package.json
@@ -2,7 +2,7 @@
   "name": "@tauri-apps/plugin-window-state",
   "version": "2.0.0-rc.1",
   "description": "Save window positions and sizes and restore them when the app is reopened.",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],

--- a/shared/template/package.json
+++ b/shared/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tauri-apps/plugin-PLUGIN_NAME",
   "version": "1.0.0",
-  "license": "MIT or APACHE-2.0",
+  "license": "MIT OR Apache-2.0",
   "authors": [
     "Tauri Programme within The Commons Conservancy"
   ],


### PR DESCRIPTION
This updates the licenses in published & template package.json files to be SPDX compliant:
1. The SPDX license identifier for Apache License 2.0 is `Apache-2.0`  
   https://spdx.org/licenses/Apache-2.0.html
1. The SPDX license expression operator `OR` is case sensitive  
   https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/#d2-case-sensitivity
