### PR TITLE
fix(shell): use async command for `open` JS API

### DIFF
--- a/.changes/shell-open-hang-windows.md
+++ b/.changes/shell-open-hang-windows.md
@@ -1,0 +1,6 @@
+---
+"shell": "patch"
+"shell-js": "patch"
+---
+
+On Windows, Fix `open` JS API hanging and freezing the app.

--- a/plugins/shell/src/commands.rs
+++ b/plugins/shell/src/commands.rs
@@ -303,7 +303,7 @@ pub fn kill<R: Runtime>(
 }
 
 #[tauri::command]
-pub fn open<R: Runtime>(
+pub async fn open<R: Runtime>(
     _window: Window<R>,
     shell: State<'_, Shell<R>>,
     path: String,


### PR DESCRIPTION
closes tauri-apps/tauri#11212