### PR TITLE
fix: autoSave Inconsistency

### DIFF
--- a/plugins/store/guest-js/index.ts
+++ b/plugins/store/guest-js/index.ts
@@ -19,7 +19,7 @@ export type StoreOptions = {
   /**
    * Auto save on modification with debounce duration in milliseconds
    */
-  autoSave?: boolean
+  autoSave?: number
 }
 
 /**


### PR DESCRIPTION
The Tauri Store plugin has a type mismatch for the autoSave option.  In TypeScript, it's documented as a boolean, but the Rust backend expects a u64. Setting autoSave to true or false in createStore causes an error:

```bash
Unhandled Promise Rejection: invalid args `autoSave` for command `create_store`: invalid type: boolean `true`, expected u64 
```