### PR TITLE
fix(sql): don't panic on missing migration when preload is enabled

### DIFF
--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -168,7 +168,6 @@ fn main() {
 
 To apply the migrations when the plugin is initialized, add the connection string to the `tauri.conf.json` file:
 
-> Notice: If `migration` is not provided, make sure that `preload` is kept empty
 
 ```json
 {

--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -168,6 +168,8 @@ fn main() {
 
 To apply the migrations when the plugin is initialized, add the connection string to the `tauri.conf.json` file:
 
+> Notice: if no migration provided, keeping the `preload` empty
+
 ```json
 {
   "plugins": {

--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -168,7 +168,7 @@ fn main() {
 
 To apply the migrations when the plugin is initialized, add the connection string to the `tauri.conf.json` file:
 
-> Notice: if no migration provided, keeping the `preload` empty
+> Notice: If `migration` is not provided, make sure that `preload` is kept empty
 
 ```json
 {

--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -168,7 +168,6 @@ fn main() {
 
 To apply the migrations when the plugin is initialized, add the connection string to the `tauri.conf.json` file:
 
-
 ```json
 {
   "plugins": {

--- a/plugins/sql/src/lib.rs
+++ b/plugins/sql/src/lib.rs
@@ -145,14 +145,11 @@ impl Builder {
                     for db in config.preload {
                         let pool = DbPool::connect(&db, app).await?;
 
-                        if let Some(migration_map) = self.migrations.as_mut(){
-                            if let Some(migrations)= migration_map.remove(&db){
-                                let migrator = Migrator::new(migrations).await?;
-                                pool.migrate(&migrator).await?;
-                            }
-                        }
-                        else{
-                            panic!("No migrations providing. Please provide at least one migration or clear `preload` list");
+                        if let Some(migrations) =
+                            self.migrations.as_mut().and_then(|mm| mm.remove(&db))
+                        {
+                            let migrator = Migrator::new(migrations).await?;
+                            pool.migrate(&migrator).await?;
                         }
 
                         lock.insert(db, pool);

--- a/plugins/sql/src/lib.rs
+++ b/plugins/sql/src/lib.rs
@@ -144,11 +144,11 @@ impl Builder {
 
                     for db in config.preload {
                         let pool = DbPool::connect(&db, app).await?;
-                        
+
                         if let Some(migration_map) = self.migrations.as_mut(){
                             if let Some(migrations)= migration_map.remove(&db){
                                 let migrator = Migrator::new(migrations).await?;
-                            pool.migrate(&migrator).await?;
+                                pool.migrate(&migrator).await?;
                             }
                         }
                         else{

--- a/plugins/sql/src/lib.rs
+++ b/plugins/sql/src/lib.rs
@@ -144,10 +144,15 @@ impl Builder {
 
                     for db in config.preload {
                         let pool = DbPool::connect(&db, app).await?;
-
-                        if let Some(migrations) = self.migrations.as_mut().unwrap().remove(&db) {
-                            let migrator = Migrator::new(migrations).await?;
+                        
+                        if let Some(migration_map) = self.migrations.as_mut(){
+                            if let Some(migrations)= migration_map.remove(&db){
+                                let migrator = Migrator::new(migrations).await?;
                             pool.migrate(&migrator).await?;
+                            }
+                        }
+                        else{
+                            panic!("No migrations providing. Please provide at least one migration or clear `preload` list");
                         }
 
                         lock.insert(db, pool);


### PR DESCRIPTION
this pr is the implement of #1930 .

# tasks
- [x] skip migration if no migration provided in preload