### PR TITLE
fix(store): `autoSave` type to `number`

### DIFF
--- a/plugins/store/guest-js/index.ts
+++ b/plugins/store/guest-js/index.ts
@@ -19,7 +19,7 @@ export type StoreOptions = {
   /**
    * Auto save on modification with debounce duration in milliseconds
    */
-  autoSave?: boolean
+  autoSave?: number
 }
 
 /**


### PR DESCRIPTION
rust receives a type of `u64` and ts passes a `boolean`, resulting in a type error!

https://github.com/tauri-apps/plugins-workspace/blob/7e1c17a635f10d69e10ea9f35081a68c71276203/plugins/store/src/lib.rs#L50

<img width="1031" alt="iShot_2024-10-14_21 29 07" src="https://github.com/user-attachments/assets/d2c1b6e9-4c29-489f-835f-052acedcd391">
