### PR TITLE
feat: allow http calls without origin header

### DIFF
--- a/.changes/http-allow-skip-origin.md
+++ b/.changes/http-allow-skip-origin.md
@@ -1,0 +1,6 @@
+---
+"http": "patch"
+"http-js": "patch"
+---
+
+Allow skipping sending Origin header in HTTP requests by sending empty string as the value for Origin header.

--- a/.changes/http-allow-skip-origin.md
+++ b/.changes/http-allow-skip-origin.md
@@ -3,4 +3,4 @@
 "http-js": "patch"
 ---
 
-Allow skipping sending Origin header in HTTP requests by sending empty string as the value for Origin header.
+Allow skipping sending `Origin` header in HTTP requests by setting `Origin` header to an empty string when calling `fetch`.

--- a/plugins/http/src/commands.rs
+++ b/plugins/http/src/commands.rs
@@ -264,6 +264,14 @@ pub async fn fetch<R: Runtime>(
                     }
                 }
 
+                // In case empty origin is passed, remove it. Some services do not like Origin header
+                // so this way we can remove it in explicit way. The default behaviour is still to set it
+                if cfg!(feature = "unsafe-headers")
+                    && headers.get(header::ORIGIN) == Some(&HeaderValue::from_static(""))
+                {
+                    headers.remove(header::ORIGIN);
+                };
+
                 if let Some(data) = data {
                     request = request.body(data);
                 }


### PR DESCRIPTION
Example [Clerk](https://clerk.com/) auth provider does not work when both Authorization and Origin headers are set. This allows one to skip setting the origin header explicitly.

In my application I'm routing all requests via tauri-http by patching global fetch. And I'm using custom Clerk setup to get the token shared between js and rust. To do that I need to use Authorization header instead of cookies to communicate with Clerk. And Clerk fails if there is both Authorization header and Origin header, as such I need a way to send requests without origin header.

I do like the default behavior of setting the origin header if it's not set as that mimics the browser behavior. But I also need a way to not send it. This does not change any existing behaviors, and Origin header can anyways be:
```
Origin: null
Origin: <scheme>://<hostname>
Origin: <scheme>://<hostname>:<port>
```
So empty string would be invalid header value according to the spec. As such I was thinking that if client has sent empty origin header we could just omit the origin header.