### PR TITLE
Remove cameraView from superview after scanning

### DIFF
--- a/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
+++ b/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
@@ -170,6 +170,7 @@ class BarcodeScannerPlugin: Plugin, AVCaptureMetadataOutputObjectsDelegate {
     if self.captureSession != nil {
       self.captureSession!.stopRunning()
       self.cameraView.removePreviewLayer()
+      self.cameraView.removeFromSuperview()
       self.captureVideoPreviewLayer = nil
       self.metaOutput = nil
       self.captureSession = nil


### PR DESCRIPTION
Remove from superview when camera subview is dismantled. 

If the view is not removed, all inputs are captured by this (transparent) view.
After removing, all events are propagated to the WebView as expected.