### PR TITLE
fix(fs): fix compilation on targets with pointer width 16 and 32

### DIFF
--- a/.changes/change-pr-1958.md
+++ b/.changes/change-pr-1958.md
@@ -1,0 +1,5 @@
+---
+"fs": patch
+---
+
+Fix compilation on targets with pointer width of `16` or `32`

--- a/plugins/fs/src/commands.rs
+++ b/plugins/fs/src/commands.rs
@@ -316,12 +316,14 @@ pub async fn read<R: Runtime>(
         let nread = nread.to_be_bytes();
         let mut out = [0; 8];
         out[6..].copy_from_slice(&nread);
+        out
     };
     #[cfg(target_pointer_width = "32")]
     let nread = {
         let nread = nread.to_be_bytes();
         let mut out = [0; 8];
         out[4..].copy_from_slice(&nread);
+        out
     };
     #[cfg(target_pointer_width = "64")]
     let nread = nread.to_be_bytes();


### PR DESCRIPTION
Fixed compilation for systems where `target_pointer_width`  is 16 or 32