### PR TITLE
feat(localhost): add custom host binding to allow external access

### DIFF
--- a/.changes/localhost-custom-host-binding.md
+++ b/.changes/localhost-custom-host-binding.md
@@ -1,0 +1,5 @@
+---
+'localhost': 'minor'
+---
+
+Add custom host binding to allow external access

--- a/plugins/localhost/src/lib.rs
+++ b/plugins/localhost/src/lib.rs
@@ -59,8 +59,9 @@ impl Builder {
         }
     }
 
-    pub fn host<H: AsRef<str>>(mut self, host: H) -> Self {
-        self.host = Some(host.as_ref().to_string());
+    // Change the host the plugin binds to. Defaults to `localhost`.
+    pub fn host<H: Into<String>>(mut self, host: H) -> Self {
+        self.host = Some(host.into());
         self
     }
 

--- a/plugins/localhost/src/lib.rs
+++ b/plugins/localhost/src/lib.rs
@@ -46,6 +46,7 @@ type OnRequest = Option<Box<dyn Fn(&Request, &mut Response) + Send + Sync>>;
 
 pub struct Builder {
     port: u16,
+    host: Option<String>,
     on_request: OnRequest,
 }
 
@@ -53,10 +54,16 @@ impl Builder {
     pub fn new(port: u16) -> Self {
         Self {
             port,
+            host: None,
             on_request: None,
         }
     }
 
+    pub fn host<H: AsRef<str>>(mut self, host: H) -> Self {
+        self.host = Some(host.as_ref().to_string());
+        self
+    }
+    
     pub fn on_request<F: Fn(&Request, &mut Response) + Send + Sync + 'static>(
         mut self,
         f: F,
@@ -67,6 +74,7 @@ impl Builder {
 
     pub fn build<R: Runtime>(mut self) -> TauriPlugin<R> {
         let port = self.port;
+        let host = self.host.unwrap_or("localhost".to_string());
         let on_request = self.on_request.take();
 
         PluginBuilder::new("localhost")
@@ -74,7 +82,7 @@ impl Builder {
                 let asset_resolver = app.asset_resolver();
                 std::thread::spawn(move || {
                     let server =
-                        Server::http(format!("localhost:{port}")).expect("Unable to spawn server");
+                        Server::http(format!("{host}:{port}")).expect("Unable to spawn server");
                     for req in server.incoming_requests() {
                         let path = req
                             .url()

--- a/plugins/localhost/src/lib.rs
+++ b/plugins/localhost/src/lib.rs
@@ -63,7 +63,7 @@ impl Builder {
         self.host = Some(host.as_ref().to_string());
         self
     }
-    
+
     pub fn on_request<F: Fn(&Request, &mut Response) + Send + Sync + 'static>(
         mut self,
         f: F,


### PR DESCRIPTION
This PR introduces the ability to specify a custom host binding for the server, allowing external access. Previously, the server was hardcoded to bind to `localhost`, limiting accessibility to only the local machine. With this change, users can configure the server to bind to any IP address or hostname, including `0.0.0.0`, which enables connections from external devices.
