### PR TITLE
fix(clipboard-manager): `read_image` wrongly set the image rgba data with binary PNG data.

### DIFF
--- a/.changes/fix-1985.md
+++ b/.changes/fix-1985.md
@@ -1,0 +1,5 @@
+---
+"clipboard-manager": patch
+---
+
+Fix that `read_image` wrongly set the image rgba data with binary PNG data.

--- a/plugins/clipboard-manager/Cargo.toml
+++ b/plugins/clipboard-manager/Cargo.toml
@@ -37,4 +37,3 @@ tauri = { workspace = true, features = ["wry"] }
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 arboard = "3"
-image = "0.25"

--- a/plugins/clipboard-manager/src/desktop.rs
+++ b/plugins/clipboard-manager/src/desktop.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: MIT
 
 use arboard::ImageData;
-use image::ImageEncoder;
 use serde::de::DeserializeOwned;
 use tauri::{image::Image, plugin::PluginApi, AppHandle, Runtime};
 
@@ -85,16 +84,7 @@ impl<R: Runtime> Clipboard<R> {
         match &self.clipboard {
             Ok(clipboard) => {
                 let image = clipboard.lock().unwrap().get_image()?;
-
-                let mut buffer: Vec<u8> = Vec::new();
-                image::codecs::png::PngEncoder::new(&mut buffer).write_image(
-                    &image.bytes,
-                    image.width as u32,
-                    image.height as u32,
-                    image::ExtendedColorType::Rgba8,
-                )?;
-
-                let image = Image::new_owned(buffer, image.width as u32, image.height as u32);
+                let image = Image::new_owned(image.bytes.to_vec(), image.width as u32, image.height as u32);
                 Ok(image)
             }
             Err(e) => Err(crate::Error::Clipboard(e.to_string())),

--- a/plugins/clipboard-manager/src/desktop.rs
+++ b/plugins/clipboard-manager/src/desktop.rs
@@ -84,7 +84,11 @@ impl<R: Runtime> Clipboard<R> {
         match &self.clipboard {
             Ok(clipboard) => {
                 let image = clipboard.lock().unwrap().get_image()?;
-                let image = Image::new_owned(image.bytes.to_vec(), image.width as u32, image.height as u32);
+                let image = Image::new_owned(
+                    image.bytes.to_vec(),
+                    image.width as u32,
+                    image.height as u32,
+                );
                 Ok(image)
             }
             Err(e) => Err(crate::Error::Clipboard(e.to_string())),

--- a/plugins/clipboard-manager/src/error.rs
+++ b/plugins/clipboard-manager/src/error.rs
@@ -15,9 +15,6 @@ pub enum Error {
     Clipboard(String),
     #[error(transparent)]
     Tauri(#[from] tauri::Error),
-    #[cfg(desktop)]
-    #[error("invalid image: {0}")]
-    Image(#[from] image::ImageError),
 }
 
 impl Serialize for Error {


### PR DESCRIPTION
fix #1985 

The dependency of `image` crate may be unnecessary now. I'm not sure whether it should be removed.