### PR TITLE
fix(window-state): Ignore is_maximized state in resize events on macos

### DIFF
--- a/.changes/window-state-disable-maximize-check.md
+++ b/.changes/window-state-disable-maximize-check.md
@@ -1,0 +1,5 @@
+---
+window-state: patch
+---
+
+On macOS the plugin now (temporarily) ignores the maximized state for undecorated windows on resize events to fix app freezes.

--- a/plugins/window-state/src/lib.rs
+++ b/plugins/window-state/src/lib.rs
@@ -471,13 +471,23 @@ impl Builder {
                             .0
                             .try_lock()
                             .is_ok()
-                            && !window_clone.is_minimized().unwrap_or_default()
-                            && !window_clone.is_maximized().unwrap_or_default()
                         {
-                            let mut c = cache.lock().unwrap();
-                            if let Some(state) = c.get_mut(&label) {
-                                state.width = size.width;
-                                state.height = size.height;
+                            // TODO: Remove once https://github.com/tauri-apps/tauri/issues/5812 is resolved.
+                            let is_maximized = if cfg!(target_os = "macos")
+                                && (!window_clone.is_decorated().unwrap_or_default()
+                                    || !window_clone.is_resizable().unwrap_or_default())
+                            {
+                                false
+                            } else {
+                                window_clone.is_maximized().unwrap_or_default()
+                            };
+
+                            if !window_clone.is_minimized().unwrap_or_default() && !is_maximized {
+                                let mut c = cache.lock().unwrap();
+                                if let Some(state) = c.get_mut(&label) {
+                                    state.width = size.width;
+                                    state.height = size.height;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
fixes #1918

i don't have the brain capacity right now to find an actual workaround or even fix the underlying issue so this has to do for now.