### PR TITLE
fix(deep-link): Remove getCurrent call in onOpenUrl

### DIFF
--- a/.changes/fix-deep-link-onopenurl-current.md
+++ b/.changes/fix-deep-link-onopenurl-current.md
@@ -1,0 +1,5 @@
+---
+deep-link-js: patch
+---
+
+`onOpenUrl()` will now not call `getCurrent()` anymore, matching the documented behavior.

--- a/.changes/fix-deep-link-onopenurl-current.md
+++ b/.changes/fix-deep-link-onopenurl-current.md
@@ -1,4 +1,5 @@
 ---
+deep-link: patch
 deep-link-js: patch
 ---
 

--- a/plugins/deep-link/guest-js/index.ts
+++ b/plugins/deep-link/guest-js/index.ts
@@ -99,11 +99,6 @@ export async function isRegistered(protocol: string): Promise<boolean> {
 export async function onOpenUrl(
   handler: (urls: string[]) => void
 ): Promise<UnlistenFn> {
-  const current = await getCurrent()
-  if (current) {
-    handler(current)
-  }
-
   return await listen<string[]>('deep-link://new-url', (event) => {
     handler(event.payload)
   })

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -478,13 +478,10 @@ impl OpenUrlEvent {
 }
 
 impl<R: Runtime> DeepLink<R> {
-    /// Handle a new deep link being triggered to open the app.
+    /// Helper function for the `deep-link://new-url` event to run a function each time the protocol is triggered while the app is running.
     ///
-    /// To avoid race conditions, if the app was started with a deep link,
-    /// the closure gets immediately called with the deep link URL.
+    /// Use `get_current` on app load to check whether your app was started via a deep link.
     pub fn on_open_url<F: Fn(OpenUrlEvent) + Send + Sync + 'static>(&self, f: F) -> EventId {
-        let f = Arc::new(f);
-        let f_ = f.clone();
         let event_id = self.app.listen("deep-link://new-url", move |event| {
             if let Ok(urls) = serde_json::from_str(event.payload()) {
                 f(OpenUrlEvent {
@@ -493,13 +490,6 @@ impl<R: Runtime> DeepLink<R> {
                 })
             }
         });
-
-        if let Ok(Some(current)) = self.get_current() {
-            f_(OpenUrlEvent {
-                id: event_id,
-                urls: current,
-            })
-        }
 
         event_id
     }

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::sync::Arc;
-
 use tauri::{
     plugin::{Builder, PluginApi, TauriPlugin},
     AppHandle, EventId, Listener, Manager, Runtime,


### PR DESCRIPTION
I received multiple reports that this behavior causes issues, like when reloading pages or re-mounting components. It's also not the behavior people seem to expect. Also, the function docs actually told users to use getCurrent themselves.

I'm not 100% sure about the rust side. The issues you see on the rust side aren't as apparent and the docs are also correct there but i think it would make sense to also change it.