### PR TITLE
feat(upload): add `progressTotal` to event payload

### DIFF
--- a/.changes/add-total-transferred-field.md
+++ b/.changes/add-total-transferred-field.md
@@ -3,4 +3,4 @@
 "upload-js": "minor"
 ---
 
-Added a new field `total_transferred` (or `progressTotal` in JS) to track the total amount of data transferred during the upload/download process.
+Added a new field `progressTotal` to track the total amount of data transferred during the upload/download process.

--- a/.changes/add-total-transferred-field.md
+++ b/.changes/add-total-transferred-field.md
@@ -1,0 +1,6 @@
+---
+"upload": "minor"
+"upload-js": "minor"
+---
+
+Added a new field `total_transferred` (or `progressTotal` in JS) to track the total amount of data transferred during the upload/download process.

--- a/plugins/upload/guest-js/index.ts
+++ b/plugins/upload/guest-js/index.ts
@@ -6,6 +6,7 @@ import { invoke, Channel } from '@tauri-apps/api/core'
 
 interface ProgressPayload {
   progress: number
+  progressTotal: number
   total: number
   transferSpeed: number
 }

--- a/plugins/upload/src/lib.rs
+++ b/plugins/upload/src/lib.rs
@@ -61,6 +61,7 @@ impl Serialize for Error {
 #[serde(rename_all = "camelCase")]
 struct ProgressPayload {
     progress: u64,
+    progress_total: u64,
     total: u64,
     transfer_speed: u64,
 }
@@ -98,7 +99,8 @@ async fn download(
         file.write_all(&chunk).await?;
         stats.record_chunk_transfer(chunk.len());
         let _ = on_progress.send(ProgressPayload {
-            progress: stats.total_transferred,
+            progress: chunk.len() as u64,
+            progress_total: stats.total_transferred,
             total,
             transfer_speed: stats.transfer_speed,
         });
@@ -153,6 +155,7 @@ fn file_to_body(channel: Channel<ProgressPayload>, file: File) -> reqwest::Body 
             stats.record_chunk_transfer(progress as usize);
             let _ = channel.send(ProgressPayload {
                 progress,
+                progress_total: stats.total_transferred,
                 total,
                 transfer_speed: stats.transfer_speed,
             });

--- a/plugins/upload/src/lib.rs
+++ b/plugins/upload/src/lib.rs
@@ -98,7 +98,7 @@ async fn download(
         file.write_all(&chunk).await?;
         stats.record_chunk_transfer(chunk.len());
         let _ = on_progress.send(ProgressPayload {
-            progress: chunk.len() as u64,
+            progress: stats.total_transferred,
             total,
             transfer_speed: stats.transfer_speed,
         });

--- a/plugins/upload/src/transfer_stats.rs
+++ b/plugins/upload/src/transfer_stats.rs
@@ -4,11 +4,12 @@
 
 use std::time::Instant;
 
-// The TransferStats struct is used to track and calculate the transfer speed of data chunks over time.
+// The TransferStats struct tracks both transfer speed and cumulative transfer progress.
 pub struct TransferStats {
     accumulated_chunk_len: usize, // Total length of chunks transferred in the current period
     accumulated_time: u128,       // Total time taken for the transfers in the current period
     pub transfer_speed: u64,      // Calculated transfer speed in bytes per second
+    pub total_transferred: u64,   // Cumulative total of all transferred data
     start_time: Instant,          // Time when the current period started
     granularity: u32, // Time period (in milliseconds) over which the transfer speed is calculated
 }
@@ -20,18 +21,20 @@ impl TransferStats {
             accumulated_chunk_len: 0,
             accumulated_time: 0,
             transfer_speed: 0,
+            total_transferred: 0,
             start_time: Instant::now(),
             granularity,
         }
     }
-    // Records the transfer of a data chunk and updates the transfer speed if the granularity period has elapsed.
+    // Records the transfer of a data chunk and updates both transfer speed and total progress.
     pub fn record_chunk_transfer(&mut self, chunk_len: usize) {
         let now = Instant::now();
         let it_took = now.duration_since(self.start_time).as_millis();
         self.accumulated_chunk_len += chunk_len;
+        self.total_transferred += chunk_len as u64;
         self.accumulated_time += it_took;
 
-        // If the accumulated time exceeds the granularity, calculate the transfer speed.
+        // Calculate transfer speed if accumulated time exceeds granularity.
         if self.accumulated_time >= self.granularity as u128 {
             self.transfer_speed =
                 (self.accumulated_chunk_len as u128 / self.accumulated_time * 1024) as u64;
@@ -47,6 +50,6 @@ impl TransferStats {
 // Provides a default implementation for TransferStats with a granularity of 500 milliseconds.
 impl Default for TransferStats {
     fn default() -> Self {
-        Self::start(500) // Default granularity is 500
+        Self::start(500) // Default granularity is 500 ms
     }
 }


### PR DESCRIPTION
This pull request addresses an issue with progress tracking during downloads. Previously, progress was updated using `chunk.len()`, which only reflected the size of each individual chunk rather than the cumulative total.

Changes:

Progress Calculation: Replaced `chunk.len()` with `stats.total_transferred` for progress, ensuring it accurately reflects the cumulative download progress from start to end.

TransferStats Update: Added `total_transferred` to `TransferStats` to maintain an ongoing count of all transferred bytes without resetting per granularity interval.