### PR TITLE
fix(sql) Allow tauri-plugin-sql to work when Tauri is running async

### DIFF
--- a/.changes/sql-allow-blocking-without-nested-runtime.md
+++ b/.changes/sql-allow-blocking-without-nested-runtime.md
@@ -1,0 +1,5 @@
+---
+"sql": "patch"
+---
+
+Allow blocking on async code without creating a nested runtime.

--- a/plugins/sql/src/lib.rs
+++ b/plugins/sql/src/lib.rs
@@ -106,7 +106,11 @@ impl MigrationSource<'static> for MigrationList {
 
 /// Allows blocking on async code without creating a nested runtime.
 fn run_async_command<F: std::future::Future>(cmd: F) -> F::Output {
-    tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(cmd))
+    if tokio::runtime::Handle::try_current().is_ok() {
+        tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(cmd))
+    } else {
+        tauri::async_runtime::block_on(cmd)
+    }
 }
 
 /// Tauri SQL plugin builder.

--- a/plugins/sql/src/lib.rs
+++ b/plugins/sql/src/lib.rs
@@ -104,10 +104,9 @@ impl MigrationSource<'static> for MigrationList {
     }
 }
 
-macro_rules! run_async_command {
-    ($cmd:expr) => {
-        tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on($cmd))
-    };
+/// Allows blocking on async code without creating a nested runtime.
+fn run_async_command<F: std::future::Future>(cmd: F) -> F::Output {
+    tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(cmd))
 }
 
 /// Tauri SQL plugin builder.
@@ -144,7 +143,7 @@ impl Builder {
             .setup(|app, api| {
                 let config = api.config().clone().unwrap_or_default();
 
-                run_async_command!(async move {
+                run_async_command(async move {
                     let instances = DbInstances::default();
                     let mut lock = instances.0.write().await;
 
@@ -172,7 +171,7 @@ impl Builder {
             })
             .on_event(|app, event| {
                 if let RunEvent::Exit = event {
-                    run_async_command!(async move {
+                    run_async_command(async move {
                         let instances = &*app.state::<DbInstances>();
                         let instances = instances.0.read().await;
                         for value in instances.values() {

--- a/plugins/sql/src/lib.rs
+++ b/plugins/sql/src/lib.rs
@@ -104,6 +104,12 @@ impl MigrationSource<'static> for MigrationList {
     }
 }
 
+macro_rules! run_async_command {
+    ($cmd:expr) => {
+        tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on($cmd))
+    };
+}
+
 /// Tauri SQL plugin builder.
 #[derive(Default)]
 pub struct Builder {
@@ -138,7 +144,7 @@ impl Builder {
             .setup(|app, api| {
                 let config = api.config().clone().unwrap_or_default();
 
-                tauri::async_runtime::block_on(async move {
+                run_async_command!(async move {
                     let instances = DbInstances::default();
                     let mut lock = instances.0.write().await;
 
@@ -166,7 +172,7 @@ impl Builder {
             })
             .on_event(|app, event| {
                 if let RunEvent::Exit = event {
-                    tauri::async_runtime::block_on(async move {
+                    run_async_command!(async move {
                         let instances = &*app.state::<DbInstances>();
                         let instances = instances.0.read().await;
                         for value in instances.values() {


### PR DESCRIPTION
At present, `tauri-plugin-sql` only works when the main Tauri thread is using the default, synchronous runtime. 

In certain configurations, running Tauri asynchronously can be necessary, ie when using TaurPC or other dependencies that require it.

With the current configuration, running Tauri asynchronously while trying to use `tauri-plugin-sql` yields this error:

```
thread 'main' panicked at ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/mod.rs:86:9:
Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

By changing the `block_on` function call in `sql/lib.rs` to the macro provided, the plugin works flawlessly, in both synchronous and asynchronous runtimes.

Please let me know if more information is needed!