### PR TITLE
fix: #1692 

### DIFF
--- a/plugins/single-instance/src/platform_impl/windows.rs
+++ b/plugins/single-instance/src/platform_impl/windows.rs
@@ -64,8 +64,12 @@ pub fn init<R: Runtime>(f: Box<SingleInstanceCallback<R>>) -> TauriPlugin<R> {
                             cbData: bytes.len() as _,
                             lpData: bytes.as_ptr() as _,
                         };
-                        SendMessageW(hwnd, WM_COPYDATA, 0, &cds as *const _ as _);
-                        app.exit(0);
+                        let contains_restart = data.split('|').any(|part| part.trim() == "restart_from_tauri_api\0");
+                        // Single instance mode should not cause restarted applications to exit
+                        if !contains_restart {
+                            SendMessageW(hwnd, WM_COPYDATA, 0, &cds as *const _ as _);
+                            app.exit(0);
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Single instance mode should not cause restarted applications to exit.

We can add an additional `restart_from_tauri_api` parameter to tauri::api::process::restart to tell single-instance that this startup should not be blocked.

link tauri api process model changes: [#11684](https://github.com/tauri-apps/tauri/pull/11684)