### PR TITLE
fix(dialog): improve file type handling and media type checks

### DIFF
--- a/plugins/dialog/src/commands.rs
+++ b/plugins/dialog/src/commands.rs
@@ -25,8 +25,8 @@ pub enum OpenResponse {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
 pub struct DialogFilter {
     name: String,
     extensions: Vec<String>,


### PR DESCRIPTION
Fixes bug #1578, allowing different file types on iOS to correctly use the image picker and document picker. This update also addresses issues discussed in #1596 and #1984.