### PR TITLE
docs(clipboard-manager): update readImage doc to use async rgba() instead of bytes

### DIFF
--- a/plugins/clipboard-manager/guest-js/index.ts
+++ b/plugins/clipboard-manager/guest-js/index.ts
@@ -90,7 +90,7 @@ async function writeImage(
  * import { readImage } from '@tauri-apps/plugin-clipboard-manager';
  *
  * const clipboardImage = await readImage();
- * const blob = new Blob([clipboardImage.bytes], { type: 'image' })
+ * const blob = new Blob([await clipboardImage.rbga()], { type: 'image' })
  * const url = URL.createObjectURL(blob)
  * ```
  * @since 2.0.0


### PR DESCRIPTION
Updated the doc comments of readImage function