### PR TITLE
feat(http): add request and response tracing behind feature flag

### DIFF
--- a/.changes/http-tracing.md
+++ b/.changes/http-tracing.md
@@ -1,0 +1,5 @@
+---
+"http": "patch"
+---
+
+Add tracing logs for requestes and responses behind `tracing` feature flag.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6615,6 +6615,7 @@ version = "2.0.3"
 dependencies = [
  "data-url",
  "http",
+ "log",
  "regex",
  "reqwest",
  "schemars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6456,7 +6456,6 @@ name = "tauri-plugin-autostart"
 version = "2.0.1"
 dependencies = [
  "auto-launch",
- "log",
  "serde",
  "serde_json",
  "tauri",
@@ -6520,7 +6519,6 @@ name = "tauri-plugin-deep-link"
 version = "2.0.1"
 dependencies = [
  "dunce",
- "log",
  "rust-ini",
  "serde",
  "serde_json",
@@ -6528,6 +6526,7 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.3",
+ "tracing",
  "url",
  "windows-registry 0.3.0",
  "windows-result 0.2.0",
@@ -6615,7 +6614,6 @@ version = "2.0.3"
 dependencies = [
  "data-url",
  "http",
- "log",
  "regex",
  "reqwest",
  "schemars",
@@ -6626,6 +6624,7 @@ dependencies = [
  "tauri-plugin-fs",
  "thiserror 2.0.3",
  "tokio",
+ "tracing",
  "url",
  "urlpattern",
 ]
@@ -6792,13 +6791,13 @@ dependencies = [
 name = "tauri-plugin-single-instance"
 version = "2.0.1"
 dependencies = [
- "log",
  "semver",
  "serde",
  "serde_json",
  "tauri",
  "tauri-plugin-deep-link",
  "thiserror 2.0.3",
+ "tracing",
  "windows-sys 0.59.0",
  "zbus 4.4.0",
 ]
@@ -6825,13 +6824,13 @@ name = "tauri-plugin-store"
 version = "2.1.0"
 dependencies = [
  "dunce",
- "log",
  "serde",
  "serde_json",
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.3",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
+tracing = "0.1"
 log = "0.4"
 tauri = { version = "2", default-features = false }
 tauri-build = "2"

--- a/plugins/autostart/Cargo.toml
+++ b/plugins/autostart/Cargo.toml
@@ -27,6 +27,5 @@ tauri-plugin = { workspace = true, features = ["build"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tauri = { workspace = true }
-log = { workspace = true }
 thiserror = { workspace = true }
 auto-launch = "0.5"

--- a/plugins/autostart/src/lib.rs
+++ b/plugins/autostart/src/lib.rs
@@ -11,8 +11,6 @@
 #![cfg(not(any(target_os = "android", target_os = "ios")))]
 
 use auto_launch::{AutoLaunch, AutoLaunchBuilder};
-#[cfg(target_os = "macos")]
-use log::info;
 use serde::{ser::Serializer, Serialize};
 use tauri::{
     command,
@@ -133,7 +131,6 @@ pub fn init<R: Runtime>(
                     } else {
                         exe_path
                     };
-                info!("auto_start path {}", &app_path);
                 builder.set_app_path(&app_path);
             }
             #[cfg(target_os = "linux")]

--- a/plugins/deep-link/Cargo.toml
+++ b/plugins/deep-link/Cargo.toml
@@ -32,7 +32,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tauri = { workspace = true }
 tauri-utils = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -215,7 +215,7 @@ mod imp {
                         current.replace(vec![url.clone()]);
                         let _ = self.app.emit("deep-link://new-url", vec![url]);
                     } else if cfg!(debug_assertions) {
-                        log::warn!("argument {url} does not match any configured deep link scheme; skipping it");
+                        tracing::warn!("argument {url} does not match any configured deep link scheme; skipping it");
                     }
                 }
             }

--- a/plugins/http/Cargo.toml
+++ b/plugins/http/Cargo.toml
@@ -41,6 +41,7 @@ http = "1"
 reqwest = { version = "0.12", default-features = false }
 url = { workspace = true }
 data-url = "0.3"
+log = { workspace = true, optional = true }
 
 [features]
 default = [
@@ -71,3 +72,4 @@ http2 = ["reqwest/http2"]
 charset = ["reqwest/charset"]
 macos-system-configuration = ["reqwest/macos-system-configuration"]
 unsafe-headers = []
+tracing = ["dep:log"]

--- a/plugins/http/Cargo.toml
+++ b/plugins/http/Cargo.toml
@@ -41,7 +41,7 @@ http = "1"
 reqwest = { version = "0.12", default-features = false }
 url = { workspace = true }
 data-url = "0.3"
-log = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 
 [features]
 default = [
@@ -72,4 +72,4 @@ http2 = ["reqwest/http2"]
 charset = ["reqwest/charset"]
 macos-system-configuration = ["reqwest/macos-system-configuration"]
 unsafe-headers = []
-tracing = ["dep:log"]
+tracing = ["dep:tracing"]

--- a/plugins/http/src/commands.rs
+++ b/plugins/http/src/commands.rs
@@ -283,6 +283,9 @@ pub async fn fetch<R: Runtime>(
 
                 request = request.headers(headers);
 
+                #[cfg(feature = "tracing")]
+                log::trace!("{:?}", request);
+
                 let fut = async move { request.send().await.map_err(Into::into) };
                 let mut resources_table = webview.resources_table();
                 let rid = resources_table.add_request(Box::pin(fut));
@@ -303,6 +306,9 @@ pub async fn fetch<R: Runtime>(
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, data_url.mime_type().to_string())
                 .body(reqwest::Body::from(body))?;
+
+            #[cfg(feature = "tracing")]
+            log::trace!("{:?}", response);
 
             let fut = async move { Ok(reqwest::Response::from(response)) };
             let mut resources_table = webview.resources_table();
@@ -350,6 +356,9 @@ pub async fn fetch_send<R: Runtime>(
             return Err(Error::RequestCanceled);
         }
     };
+
+    #[cfg(feature = "tracing")]
+    log::trace!("{:?}", res);
 
     let status = res.status();
     let url = res.url().to_string();

--- a/plugins/http/src/commands.rs
+++ b/plugins/http/src/commands.rs
@@ -284,7 +284,7 @@ pub async fn fetch<R: Runtime>(
                 request = request.headers(headers);
 
                 #[cfg(feature = "tracing")]
-                log::trace!("{:?}", request);
+                tracing::trace!("{:?}", request);
 
                 let fut = async move { request.send().await.map_err(Into::into) };
                 let mut resources_table = webview.resources_table();
@@ -308,7 +308,7 @@ pub async fn fetch<R: Runtime>(
                 .body(reqwest::Body::from(body))?;
 
             #[cfg(feature = "tracing")]
-            log::trace!("{:?}", response);
+            tracing::trace!("{:?}", response);
 
             let fut = async move { Ok(reqwest::Response::from(response)) };
             let mut resources_table = webview.resources_table();
@@ -358,7 +358,7 @@ pub async fn fetch_send<R: Runtime>(
     };
 
     #[cfg(feature = "tracing")]
-    log::trace!("{:?}", res);
+    tracing::trace!("{:?}", res);
 
     let status = res.status();
     let url = res.url().to_string();

--- a/plugins/single-instance/Cargo.toml
+++ b/plugins/single-instance/Cargo.toml
@@ -24,7 +24,7 @@ ios = { level = "none", notes = "" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tauri = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 thiserror = { workspace = true }
 tauri-plugin-deep-link = { path = "../deep-link", version = "2.0.1", optional = true }
 semver = { version = "1", optional = true }

--- a/plugins/single-instance/src/platform_impl/macos.rs
+++ b/plugins/single-instance/src/platform_impl/macos.rs
@@ -34,7 +34,7 @@ pub fn init<R: Runtime>(cb: Box<SingleInstanceCallback<R>>) -> TauriPlugin<R> {
                             listen_for_other_instances(&socket, app.clone(), cb);
                         }
                         _ => {
-                            log::debug!(
+                            tracing::debug!(
                                 "single_instance failed to notify - launching normally: {}",
                                 e
                             );
@@ -108,11 +108,13 @@ fn listen_for_other_instances<A: Runtime>(
                                         s.split('\0').map(String::from).collect();
                                     cb(app.app_handle(), args, cwd.clone());
                                 }
-                                Err(e) => log::debug!("single_instance failed to be notified: {e}"),
+                                Err(e) => {
+                                    tracing::debug!("single_instance failed to be notified: {e}")
+                                }
                             }
                         }
                         Err(err) => {
-                            log::debug!("single_instance failed to be notified: {}", err);
+                            tracing::debug!("single_instance failed to be notified: {}", err);
                             continue;
                         }
                     }
@@ -120,7 +122,7 @@ fn listen_for_other_instances<A: Runtime>(
             });
         }
         Err(err) => {
-            log::error!(
+            tracing::error!(
                 "single_instance failed to listen to other processes - launching normally: {}",
                 err
             );

--- a/plugins/store/Cargo.toml
+++ b/plugins/store/Cargo.toml
@@ -27,7 +27,7 @@ tauri-plugin = { workspace = true, features = ["build"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tauri = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 thiserror = { workspace = true }
 dunce = { workspace = true }
 tokio = { version = "1", features = ["sync", "time", "macros"] }

--- a/plugins/store/src/lib.rs
+++ b/plugins/store/src/lib.rs
@@ -432,7 +432,7 @@ impl Builder {
                     for (path, rid) in stores.iter() {
                         if let Ok(store) = app_handle.resources_table().get::<Store<R>>(*rid) {
                             if let Err(err) = store.save() {
-                                log::error!("failed to save store {path:?} with error {err:?}");
+                                tracing::error!("failed to save store {path:?} with error {err:?}");
                             }
                         }
                     }


### PR DESCRIPTION
closes #2055


Users can use tauri-plugin-log or CrabeNebula devtools to inspect the requests and responses.