### PR TITLE
docs(deep-link): Fix js inline docs

### DIFF
--- a/plugins/deep-link/guest-js/index.ts
+++ b/plugins/deep-link/guest-js/index.ts
@@ -73,7 +73,7 @@ export async function unregister(protocol: string): Promise<null> {
  * await isRegistered("my-scheme");
  * ```
  *
- * #### - **macOS / Android / iOS**: Unsupported, always returns `true`.
+ * #### - **macOS / Android / iOS**: Unsupported.
  *
  * @since 2.0.0
  */
@@ -92,7 +92,7 @@ export async function isRegistered(protocol: string): Promise<boolean> {
  * await onOpenUrl((urls) => { console.log(urls) });
  * ```
  *
- * #### - **Windows / Linux**: Unsupported, the OS will spawn a new app instance passing the URL as a CLI argument.
+ * #### - **Windows / Linux**: Unsupported without the single-instance plugin. The OS will spawn a new app instance passing the URL as a CLI argument.
  *
  * @since 2.0.0
  */


### PR DESCRIPTION
isRegistered does _not_ return a boolean and hasn't been for a long time (since i added desktop support), i just forgot to update the js docs.