### PR TITLE
docs(store): Fix file reference

### DIFF
--- a/plugins/store/README.md
+++ b/plugins/store/README.md
@@ -54,7 +54,7 @@ yarn add https://github.com/tauri-apps/tauri-plugin-store#v2
 
 First you need to register the core plugin with Tauri:
 
-`src-tauri/src/main.rs`
+`src-tauri/src/lib.rs`
 
 ```rust
 fn main() {


### PR DESCRIPTION
Fixes references to file in readme from main.rs to lib.rs where the code being referred to actually is.