### PR TITLE
docs(clipboard-manager): Added missing codeblock quotes in inline code docs

### DIFF
--- a/plugins/clipboard-manager/guest-js/index.ts
+++ b/plugins/clipboard-manager/guest-js/index.ts
@@ -65,6 +65,7 @@ async function readText(): Promise<string> {
  *   0, 255, 0, 255,
  * ];
  * await writeImage(buffer);
+ * ```
  *
  * @returns A promise indicating the success or failure of the operation.
  *


### PR DESCRIPTION
Added missing codeblock quotes (\`\`\`)  to inline source code documentation for `clipboard-manager`

so the documentation's formatting can be fixed
<img width="609" alt="Снимок экрана 2024-12-03 в 8 31 27 PM" src="https://github.com/user-attachments/assets/bbd88105-577a-4eb8-97eb-3b8fa4f5d5fd">
