### PR TITLE
fix(opener): use the correct packagename in OpenerPlugin.kt

### DIFF
--- a/.changes/fix-opener-android-packagename.md
+++ b/.changes/fix-opener-android-packagename.md
@@ -1,5 +1,6 @@
 ---
 "opener": patch
+"opener-js": patch
 ---
 
 Fixed OpenerPlugin packagename for android

--- a/.changes/fix-opener-android-packagename.md
+++ b/.changes/fix-opener-android-packagename.md
@@ -1,0 +1,5 @@
+---
+"opener": patch
+---
+
+Fixed OpenerPlugin packagename for android

--- a/plugins/opener/android/src/main/java/OpenerPlugin.kt
+++ b/plugins/opener/android/src/main/java/OpenerPlugin.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-package app.tauri.shell
+package app.tauri.opener
 
 import android.app.Activity
 import android.content.Intent


### PR DESCRIPTION
The packagename in OpenerPlugin.kt was set to 'package app.tauri.shell' which leads to an ClassNotFoundException when using android as the PLUGIN_IDENTIFIER in lib.rs is set to app.tauri.opener.

I fixed the packagename according to the value in lib.rs (app.tauri.opener)