### PR TITLE
refactor(shell): Use &self instead of self to allow kill to be called multiple times.

### DIFF
--- a/.changes/change-pr-2224.md
+++ b/.changes/change-pr-2224.md
@@ -1,0 +1,5 @@
+---
+"shell": patch
+---
+
+Use &self instead of self to allow kill to be called multiple times. 

--- a/.changes/change-pr-2224.md
+++ b/.changes/change-pr-2224.md
@@ -1,5 +1,6 @@
 ---
 "shell": patch
+"shell-js": patch
 ---
 
-Use &self instead of self to allow kill to be called multiple times. 
+Use &self instead of self to allow kill to be called multiple times.

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -80,13 +80,6 @@ impl CommandChild {
         Ok(())
     }
 
-    /// Return the child's exit status if it has already exited. If the child is
-    /// still running, return `Ok(None)`.
-    pub fn exit_status(&self) -> crate::Result<Option<ExitStatus>> {
-        let status = self.inner.try_wait()?;
-        Ok(status.map(|s| ExitStatus { code: s.code() }))
-    }
-
     /// Returns the process pid.
     pub fn pid(&self) -> u32 {
         self.inner.id()

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -75,7 +75,7 @@ impl CommandChild {
     }
 
     /// Sends a kill signal to the child.
-    pub fn kill(self) -> crate::Result<()> {
+    pub fn kill(&self) -> crate::Result<()> {
         self.inner.kill()?;
         Ok(())
     }

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -80,6 +80,13 @@ impl CommandChild {
         Ok(())
     }
 
+    /// Return the child's exit status if it has already exited. If the child is
+    /// still running, return `Ok(None)`.
+    pub fn exit_status(&self) -> crate::Result<Option<ExitStatus>> {
+        let status = self.inner.try_wait()?;
+        Ok(status.map(|s| ExitStatus { code: s.code() }))
+    }
+
     /// Returns the process pid.
     pub fn pid(&self) -> u32 {
         self.inner.id()


### PR DESCRIPTION
### Description

This refactor modifies the kill method in the CommandChild struct to take a reference (&self) instead of consuming the instance (self). This change allows the kill method to be called multiple times on the same CommandChild instance, providing more flexibility in managing child processes.

### Use Case


```
use tauri_plugin_shell::process::Command;
use std::time::Duration;
use std::thread::sleep;

fn main() -> Result<(), Box<dyn std::error::Error>> {
    // Create a new command to run a long-running process
    let process = Command::new("sleep").arg("10").spawn()?;

    // Attempt to kill the process multiple times in a loop
    loop {
        process.kill()?;
        // Do something to check if the process still exists?
        // ...
        sleep(Duration::from_secs(1));
    }

    Ok(())
}
```