### PR TITLE
fix(opener): return error if path not exists

### DIFF
--- a/.changes/fix-opener-open-path-error.md
+++ b/.changes/fix-opener-open-path-error.md
@@ -1,0 +1,5 @@
+---
+"opener": patch
+"opener-js": patch
+---
+`open_path` now returns an error if the file does not exist

--- a/.changes/fix-opener-open-path-error.md
+++ b/.changes/fix-opener-open-path-error.md
@@ -2,4 +2,5 @@
 "opener": patch
 "opener-js": patch
 ---
-`open_path` now returns an error if the file does not exist
+
+Return an error in `open_path` if the file does not exist when opening with default application.

--- a/plugins/opener/src/open.rs
+++ b/plugins/opener/src/open.rs
@@ -53,5 +53,9 @@ pub fn open_url<P: AsRef<str>, S: AsRef<str>>(url: P, with: Option<S>) -> crate:
 /// ```
 pub fn open_path<P: AsRef<Path>, S: AsRef<str>>(path: P, with: Option<S>) -> crate::Result<()> {
     let path = path.as_ref();
+    if with.is_none() {
+        // Returns an IO error if not exists, and besides `exists()` is a shorthand for `metadata()`
+        _ = path.metadata()?;
+    }
     open(path, with)
 }


### PR DESCRIPTION
From discussion on Discord. This PR checks that the path exists before shelling out to the "launcher". This helps with the common error that a file doesn't exist, and thus cannot be opened.

This is needed because we open files & urls "detached" in a separate thread, so we can't alert users if the action failed.