### PR TITLE
 docs(fs): fix link to path API

### DIFF
--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -10,7 +10,7 @@
  * This module prevents path traversal, not allowing parent directory accessors to be used
  * (i.e. "/usr/path/to/../file" or "../path/to/file" paths are not allowed).
  * Paths accessed with this API must be either relative to one of the {@link BaseDirectory | base directories}
- * or created with the {@link https://v2.tauri.app/reference/javascript/api/namespacepath | path API}.
+ * or created with the {@link https://v2.tauri.app/reference/javascript/api/namespacepath/ | path API}.
  *
  * The API has a scope configuration that forces you to restrict the paths that can be accessed using glob patterns.
  *


### PR DESCRIPTION
Getting an error in Chrome when trailing slash is omitted

The link is in the 1st paragraph on this page https://v2.tauri.app/reference/javascript/fs/#security

![image](https://github.com/user-attachments/assets/be2bc7dd-089a-4ea7-b88e-b957feda088e)