### PR TITLE
[log] add mention of cability to log plugin README.md

### DIFF
--- a/plugins/log/README.md
+++ b/plugins/log/README.md
@@ -54,7 +54,23 @@ yarn add https://github.com/tauri-apps/tauri-plugin-log#v2
 
 ## Usage
 
-First you need to register the core plugin with Tauri:
+First, you should enable the `log:default` capability:
+
+```json
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Capability for the main window",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "opener:default",
+    "log:default" # add this!
+  ]
+}
+```
+
+Then, you need to register the core plugin with Tauri:
 
 `src-tauri/src/lib.rs`
 


### PR DESCRIPTION
burned an hour trying to set this up, finally figured it out when I realized that the log methods return futures and may be erroring... inspecting the error, I realized I had a permission problem.