### PR TITLE
[opener] Prepare for objc2 frameworks v0.3

### DIFF
--- a/plugins/opener/Cargo.toml
+++ b/plugins/opener/Cargo.toml
@@ -55,11 +55,13 @@ url = { workspace = true }
 
 [target."cfg(target_os = \"macos\")".dependencies.objc2-app-kit]
 version = "0.2"
-features = ["NSWorkspace"]
+default-features = false
+features = ["std", "NSWorkspace"]
 
 [target."cfg(target_os = \"macos\")".dependencies.objc2-foundation]
 version = "0.2"
-features = ["NSURL", "NSArray", "NSString"]
+default-features = false
+features = ["std", "NSURL", "NSArray", "NSString"]
 
 [target.'cfg(target_os = "ios")'.dependencies]
 tauri = { workspace = true, features = ["wry"] }


### PR DESCRIPTION
The next version will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them (so that your compile times down blow up once you upgrade to the next version).

I did not include a changelog entry here, since there are no user-facing changes, and since it doesn't need to be shipped to users.