### PR TITLE
[log] Use objc2

### DIFF
--- a/.changes/objc2-log.md
+++ b/.changes/objc2-log.md
@@ -1,0 +1,5 @@
+---
+"tauri-plugin-log": patch
+---
+
+Use `objc2` instead of `objc`.

--- a/.changes/objc2-log.md
+++ b/.changes/objc2-log.md
@@ -1,5 +1,6 @@
 ---
-"tauri-plugin-log": patch
+"log": patch
+"log-js": patch
 ---
 
 Use `objc2` instead of `objc`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6645,10 +6645,10 @@ version = "2.2.0"
 dependencies = [
  "android_logger",
  "byte-unit",
- "cocoa",
  "fern",
  "log",
- "objc",
+ "objc2",
+ "objc2-foundation",
  "serde",
  "serde_json",
  "serde_repr",

--- a/plugins/log/Cargo.toml
+++ b/plugins/log/Cargo.toml
@@ -41,8 +41,8 @@ android_logger = "0.14"
 swift-rs = "1"
 objc2 = "0.5"
 objc2-foundation = { version = "0.2", default-features = false, features = [
-    "std",
-    "NSString",
+  "std",
+  "NSString",
 ] }
 
 [features]

--- a/plugins/log/Cargo.toml
+++ b/plugins/log/Cargo.toml
@@ -39,8 +39,11 @@ android_logger = "0.14"
 
 [target."cfg(target_os = \"ios\")".dependencies]
 swift-rs = "1"
-objc = "0.2"
-cocoa = "0.26"
+objc2 = "0.5"
+objc2-foundation = { version = "0.2", default-features = false, features = [
+    "std",
+    "NSString",
+] }
 
 [features]
 colored = ["fern/colored"]


### PR DESCRIPTION
This makes it easier to correctly do the `NSString` construction.

See https://github.com/tauri-apps/wry/issues/1239 for more details on using `objc2` in Tauri. `objc2` is already used in the `tauri-plugin-opener` crate in this repo.