### PR TITLE
docs(process): fix typo in Default Permission section

### DIFF
--- a/plugins/process/permissions/autogenerated/reference.md
+++ b/plugins/process/permissions/autogenerated/reference.md
@@ -1,7 +1,7 @@
 ## Default Permission
 
 This permission set configures which
-process feeatures are by default exposed.
+process features are by default exposed.
 
 #### Granted Permissions
 

--- a/plugins/process/permissions/default.toml
+++ b/plugins/process/permissions/default.toml
@@ -3,7 +3,7 @@
 [default]
 description = """
 This permission set configures which
-process feeatures are by default exposed.
+process features are by default exposed.
 
 #### Granted Permissions
 

--- a/plugins/process/permissions/schemas/schema.json
+++ b/plugins/process/permissions/schemas/schema.json
@@ -315,7 +315,7 @@
           "const": "deny-restart"
         },
         {
-          "description": "This permission set configures which\nprocess feeatures are by default exposed.\n\n#### Granted Permissions\n\nThis enables to quit via `allow-exit` and restart via `allow-restart`\nthe application.\n",
+          "description": "This permission set configures which\nprocess features are by default exposed.\n\n#### Granted Permissions\n\nThis enables to quit via `allow-exit` and restart via `allow-restart`\nthe application.\n",
           "type": "string",
           "const": "default"
         }


### PR DESCRIPTION
Corrected a typo in the [Default Permission](https://v2.tauri.app/plugin/process/#default-permission) section of the Tauri v2 documentation. The word "feeatures" was changed to "features" to fix the spelling error.