### PR TITLE
Additional documentation for Haptics

### DIFF
--- a/plugins/haptics/README.md
+++ b/plugins/haptics/README.md
@@ -69,6 +69,18 @@ fn main() {
 }
 ```
 
+Second, add the required permissions in the project:
+
+`src-tauri/capabilities/default.json`
+
+```rust
+  "permissions": [
+    +"haptics:allow-impact-feedback",
+    +"haptics:allow-notification-feedback",
+    +"haptics:allow-selection-feedback",
+    +"haptics:allow-vibrate"
+  ]```
+
 Afterwards all the plugin's APIs are available through the JavaScript guest bindings:
 
 ```javascript


### PR DESCRIPTION
Initially when trying to use the haptics it mysteriously wasn't working. I resolved the issue using #2023, the examples were updated but the above file was not.
Simply added a step with the proper permissions in the default.json file.
