### PR TITLE
fix(log): timezone_strategy overwriting LogLevels (fix #2262)

### DIFF
--- a/.changes/log-timezone_strategy-loglevel-fix.md
+++ b/.changes/log-timezone_strategy-loglevel-fix.md
@@ -1,0 +1,6 @@
+---
+"log": patch
+"log-js": patch
+---
+
+Fix timezone_strategy overwriting previously set LogLevels.

--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -278,7 +278,7 @@ impl Builder {
         let format =
             time::format_description::parse("[[[year]-[month]-[day]][[[hour]:[minute]:[second]]")
                 .unwrap();
-        self.dispatch = fern::Dispatch::new().format(move |out, message, record| {
+        self.dispatch = self.dispatch.format(move |out, message, record| {
             out.finish(format_args!(
                 "{}[{}][{}] {}",
                 timezone_strategy.get_now().format(&format).unwrap(),


### PR DESCRIPTION
Fixes #2262