### PR TITLE
feat(log): expose `chain` method of `Builder::dispatch`

### DIFF
--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -321,6 +321,11 @@ impl Builder {
         self
     }
 
+    pub fn chain<T: Into<fern::Output>>(mut self, logger: T) -> Self{
+        self.dispatch = self.dispatch.chain(logger);
+        self
+    }
+
     /// Removes all targets. Useful to ignore the default targets and reconfigure them.
     pub fn clear_targets(mut self) -> Self {
         self.targets.clear();


### PR DESCRIPTION
By exposing the `chain` method of `Builder::dispatch`, tauri-plugin-log is able to support multiple output logics. 

The primary purpose  is to allow customize the formatting logic when outputting logs to files, thereby avoiding the impact of terminal color codes on the content of the log files.