### PR TITLE
chore: ignore vscode settings.json and tasks.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ target/
 
 # .vscode workspace settings file
 .vscode/settings.json
+.vscode/launch.json
+.vscode/tasks.json
 
 # npm, yarn and bun lock files
 package-lock.json


### PR DESCRIPTION
I sometimes use it to launch the debugger on the API example and it's quite annoying to stash it every time I want to commit/switch something