### PR TITLE
fix(updater): should be `log::debug` not `println`

### DIFF
--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -428,7 +428,7 @@ impl Updater {
                             .map_err(Into::into)
                         {
                             Ok(release) => {
-                                println!("parsed release response {release:?}");
+                                log::debug!("parsed release response {release:?}");
                                 last_error = None;
                                 remote_release = Some(release);
                                 // we found a release, break the loop


### PR DESCRIPTION
Reference: https://github.com/tauri-apps/plugins-workspace/pull/2513/files#r1986198042