### PR TITLE
enable TargetKind::LogDir on mobile

### DIFF
--- a/.changes/change-pr-2524.md
+++ b/.changes/change-pr-2524.md
@@ -1,0 +1,6 @@
+---
+"log": patch
+"log-js": patch
+---
+
+enable TargetKind::LogDir on mobile

--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -159,11 +159,12 @@ pub enum TargetKind {
     ///
     /// ### Platform-specific
     ///
-    /// |Platform | Value                                                                                     | Example                                                     |
-    /// | ------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-    /// | Linux   | `$XDG_DATA_HOME/{bundleIdentifier}/logs` or `$HOME/.local/share/{bundleIdentifier}/logs`  | `/home/alice/.local/share/com.tauri.dev/logs`               |
-    /// | macOS   | `{homeDir}/Library/Logs/{bundleIdentifier}`                                               | `/Users/Alice/Library/Logs/com.tauri.dev`                   |
-    /// | Windows | `{FOLDERID_LocalAppData}/{bundleIdentifier}/logs`                                         | `C:\Users\Alice\AppData\Local\com.tauri.dev\logs`           |
+    /// |Platform   | Value                                                                                     | Example                                                     |
+    /// | --------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+    /// | Linux     | `$XDG_DATA_HOME/{bundleIdentifier}/logs` or `$HOME/.local/share/{bundleIdentifier}/logs`  | `/home/alice/.local/share/com.tauri.dev/logs`               |
+    /// | macOS/iOS | `{homeDir}/Library/Logs/{bundleIdentifier}`                                               | `/Users/Alice/Library/Logs/com.tauri.dev`                   |
+    /// | Windows   | `{FOLDERID_LocalAppData}/{bundleIdentifier}/logs`                                         | `C:\Users\Alice\AppData\Local\com.tauri.dev\logs`           |
+    /// | Android   | `{ConfigDir}/logs`                                                                        | `/data/data/com.tauri.dev/files/logs`                       |
     LogDir { file_name: Option<String> },
     /// Forward logs to the webview (via the `log://log` event).
     ///
@@ -451,9 +452,6 @@ impl Builder {
                     )?)?
                     .into()
                 }
-                #[cfg(mobile)]
-                TargetKind::LogDir { .. } => continue,
-                #[cfg(desktop)]
                 TargetKind::LogDir { file_name } => {
                     let path = app_handle.path().app_log_dir()?;
                     if !path.exists() {


### PR DESCRIPTION
It's not possible to do a workaround on mobile with `TargetKind::Folder` as it's not possible to access the `AppHandle` to get a writable location and I didn't want to copy that code into my project.

I tested it on Android, but it should also work on iOS.

Do you see this as a breaking change because it generates logs on mobile apps with the default setting when it didn't do that before? I could change the defaults for mobile, if that change is considered breaking.
