### PR TITLE
feat(updater): add support to riscv64 architecture

### DIFF
--- a/.changes/updater-riscv64.md
+++ b/.changes/updater-riscv64.md
@@ -1,0 +1,6 @@
+---
+"updater": patch
+"updater-js": patch
+---
+
+Add support to the `riscv64` architecture.

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -1223,6 +1223,8 @@ pub(crate) fn get_updater_arch() -> Option<&'static str> {
         Some("armv7")
     } else if cfg!(target_arch = "aarch64") {
         Some("aarch64")
+    } else if cfg!(target_arch = "riscv64") {
+        Some("riscv64")
     } else {
         None
     }


### PR DESCRIPTION
Tauri now supports it, so the updater should check the riscv64 arch and replace the {{arch}} and {{target}} variables properly.

ref https://github.com/tauri-apps/tauri/pull/12602/