### PR TITLE
fix(updater): download reuse check timeout

### DIFF
--- a/.changes/updater-download-inherit-check-timeout.md
+++ b/.changes/updater-download-inherit-check-timeout.md
@@ -1,0 +1,6 @@
+---
+"updater": "patch:bug"
+"updater-js": "patch:bug"
+---
+
+Fix `timeout` passed to `check` gets re-used by `download` and `downloadAndinstall` 

--- a/plugins/updater/README.md
+++ b/plugins/updater/README.md
@@ -76,7 +76,7 @@ Afterwards all the plugin's APIs are available through the JavaScript guest bind
 import { check } from '@tauri-apps/plugin-updater'
 import { relaunch } from '@tauri-apps/plugin-process'
 const update = await check()
-if (update?.available) {
+if (update) {
   await update.downloadAndInstall()
   await relaunch()
 }

--- a/plugins/updater/guest-js/index.ts
+++ b/plugins/updater/guest-js/index.ts
@@ -133,7 +133,10 @@ async function check(options?: CheckOptions): Promise<Update | null> {
 
   return await invoke<UpdateMetadata>('plugin:updater|check', {
     ...options
-  }).then((meta) => (meta.available ? new Update(meta) : null))
+  }).then((meta) =>
+    // TODO: Handle this in the rust side
+    meta.available ? new Update(meta) : null
+  )
 }
 
 export type { CheckOptions, DownloadOptions, DownloadEvent }

--- a/plugins/updater/src/commands.rs
+++ b/plugins/updater/src/commands.rs
@@ -40,6 +40,8 @@ pub(crate) struct Metadata {
 struct DownloadedBytes(pub Vec<u8>);
 impl Resource for DownloadedBytes {}
 
+// TODO: Align this with the result of `updater.check` to Result<Option<Metadata>>
+// and remove `available` instead of handling this in the js side
 #[tauri::command]
 pub(crate) async fn check<R: Runtime>(
     webview: Webview<R>,

--- a/plugins/updater/src/lib.rs
+++ b/plugins/updater/src/lib.rs
@@ -153,8 +153,7 @@ impl Builder {
         I: IntoIterator<Item = S>,
         S: Into<OsString>,
     {
-        let args = args.into_iter().map(|a| a.into()).collect::<Vec<_>>();
-        self.installer_args.extend_from_slice(&args);
+        self.installer_args.extend(args.into_iter().map(Into::into));
         self
     }
 
@@ -214,7 +213,7 @@ impl Builder {
                     config.pubkey = pubkey;
                 }
                 if let Some(windows) = &mut config.windows {
-                    windows.installer_args.extend_from_slice(&installer_args);
+                    windows.installer_args.extend(installer_args);
                 }
                 app.manage(UpdaterState {
                     target,

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -124,8 +124,7 @@ pub struct UpdaterBuilder {
 impl UpdaterBuilder {
     pub(crate) fn new<R: Runtime>(app: &AppHandle<R>, config: crate::Config) -> Self {
         let app_ = app.clone();
-        let run_on_main_thread =
-            move |f: Box<dyn FnOnce() + Send + Sync + 'static>| app_.run_on_main_thread(f);
+        let run_on_main_thread = move |f| app_.run_on_main_thread(f);
         Self {
             run_on_main_thread: Box::new(run_on_main_thread),
             installer_args: config
@@ -230,8 +229,7 @@ impl UpdaterBuilder {
         I: IntoIterator<Item = S>,
         S: Into<OsString>,
     {
-        let args = args.into_iter().map(|a| a.into()).collect::<Vec<_>>();
-        self.installer_args.extend_from_slice(&args);
+        self.installer_args.extend(args.into_iter().map(Into::into));
         self
     }
 
@@ -312,8 +310,7 @@ impl UpdaterBuilder {
         I: IntoIterator<Item = S>,
         S: Into<OsString>,
     {
-        let args = args.into_iter().map(|a| a.into()).collect::<Vec<_>>();
-        self.current_exe_args.extend_from_slice(&args);
+        self.installer_args.extend(args.into_iter().map(Into::into));
         self
     }
 }
@@ -478,10 +475,10 @@ impl Updater {
                 version: release.version.to_string(),
                 date: release.pub_date,
                 download_url: release.download_url(&self.json_target)?.to_owned(),
-                body: release.notes.clone(),
                 signature: release.signature(&self.json_target)?.to_owned(),
+                body: release.notes,
                 raw_json: raw_json.unwrap(),
-                timeout: self.timeout,
+                timeout: None,
                 proxy: self.proxy.clone(),
                 headers: self.headers.clone(),
                 installer_args: self.installer_args.clone(),


### PR DESCRIPTION
Fix #2372

Fix `timeout` passed to `check` gets re-used by `download` and `downloadAndinstall` 

Also did some other cleanups