### PR TITLE
chore(process): use `request_restart`

### DIFF
--- a/.changes/request-restart.md
+++ b/.changes/request-restart.md
@@ -1,0 +1,6 @@
+---
+process: patch
+process-js: patch
+---
+
+Migrate restart to use tauri's new `AppHandle::request_restart` method

--- a/plugins/process/src/commands.rs
+++ b/plugins/process/src/commands.rs
@@ -11,5 +11,5 @@ pub fn exit<R: Runtime>(app: AppHandle<R>, code: i32) {
 
 #[tauri::command]
 pub fn restart<R: Runtime>(app: AppHandle<R>) {
-    app.restart()
+    app.request_restart()
 }


### PR DESCRIPTION
Migrate restart to use tauri's new `AppHandle::request_restart` method

Reference: https://github.com/tauri-apps/tauri/pull/12874