### PR TITLE
fix(window-state): window size jump on multi monitor setup

### DIFF
--- a/.changes/multi-monitor-window-state.md
+++ b/.changes/multi-monitor-window-state.md
@@ -1,0 +1,6 @@
+---
+window-state: patch
+window-state-js: patch
+---
+
+Fix window size gets bigger/smaller on secondary monitor with a different scaling than the primary one

--- a/plugins/window-state/src/lib.rs
+++ b/plugins/window-state/src/lib.rs
@@ -184,13 +184,6 @@ impl<R: Runtime> WindowExt for Window<R> {
                 self.set_decorations(state.decorated)?;
             }
 
-            if flags.contains(StateFlags::SIZE) {
-                self.set_size(PhysicalSize {
-                    width: state.width,
-                    height: state.height,
-                })?;
-            }
-
             if flags.contains(StateFlags::POSITION) {
                 let position = (state.x, state.y).into();
                 let size = (state.width, state.height).into();
@@ -212,6 +205,13 @@ impl<R: Runtime> WindowExt for Window<R> {
                         })?;
                     }
                 }
+            }
+
+            if flags.contains(StateFlags::SIZE) {
+                self.set_size(PhysicalSize {
+                    width: state.width,
+                    height: state.height,
+                })?;
             }
 
             if flags.contains(StateFlags::MAXIMIZED) && state.maximized {


### PR DESCRIPTION
Co-authored-by: Jerry <81011681+Jerry457@users.noreply.github.com>

Fix #2326

Fix window size gets bigger/smaller on secondary monitor with a different scaling than the primary one