### PR TITLE
[v2][log]: Add generic fern::Dispatch TargetKind to log

### DIFF
--- a/.changes/fern-dispatch-log-target.md
+++ b/.changes/fern-dispatch-log-target.md
@@ -1,0 +1,6 @@
+---
+log: minor
+log-js: minor
+---
+
+Adds a new varient `TargetKind::Dispatch` that allows you to construct arbitrary log targets

--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -170,7 +170,7 @@ pub enum TargetKind {
     ///
     /// This requires the webview to subscribe to log events, via this plugins `attachConsole` function.
     Webview,
-    /// Send logs to a fern::Dispatch
+    /// Send logs to a [`fern::Dispatch`]
     ///
     /// You can use this to construct arbitrary log targets.
     Dispatch(fern::Dispatch),

--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -170,6 +170,10 @@ pub enum TargetKind {
     ///
     /// This requires the webview to subscribe to log events, via this plugins `attachConsole` function.
     Webview,
+    /// Send logs to a fern::Dispatch
+    ///
+    /// You can use this to construct arbitrary log targets.
+    Dispatch(fern::Dispatch),
 }
 
 /// A log target.
@@ -481,6 +485,7 @@ impl Builder {
                         });
                     })
                 }
+                TargetKind::Dispatch(dispatch) => dispatch.into(),
             };
             target_dispatch = target_dispatch.chain(logger);
 

--- a/plugins/shell/permissions/schemas/schema.json
+++ b/plugins/shell/permissions/schemas/schema.json
@@ -355,10 +355,10 @@
           "markdownDescription": "Denies the stdin_write command without any pre-configured scope."
         },
         {
-          "description": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n",
+          "description": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality without any specific\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`"
+          "markdownDescription": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`"
         }
       ]
     }

--- a/plugins/shell/src/scope.rs
+++ b/plugins/shell/src/scope.rs
@@ -304,7 +304,7 @@ impl ShellScope<'_> {
             .map(|s| {
                 std::path::PathBuf::from(s)
                     .components()
-                    .last()
+                    .next_back()
                     .unwrap()
                     .as_os_str()
                     .to_string_lossy()


### PR DESCRIPTION
This is a conflict-resolved version of https://github.com/tauri-apps/plugins-workspace/pull/1130
Because I need this feature very soon 

Closes https://github.com/tauri-apps/plugins-workspace/issues/1113
Closes #2525 
Closes https://github.com/tauri-apps/plugins-workspace/issues/2530
