### PR TITLE
docs: fix log targets docs

### DIFF
--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -360,7 +360,7 @@ impl Builder {
         self
     }
 
-    /// Replace the targets of the logger.
+    /// Replaces the targets of the logger.
     ///
     /// ```rust
     /// use tauri_plugin_log::{Target, TargetKind, WEBVIEW_TARGET};

--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -360,12 +360,11 @@ impl Builder {
         self
     }
 
-    /// Adds a collection of targets to the logger.
+    /// Replace the targets of the logger.
     ///
     /// ```rust
     /// use tauri_plugin_log::{Target, TargetKind, WEBVIEW_TARGET};
     /// tauri_plugin_log::Builder::new()
-    ///     .clear_targets()
     ///     .targets([
     ///         Target::new(TargetKind::Webview),
     ///         Target::new(TargetKind::LogDir { file_name: Some("webview".into()) }).filter(|metadata| metadata.target().starts_with(WEBVIEW_TARGET)),


### PR DESCRIPTION
`Builder::targets` replaces the targets, not adding them to the logger