### PR TITLE
single-instance: fix `cwd` in single instance on macOS

### DIFF
--- a/.changes/fix-macos-cwd-single-instance.md
+++ b/.changes/fix-macos-cwd-single-instance.md
@@ -1,0 +1,5 @@
+---
+single-instance: patch
+---
+
+fix `cwd` in single instance on macOS, which was the cwd of the first instance, instead of the second (like it is on windows and linux)

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -114,8 +114,8 @@ mod imp {
         /// ## Platform-specific:
         ///
         /// - **Windows / Linux**: This function reads the command line arguments and checks if there's only one value, which must be an URL with scheme matching one of the configured values.
-        ///     Note that you must manually check the arguments when registering deep link schemes dynamically with [`Self::register`].
-        ///     Additionally, the deep link might have been provided as a CLI argument so you should check if its format matches what you expect.
+        ///   Note that you must manually check the arguments when registering deep link schemes dynamically with [`Self::register`].
+        ///   Additionally, the deep link might have been provided as a CLI argument so you should check if its format matches what you expect.
         pub fn get_current(&self) -> crate::Result<Option<Vec<url::Url>>> {
             self.plugin_handle
                 .run_mobile_plugin::<GetCurrentResponse>("getCurrent", ())
@@ -226,8 +226,8 @@ mod imp {
         /// ## Platform-specific:
         ///
         /// - **Windows / Linux**: This function reads the command line arguments and checks if there's only one value, which must be an URL with scheme matching one of the configured values.
-        ///     Note that you must manually check the arguments when registering deep link schemes dynamically with [`Self::register`].
-        ///     Additionally, the deep link might have been provided as a CLI argument so you should check if its format matches what you expect.
+        ///   Note that you must manually check the arguments when registering deep link schemes dynamically with [`Self::register`].
+        ///   Additionally, the deep link might have been provided as a CLI argument so you should check if its format matches what you expect.
         pub fn get_current(&self) -> crate::Result<Option<Vec<url::Url>>> {
             return Ok(self.current.lock().unwrap().clone());
         }
@@ -350,7 +350,7 @@ mod imp {
         /// ## Platform-specific:
         ///
         /// - **Windows**: Requires admin rights if the protocol is registered on local machine
-        ///     (this can happen when registered from the NSIS installer when the install mode is set to both or per machine)
+        ///   (this can happen when registered from the NSIS installer when the install mode is set to both or per machine)
         /// - **Linux**: Can only unregister the scheme if it was initially registered with [`register`](`Self::register`). May not work on older distros.
         /// - **macOS / Android / iOS**: Unsupported, will return [`Error::UnsupportedPlatform`](`crate::Error::UnsupportedPlatform`).
         pub fn unregister<S: AsRef<str>>(&self, _protocol: S) -> crate::Result<()> {

--- a/plugins/single-instance/src/platform_impl/macos.rs
+++ b/plugins/single-instance/src/platform_impl/macos.rs
@@ -105,13 +105,7 @@ fn listen_for_other_instances<A: Runtime>(
                             let mut s = String::new();
                             match stream.read_to_string(&mut s) {
                                 Ok(_) => {
-                                    let (cwd, args) = {
-                                        let mut split = s.split("\0\0");
-                                        (
-                                            split.next().unwrap_or_default(),
-                                            split.next().unwrap_or_default(),
-                                        )
-                                    };
+                                    let (cwd, args) = s.split_once("\0\0").unwrap_or_default();
                                     let args: Vec<String> =
                                         args.split('\0').map(String::from).collect();
                                     cb(app.app_handle(), args, cwd.to_string());

--- a/plugins/single-instance/src/platform_impl/macos.rs
+++ b/plugins/single-instance/src/platform_impl/macos.rs
@@ -77,6 +77,13 @@ fn socket_cleanup(socket: &PathBuf) {
 fn notify_singleton(socket: &PathBuf) -> Result<(), Error> {
     let stream = UnixStream::connect(socket)?;
     let mut bf = BufWriter::new(&stream);
+    let cwd = std::env::current_dir()
+        .unwrap_or_default()
+        .to_str()
+        .unwrap_or_default()
+        .to_string();
+    bf.write_all(cwd.as_bytes())?;
+    bf.write_all(b"\0\0")?;
     let args_joined = std::env::args().collect::<Vec<String>>().join("\0");
     bf.write_all(args_joined.as_bytes())?;
     bf.flush()?;
@@ -91,12 +98,6 @@ fn listen_for_other_instances<A: Runtime>(
 ) {
     match UnixListener::bind(socket) {
         Ok(listener) => {
-            let cwd = std::env::current_dir()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default()
-                .to_string();
-
             tauri::async_runtime::spawn(async move {
                 for stream in listener.incoming() {
                     match stream {
@@ -104,9 +105,16 @@ fn listen_for_other_instances<A: Runtime>(
                             let mut s = String::new();
                             match stream.read_to_string(&mut s) {
                                 Ok(_) => {
+                                    let (cwd, args) = {
+                                        let mut split = s.split("\0\0");
+                                        (
+                                            split.next().unwrap_or_default(),
+                                            split.next().unwrap_or_default(),
+                                        )
+                                    };
                                     let args: Vec<String> =
-                                        s.split('\0').map(String::from).collect();
-                                    cb(app.app_handle(), args, cwd.clone());
+                                        args.split('\0').map(String::from).collect();
+                                    cb(app.app_handle(), args, cwd.to_string());
                                 }
                                 Err(e) => {
                                     tracing::debug!("single_instance failed to be notified: {e}")

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+tab_spaces = 4

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-tab_spaces = 4


### PR DESCRIPTION
which was the `cwd` of the first instance, instead of the second how it should be and is  on windows and linux.

