### PR TITLE
fix(log): iOS simulator freezes when calling os_log too early

### DIFF
--- a/.changes/fix-ios-log-simulator.md
+++ b/.changes/fix-ios-log-simulator.md
@@ -1,0 +1,6 @@
+---
+"log": patch
+"log-js": patch
+---
+
+Fix iOS app stuck when using the iOS Simulator and the log plugin due to a deadlock when calling os_log too early.

--- a/plugins/log/ios/Sources/LogPlugin.swift
+++ b/plugins/log/ios/Sources/LogPlugin.swift
@@ -2,16 +2,41 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-import UIKit
-import Tauri
 import SwiftRs
+import Tauri
+import UIKit
+
+#if targetEnvironment(simulator)
+  var logReady = false
+#else
+  var logReady = true
+#endif
 
 @_cdecl("tauri_log")
 func log(level: Int, message: NSString) {
-	switch level {
-		case 1: Logger.debug(message as String)
-		case 2: Logger.info(message as String)
-		case 3: Logger.error(message as String)
-		default: break
-	}
+  if logReady {
+    os_log(level, message)
+  } else {
+    dispatch_log(level, message)
+  }
+}
+
+func dispatch_log(_ level: Int, _ message: NSString) {
+  // delay logging when the logger isn't immediately available
+  // in some cases when using the simulator the app would hang when calling os_log too soon
+  // better be safe here and wait a few seconds than actually freeze the app in dev mode
+  // in production this isn't a problem
+  DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+    os_log(level, message)
+    logReady = true
+  }
+}
+
+func os_log(_ level: Int, _ message: NSString) {
+  switch level {
+  case 1: Logger.debug(message as String)
+  case 2: Logger.info(message as String)
+  case 3: Logger.error(message as String)
+  default: break
+  }
 }


### PR DESCRIPTION
let's delay logs on simulator to prevent deadlocks - looks like the logging system isn't available when the Rust process starts, and it's freezing the app (simulator only)

closes https://github.com/tauri-apps/tauri/issues/12172