### PR TITLE
fix(biometric) prompt for fallback credentials when enabled and biometry unavailable on iOS (fix #2632)

### DIFF
--- a/.changes/fix-ios-biometry-fallback-auth.md
+++ b/.changes/fix-ios-biometry-fallback-auth.md
@@ -3,4 +3,4 @@
 "biometric-js": patch:bug
 ---
 
-Fix biometric plugin not prompting for fallback credentials when biometry status is unavailable or not enrolled on iOS.
+Fix biometric plugin ignoring fallback logic when biometry status is unavailable or not enrolled on iOS.

--- a/.changes/fix-ios-biometry-fallback-auth.md
+++ b/.changes/fix-ios-biometry-fallback-auth.md
@@ -1,0 +1,6 @@
+---
+"biometric": patch:bug
+"biometric-js": patch:bug
+---
+
+Fix biometric plugin not prompting for fallback credentials when biometry status is unavailable or not enrolled on iOS.

--- a/plugins/biometric/ios/Sources/BiometricPlugin.swift
+++ b/plugins/biometric/ios/Sources/BiometricPlugin.swift
@@ -98,7 +98,12 @@ class BiometricPlugin: Plugin {
   }
 
   @objc func authenticate(_ invoke: Invoke) throws {
-    guard self.status.available else {
+    let args = try invoke.parseArgs(AuthOptions.self)
+
+    let allowDeviceCredential = args.allowDeviceCredential ?? false
+
+    guard self.status.available || allowDeviceCredential else {
+      // Biometry unavailable, fallback disabled
       invoke.reject(
         self.status.errorReason ?? "",
         code: self.status.errorCode ?? ""
@@ -106,14 +111,10 @@ class BiometricPlugin: Plugin {
       return
     }
 
-    let args = try invoke.parseArgs(AuthOptions.self)
-
     let context = LAContext()
     context.localizedFallbackTitle = args.fallbackTitle
     context.localizedCancelTitle = args.cancelTitle
     context.touchIDAuthenticationAllowableReuseDuration = 0
-
-    let allowDeviceCredential = args.allowDeviceCredential ?? false
 
     // force system default fallback title if an empty string is provided (the OS hides the fallback button in this case)
     if allowDeviceCredential,


### PR DESCRIPTION
## Description
Fix #2632: This fixes the issue described in #2632 where authentication would fail without prompting for fallback credentials when biometry wasn't available or enrolled on iOS platforms.

## Root cause
The authenticate function checked the stored biometric status and failed immediately if unavailable, ignoring fallback logic when `allowDeviceCredential = true`.

## Proposed solution
Ensure fallback credential is also disabled before failing early due to biometric availability in the iOS module of the plugin.

## Additional Notes
I've tested the fix on a physical iPhone 15 Pro Max running iOS 18.3 and confirmed that a fallback prompt now appears if biometry is disabled and fallback is allowed.