### PR TITLE
fix(biometric) Incorrect error reported on Android with no device passcode set and fallback allowed

### DIFF
--- a/.changes/fix-bio-fallback-error-android.md
+++ b/.changes/fix-bio-fallback-error-android.md
@@ -1,0 +1,6 @@
+---
+"biometric": patch:bug
+"biometric-js": patch:bug
+---
+
+Fix biometric plugin reporting an inconsistent and incorrect error on Android when no device passcode was set.

--- a/plugins/biometric/android/src/main/java/BiometricActivity.kt
+++ b/plugins/biometric/android/src/main/java/BiometricActivity.kt
@@ -38,41 +38,38 @@ class BiometricActivity : AppCompatActivity() {
         var title = intent.getStringExtra(BiometricPlugin.TITLE)
         val subtitle = intent.getStringExtra(BiometricPlugin.SUBTITLE)
         val description = intent.getStringExtra(BiometricPlugin.REASON)
-        allowDeviceCredential = false
+        allowDeviceCredential = intent.getBooleanExtra(BiometricPlugin.DEVICE_CREDENTIAL, false)
+
         // Android docs say we should check if the device is secure before enabling device credential fallback
         val manager = getSystemService(
             Context.KEYGUARD_SERVICE
         ) as KeyguardManager
-        if (manager.isDeviceSecure) {
-            allowDeviceCredential =
-                intent.getBooleanExtra(BiometricPlugin.DEVICE_CREDENTIAL, false)
-        }
-
-        if (title.isNullOrEmpty()) {
-            title = "Authenticate"
-        }
-
-        builder.setTitle(title).setSubtitle(subtitle).setDescription(description)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            var authenticators = BiometricManager.Authenticators.BIOMETRIC_WEAK
-            if (allowDeviceCredential) {
-                authenticators = authenticators or BiometricManager.Authenticators.DEVICE_CREDENTIAL
+        if (allowDeviceCredential && manager.isDeviceSecure) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                var authenticators = BiometricManager.Authenticators.BIOMETRIC_WEAK
+                if (allowDeviceCredential) {
+                    authenticators = authenticators or BiometricManager.Authenticators.DEVICE_CREDENTIAL
+                }
+                builder.setAllowedAuthenticators(authenticators)
+            } else {
+                @Suppress("DEPRECATION")
+                builder.setDeviceCredentialAllowed(allowDeviceCredential)
             }
-            builder.setAllowedAuthenticators(authenticators)
         } else {
-            @Suppress("DEPRECATION")
-            builder.setDeviceCredentialAllowed(allowDeviceCredential)
-        }
-
-        // From the Android docs:
-        //  You can't call setNegativeButtonText() and setAllowedAuthenticators(... or DEVICE_CREDENTIAL)
-        //  at the same time on a BiometricPrompt.PromptInfo.Builder instance.
-        if (!allowDeviceCredential) {
+            // From the Android docs:
+            //  You can't call setNegativeButtonText() and setAllowedAuthenticators(... or DEVICE_CREDENTIAL)
+            //  at the same time on a BiometricPrompt.PromptInfo.Builder instance.
             val negativeButtonText = intent.getStringExtra(BiometricPlugin.CANCEL_TITLE)
             builder.setNegativeButtonText(
                 if (negativeButtonText.isNullOrEmpty()) "Cancel" else negativeButtonText
             )
         }
+
+        if (title.isNullOrEmpty()) {
+            title = "Authenticate"
+        }
+        builder.setTitle(title).setSubtitle(subtitle).setDescription(description)
+
         builder.setConfirmationRequired(
             intent.getBooleanExtra(BiometricPlugin.CONFIRMATION_REQUIRED, true)
         )
@@ -85,6 +82,14 @@ class BiometricActivity : AppCompatActivity() {
                     errorCode: Int,
                     errorMessage: CharSequence
                 ) {
+                    var errorCode = errorCode
+                    var errorMessage = errorMessage
+                    // override error to properly report no device credential if needed
+                    if (allowDeviceCredential
+                        && errorCode == BiometricPrompt.ERROR_NO_BIOMETRICS) {
+                        errorCode = BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL
+                        errorMessage = "No device credential set"
+                    }
                     super.onAuthenticationError(errorCode, errorMessage)
                     finishActivity(
                         BiometryResultType.ERROR,

--- a/plugins/biometric/android/src/main/java/BiometricActivity.kt
+++ b/plugins/biometric/android/src/main/java/BiometricActivity.kt
@@ -38,37 +38,38 @@ class BiometricActivity : AppCompatActivity() {
         var title = intent.getStringExtra(BiometricPlugin.TITLE)
         val subtitle = intent.getStringExtra(BiometricPlugin.SUBTITLE)
         val description = intent.getStringExtra(BiometricPlugin.REASON)
-        allowDeviceCredential = intent.getBooleanExtra(BiometricPlugin.DEVICE_CREDENTIAL, false)
-
+        val allowDeviceCredentialArg = intent.getBooleanExtra(BiometricPlugin.DEVICE_CREDENTIAL, false)
         // Android docs say we should check if the device is secure before enabling device credential fallback
         val manager = getSystemService(
             Context.KEYGUARD_SERVICE
         ) as KeyguardManager
-        if (allowDeviceCredential && manager.isDeviceSecure) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                var authenticators = BiometricManager.Authenticators.BIOMETRIC_WEAK
-                if (allowDeviceCredential) {
-                    authenticators = authenticators or BiometricManager.Authenticators.DEVICE_CREDENTIAL
-                }
-                builder.setAllowedAuthenticators(authenticators)
-            } else {
-                @Suppress("DEPRECATION")
-                builder.setDeviceCredentialAllowed(allowDeviceCredential)
+        val allowDeviceCredential = allowDeviceCredentialArg && manager.isDeviceSecure;
+
+        if (title.isNullOrEmpty()) {
+            title = "Authenticate"
+        }
+
+        builder.setTitle(title).setSubtitle(subtitle).setDescription(description)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            var authenticators = BiometricManager.Authenticators.BIOMETRIC_WEAK
+            if (allowDeviceCredential) {
+                authenticators = authenticators or BiometricManager.Authenticators.DEVICE_CREDENTIAL
             }
+            builder.setAllowedAuthenticators(authenticators)
         } else {
-            // From the Android docs:
-            //  You can't call setNegativeButtonText() and setAllowedAuthenticators(... or DEVICE_CREDENTIAL)
-            //  at the same time on a BiometricPrompt.PromptInfo.Builder instance.
+            @Suppress("DEPRECATION")
+            builder.setDeviceCredentialAllowed(allowDeviceCredential)
+        }
+
+        // From the Android docs:
+        //  You can't call setNegativeButtonText() and setAllowedAuthenticators(... or DEVICE_CREDENTIAL)
+        //  at the same time on a BiometricPrompt.PromptInfo.Builder instance.
+        if (!allowDeviceCredential) {
             val negativeButtonText = intent.getStringExtra(BiometricPlugin.CANCEL_TITLE)
             builder.setNegativeButtonText(
                 if (negativeButtonText.isNullOrEmpty()) "Cancel" else negativeButtonText
             )
         }
-
-        if (title.isNullOrEmpty()) {
-            title = "Authenticate"
-        }
-        builder.setTitle(title).setSubtitle(subtitle).setDescription(description)
 
         builder.setConfirmationRequired(
             intent.getBooleanExtra(BiometricPlugin.CONFIRMATION_REQUIRED, true)
@@ -85,8 +86,7 @@ class BiometricActivity : AppCompatActivity() {
                     var errorCode = errorCode
                     var errorMessage = errorMessage
                     // override error to properly report no device credential if needed
-                    if (allowDeviceCredential
-                        && errorCode == BiometricPrompt.ERROR_NO_BIOMETRICS) {
+                    if (allowDeviceCredentialArg && errorCode == BiometricPrompt.ERROR_NO_BIOMETRICS) {
                         errorCode = BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL
                         errorMessage = "No device credential set"
                     }
@@ -126,9 +126,5 @@ class BiometricActivity : AppCompatActivity() {
             )
         setResult(Activity.RESULT_OK, intent)
         finish()
-    }
-
-    companion object {
-        var allowDeviceCredential = false
     }
 }

--- a/plugins/biometric/android/src/main/java/BiometricPlugin.kt
+++ b/plugins/biometric/android/src/main/java/BiometricPlugin.kt
@@ -73,7 +73,7 @@ class BiometricPlugin(private val activity: Activity): Plugin(activity) {
            biometryErrorCodeMap[BiometricPrompt.ERROR_LOCKOUT_PERMANENT] = "biometryLockout"
            biometryErrorCodeMap[BiometricPrompt.ERROR_NEGATIVE_BUTTON] = "userCancel"
            biometryErrorCodeMap[BiometricPrompt.ERROR_NO_BIOMETRICS] = "biometryNotEnrolled"
-           biometryErrorCodeMap[BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL] = "noDeviceCredential"
+           biometryErrorCodeMap[BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL] = "passcodeNotSet"
            biometryErrorCodeMap[BiometricPrompt.ERROR_NO_SPACE] = "systemCancel"
            biometryErrorCodeMap[BiometricPrompt.ERROR_TIMEOUT] = "systemCancel"
            biometryErrorCodeMap[BiometricPrompt.ERROR_UNABLE_TO_PROCESS] = "systemCancel"


### PR DESCRIPTION
## Describe the problem
When performing biometric authentication on Android with no biometry or device credential set, but fallback credential allowed, the error `biometryNotEnrolled` is reported. While this error is *technically* correct, the expected error would be `passcodeNotSet`, closer matching the actual error and the behavior of other platforms.

## Steps to reproduce
In my case, I tested this using the `examples/api` app, but general reproduction steps are as follows:
- Run a Tauri app that uses the biometric plugin on an Android device or simulator; ensure that biometry is not enrolled and no device passcode is set.
- Call the authenticate command with `allowDeviceCredential` set to true
- Observe the reported error is `biometryNotEnrolled` as opposed to `passcodeNotSet`

## Cause
In my testing, I found that the following seem to be the cause of the issue:
- Early disabling of fallback credential if `manager.isDeviceSecure` returns false that prevents setting `Authenticators.DEVICE_CREDENTIAL` as a valid authenticator -- This is actually intended behavior and isn't the root cause as seen next
- The Android API itself reports the error as `ERROR_NO_BIOMETRICS` even after allowing device credential on an insecure device (`manager.isDeviceSecure == false`). It seems this is the intended behavior of the Android API, but nevertheless should be corrected in the biometric plugin as `passcodeNotSet` more accurately describes the error.

## Proposed solution
Override the error code and message to `ERROR_NO_DEVICE_CREDENTIAL` in the event that a fallback credential is allowed, but error code `ERROR_NO_BIOMETRICS` was received.

## Additional notes
Also corrected the Android module mapping `ERROR_NO_DEVICE_CREDENTIAL` to `noDeviceCredential` when it should be `passcodeNotSet`.