### PR TITLE
fix(single-instance): Check if pointer is null for V1

### DIFF
--- a/plugins/single-instance/src/platform_impl/windows.rs
+++ b/plugins/single-instance/src/platform_impl/windows.rs
@@ -113,6 +113,9 @@ unsafe extern "system" fn single_instance_window_proc<R: Runtime>(
 ) -> LRESULT {
     let data_ptr = GetWindowLongPtrW(hwnd, GWL_USERDATA)
         as *mut (AppHandle<R>, Box<SingleInstanceCallback<R>>);
+    if data_ptr.is_null() {
+        return DefWindowProcW(hwnd, msg, wparam, lparam);
+    }
     let (app_handle, callback) = &mut *data_ptr;
 
     match msg {


### PR DESCRIPTION
This just adds the [fix](https://github.com/tauri-apps/plugins-workspace/pull/2452) that was merged into the V2 version of the plugin into the V1 version.

Tested working on Windows 11 with `rust 1.86.0`