### PR TITLE
fix(opener-js): allow URL type

### DIFF
--- a/.changes/opener-url-type.md
+++ b/.changes/opener-url-type.md
@@ -1,0 +1,5 @@
+---
+"opener-js": patch
+---
+
+Adjust `open_url` url type to allow `URL`

--- a/.changes/opener-url-type.md
+++ b/.changes/opener-url-type.md
@@ -1,4 +1,5 @@
 ---
+"opener": patch
 "opener-js": patch
 ---
 

--- a/plugins/opener/guest-js/index.ts
+++ b/plugins/opener/guest-js/index.ts
@@ -38,7 +38,10 @@ import { invoke } from '@tauri-apps/api/core'
  *
  * @since 2.0.0
  */
-export async function openUrl(url: string, openWith?: string): Promise<void> {
+export async function openUrl(
+  url: string | URL,
+  openWith?: string
+): Promise<void> {
   await invoke('plugin:opener|open_url', {
     url,
     with: openWith


### PR DESCRIPTION
This updates the JS type to allow `URL` for the `openUrl` IPC.

As seen here, using a URL already serializes correctly:

https://github.com/tauri-apps/plugins-workspace/blob/a6b854032d0b10f0f17c4ffa6bdf4a05429e05fb/plugins/opener/guest-js/init.ts#L45

I thought this could either be `patch` or `minor`. Decided on `patch`, because it does not feel much like a feature.