### PR TITLE
feat(autostart): add prefered name configuration for auto start entry

### DIFF
--- a/.changes/autostart-feature.md
+++ b/.changes/autostart-feature.md
@@ -1,5 +1,6 @@
 ---
 autostart: minor
+autostart-js: minor
 ---
 
 Added a new builder method app_name() to allow customizing the application name in the autostart entry.

--- a/.changes/autostart-feature.md
+++ b/.changes/autostart-feature.md
@@ -1,0 +1,5 @@
+---
+autostart: minor
+---
+
+Added a new builder method app_name() to allow customizing the application name in the autostart entry.

--- a/plugins/autostart/README.md
+++ b/plugins/autostart/README.md
@@ -62,7 +62,7 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_autostart::Builder::new()
             .args(["--flag1", "--flag2"])
-            .app_name(tauri_plugin_autostart::PreferedName::AppName)
+            .app_name("My Custom Name")
             .build())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/plugins/autostart/README.md
+++ b/plugins/autostart/README.md
@@ -57,9 +57,13 @@ First you need to register the core plugin with Tauri:
 `src-tauri/src/lib.rs`
 
 ```rust
+
 fn main() {
     tauri::Builder::default()
-        .plugin(tauri_plugin_autostart::Builder::new().args((["--flag1", "--flag2"])).build()))
+        .plugin(tauri_plugin_autostart::Builder::new()
+            .args(["--flag1", "--flag2"])
+            .prefered_name(tauri_plugin_autostart::PreferedName::PackageInfoName)
+            .build())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/plugins/autostart/README.md
+++ b/plugins/autostart/README.md
@@ -57,7 +57,6 @@ First you need to register the core plugin with Tauri:
 `src-tauri/src/lib.rs`
 
 ```rust
-
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_autostart::Builder::new()

--- a/plugins/autostart/README.md
+++ b/plugins/autostart/README.md
@@ -62,7 +62,7 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_autostart::Builder::new()
             .args(["--flag1", "--flag2"])
-            .prefered_name(tauri_plugin_autostart::PreferedName::PackageInfoName)
+            .app_name(tauri_plugin_autostart::PreferedName::AppName)
             .build())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/plugins/autostart/src/lib.rs
+++ b/plugins/autostart/src/lib.rs
@@ -13,7 +13,9 @@
 use auto_launch::{AutoLaunch, AutoLaunchBuilder};
 use serde::{ser::Serializer, Serialize};
 use tauri::{
-    command, plugin::{Builder as PluginBuilder, TauriPlugin}, AppHandle, Manager, Runtime, State
+    command,
+    plugin::{Builder as PluginBuilder, TauriPlugin},
+    AppHandle, Manager, Runtime, State,
 };
 
 use std::env::current_exe;
@@ -27,15 +29,15 @@ pub enum MacosLauncher {
     AppleScript,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default)]
 pub enum PreferedName {
-    PackageInfoName,
-    PackageInfoCrateName,
-    ConfigIdentifier,
-    ConfigProductName,
-    Custom(String)
+    #[default]
+    AppName,
+    CrateName,
+    Identifier,
+    ProductName,
+    Custom(String),
 }
-
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -54,29 +56,25 @@ impl Serialize for Error {
     }
 }
 
-impl Default for PreferedName {
-    fn default() -> Self {
-        PreferedName::PackageInfoName
-    }
-}
-
 impl PreferedName {
     pub fn get_value<R: Runtime>(&self, app: &AppHandle<R>) -> String {
         match self {
-            PreferedName::PackageInfoName => {
-                app.package_info().name.to_string()
-            },
-            PreferedName::PackageInfoCrateName => {
-                app.package_info().crate_name.to_string()
-            },
-            PreferedName::ConfigIdentifier => {
-                app.config().identifier.to_string()
-            },
-            PreferedName::ConfigProductName => {
-                app.config().product_name.clone().unwrap_or("TauriAPP".to_string())
-            },
+            PreferedName::AppName => app.package_info().name.to_string(),
+            PreferedName::CrateName => app.package_info().crate_name.to_string(),
+            PreferedName::Identifier => app.config().identifier.to_string(),
+            PreferedName::ProductName => app
+                .config()
+                .product_name
+                .clone()
+                .unwrap_or("TauriAPP".to_string()),
             PreferedName::Custom(s) => s.clone(),
         }
+    }
+}
+
+impl<S: Into<String>> From<S> for PreferedName {
+    fn from(name: S) -> Self {
+        PreferedName::Custom(name.into())
     }
 }
 
@@ -137,7 +135,7 @@ pub struct Builder {
     #[cfg(target_os = "macos")]
     macos_launcher: MacosLauncher,
     args: Vec<String>,
-    prefered_name: PreferedName,
+    app_name: PreferedName,
 }
 
 impl Builder {
@@ -189,23 +187,23 @@ impl Builder {
         self
     }
 
-    /// Sets the preferred name to be used for the auto start entry.
+    /// Sets the app name to be used for the auto start entry.
     ///
     /// ## Examples
     ///
     /// ```no_run
     /// Builder::new()
-    ///     .prefered_name(PreferedName::PackageInfoName)
+    ///     .app_name(PreferedName::AppName)
     ///     .build();
     /// ```
     ///
     /// ```no_run
     /// Builder::new()
-    ///     .prefered_name(PreferedName::Custom("My Custom Name".into()))
+    ///     .app_name("My Custom Name"))
     ///     .build();
     /// ```
-    pub fn prefered_name(mut self, prefered_name: PreferedName) -> Self {
-        self.prefered_name = prefered_name;
+    pub fn app_name(mut self, app_name: impl Into<PreferedName>) -> Self {
+        self.app_name = app_name.into();
         self
     }
 
@@ -215,7 +213,7 @@ impl Builder {
             .setup(move |app, _api| {
                 let mut builder = AutoLaunchBuilder::new();
 
-                let prefered_name = self.prefered_name.get_value(&app);
+                let prefered_name = self.app_name.get_value(app);
                 builder.set_app_name(&prefered_name);
 
                 builder.set_args(&self.args);
@@ -274,7 +272,6 @@ impl Builder {
 pub fn init<R: Runtime>(
     #[allow(unused)] macos_launcher: MacosLauncher,
     args: Option<Vec<&'static str>>,
-    prefered_name: Option<PreferedName>
 ) -> TauriPlugin<R> {
     let mut builder = Builder::new();
     if let Some(args) = args {
@@ -284,6 +281,5 @@ pub fn init<R: Runtime>(
     {
         builder = builder.macos_launcher(macos_launcher);
     }
-    builder = builder.prefered_name(prefered_name.unwrap_or_default());
     builder.build()
 }

--- a/plugins/autostart/src/lib.rs
+++ b/plugins/autostart/src/lib.rs
@@ -164,8 +164,8 @@ impl Builder {
     ///     .app_name("My Custom Name"))
     ///     .build();
     /// ```
-    pub fn app_name(mut self, app_name: &str) -> Self {
-        self.app_name = Some(app_name.to_string());
+    pub fn app_name<S: Into<String>>(mut self, app_name: S) -> Self {
+        self.app_name = Some(app_name.into());
         self
     }
 
@@ -175,8 +175,11 @@ impl Builder {
             .setup(move |app, _api| {
                 let mut builder = AutoLaunchBuilder::new();
 
-                let app_name = self.app_name.unwrap_or(app.package_info().name.clone());
-                builder.set_app_name(&app_name);
+                let app_name = self
+                    .app_name
+                    .as_ref()
+                    .unwrap_or_else(|| &app.package_info().name);
+                builder.set_app_name(app_name);
 
                 builder.set_args(&self.args);
 

--- a/plugins/autostart/src/lib.rs
+++ b/plugins/autostart/src/lib.rs
@@ -15,7 +15,7 @@ use serde::{ser::Serializer, Serialize};
 use tauri::{
     command,
     plugin::{Builder as PluginBuilder, TauriPlugin},
-    AppHandle, Manager, Runtime, State,
+    Manager, Runtime, State,
 };
 
 use std::env::current_exe;
@@ -27,16 +27,6 @@ pub enum MacosLauncher {
     #[default]
     LaunchAgent,
     AppleScript,
-}
-
-#[derive(Default)]
-pub enum PreferedName {
-    #[default]
-    AppName,
-    CrateName,
-    Identifier,
-    ProductName,
-    Custom(String),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -53,28 +43,6 @@ impl Serialize for Error {
         S: Serializer,
     {
         serializer.serialize_str(self.to_string().as_ref())
-    }
-}
-
-impl PreferedName {
-    pub fn get_value<R: Runtime>(&self, app: &AppHandle<R>) -> String {
-        match self {
-            PreferedName::AppName => app.package_info().name.to_string(),
-            PreferedName::CrateName => app.package_info().crate_name.to_string(),
-            PreferedName::Identifier => app.config().identifier.to_string(),
-            PreferedName::ProductName => app
-                .config()
-                .product_name
-                .clone()
-                .unwrap_or("TauriAPP".to_string()),
-            PreferedName::Custom(s) => s.clone(),
-        }
-    }
-}
-
-impl<S: Into<String>> From<S> for PreferedName {
-    fn from(name: S) -> Self {
-        PreferedName::Custom(name.into())
     }
 }
 
@@ -135,7 +103,7 @@ pub struct Builder {
     #[cfg(target_os = "macos")]
     macos_launcher: MacosLauncher,
     args: Vec<String>,
-    app_name: PreferedName,
+    app_name: Option<String>,
 }
 
 impl Builder {
@@ -193,17 +161,11 @@ impl Builder {
     ///
     /// ```no_run
     /// Builder::new()
-    ///     .app_name(PreferedName::AppName)
-    ///     .build();
-    /// ```
-    ///
-    /// ```no_run
-    /// Builder::new()
     ///     .app_name("My Custom Name"))
     ///     .build();
     /// ```
-    pub fn app_name(mut self, app_name: impl Into<PreferedName>) -> Self {
-        self.app_name = app_name.into();
+    pub fn app_name(mut self, app_name: &str) -> Self {
+        self.app_name = Some(app_name.to_string());
         self
     }
 
@@ -213,8 +175,8 @@ impl Builder {
             .setup(move |app, _api| {
                 let mut builder = AutoLaunchBuilder::new();
 
-                let prefered_name = self.app_name.get_value(app);
-                builder.set_app_name(&prefered_name);
+                let app_name = self.app_name.unwrap_or(app.package_info().name.clone());
+                builder.set_app_name(&app_name);
 
                 builder.set_args(&self.args);
 

--- a/plugins/autostart/src/lib.rs
+++ b/plugins/autostart/src/lib.rs
@@ -13,9 +13,7 @@
 use auto_launch::{AutoLaunch, AutoLaunchBuilder};
 use serde::{ser::Serializer, Serialize};
 use tauri::{
-    command,
-    plugin::{Builder as PluginBuilder, TauriPlugin},
-    Manager, Runtime, State,
+    command, plugin::{Builder as PluginBuilder, TauriPlugin}, AppHandle, Manager, Runtime, State
 };
 
 use std::env::current_exe;
@@ -28,6 +26,16 @@ pub enum MacosLauncher {
     LaunchAgent,
     AppleScript,
 }
+
+#[derive(Debug, Clone)]
+pub enum PreferedName {
+    PackageInfoName,
+    PackageInfoCrateName,
+    ConfigIdentifier,
+    ConfigProductName,
+    Custom(String)
+}
+
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -43,6 +51,32 @@ impl Serialize for Error {
         S: Serializer,
     {
         serializer.serialize_str(self.to_string().as_ref())
+    }
+}
+
+impl Default for PreferedName {
+    fn default() -> Self {
+        PreferedName::PackageInfoName
+    }
+}
+
+impl PreferedName {
+    pub fn get_value<R: Runtime>(&self, app: &AppHandle<R>) -> String {
+        match self {
+            PreferedName::PackageInfoName => {
+                app.package_info().name.to_string()
+            },
+            PreferedName::PackageInfoCrateName => {
+                app.package_info().crate_name.to_string()
+            },
+            PreferedName::ConfigIdentifier => {
+                app.config().identifier.to_string()
+            },
+            PreferedName::ConfigProductName => {
+                app.config().product_name.clone().unwrap_or("TauriAPP".to_string())
+            },
+            PreferedName::Custom(s) => s.clone(),
+        }
     }
 }
 
@@ -103,6 +137,7 @@ pub struct Builder {
     #[cfg(target_os = "macos")]
     macos_launcher: MacosLauncher,
     args: Vec<String>,
+    prefered_name: PreferedName,
 }
 
 impl Builder {
@@ -154,12 +189,35 @@ impl Builder {
         self
     }
 
+    /// Sets the preferred name to be used for the auto start entry.
+    ///
+    /// ## Examples
+    ///
+    /// ```no_run
+    /// Builder::new()
+    ///     .prefered_name(PreferedName::PackageInfoName)
+    ///     .build();
+    /// ```
+    ///
+    /// ```no_run
+    /// Builder::new()
+    ///     .prefered_name(PreferedName::Custom("My Custom Name".into()))
+    ///     .build();
+    /// ```
+    pub fn prefered_name(mut self, prefered_name: PreferedName) -> Self {
+        self.prefered_name = prefered_name;
+        self
+    }
+
     pub fn build<R: Runtime>(self) -> TauriPlugin<R> {
         PluginBuilder::new("autostart")
             .invoke_handler(tauri::generate_handler![enable, disable, is_enabled])
             .setup(move |app, _api| {
                 let mut builder = AutoLaunchBuilder::new();
-                builder.set_app_name(&app.package_info().name);
+
+                let prefered_name = self.prefered_name.get_value(&app);
+                builder.set_app_name(&prefered_name);
+
                 builder.set_args(&self.args);
 
                 let current_exe = current_exe()?;
@@ -216,6 +274,7 @@ impl Builder {
 pub fn init<R: Runtime>(
     #[allow(unused)] macos_launcher: MacosLauncher,
     args: Option<Vec<&'static str>>,
+    prefered_name: Option<PreferedName>
 ) -> TauriPlugin<R> {
     let mut builder = Builder::new();
     if let Some(args) = args {
@@ -225,5 +284,6 @@ pub fn init<R: Runtime>(
     {
         builder = builder.macos_launcher(macos_launcher);
     }
+    builder = builder.prefered_name(prefered_name.unwrap_or_default());
     builder.build()
 }


### PR DESCRIPTION
### Add Prefered Name Configuration for AutoStart Entry  

This PR introduces the ability to customize the application name used in auto start entries by adding a `PreferedName` enum to support different naming strategies.  

#### Key Changes:  
- Added `PreferedName` enum with variants:  
  - `PackageInfoName` (default) – Uses name from Tauri's package info  
  - `PackageInfoCrateName` – Uses the crate name from `Cargo.toml`  
  - `ConfigIdentifier` – Uses the identifier from Tauri's runtime config  
  - `ConfigProductName` Uses the product_name from Tauri's runtime config
  - `Custom(String)` – Allows specifying a custom name  
- Implemented `Default` trait for `PreferedName` (defaults to `PackageInfoName`)  
- Added `prefered_name` builder method with documentation and usage examples  
- Integrated prefered name selection into auto start configuration  

#### Usage Example:  
```rust  
Builder::new()
     .prefered_name(PreferedName::PackageInfoName)
     .build();

Builder::new()
    .prefered_name(PreferedName::Custom("My Custom Name".into()))
     .build();
```  

This enhancement provides flexibility for apps that need to control their display name in system auto start entries, supporting use cases like branding adjustments or multi-instance differentiation.  
