### PR TITLE
feat(updater): add allowDowngrades option

### DIFF
--- a/.changes/add-allow-downgrades.md
+++ b/.changes/add-allow-downgrades.md
@@ -1,0 +1,8 @@
+---
+"@tauri-apps/plugin-updater": minor
+"tauri-plugin-updater": minor
+---
+
+Add allowDowngrades parameter to check command
+
+Added a new optional `allowDowngrades` parameter to the JavaScript check command that allows the updater to consider versions that are lower than the current version as valid updates. When enabled, the version comparator will accept any version that is different from the current version, effectively allowing downgrades.

--- a/.changes/add-allow-downgrades.md
+++ b/.changes/add-allow-downgrades.md
@@ -1,6 +1,6 @@
 ---
-"@tauri-apps/plugin-updater": minor
-"tauri-plugin-updater": minor
+"updater": minor
+"updater-js": minor
 ---
 
 Add allowDowngrades parameter to check command

--- a/plugins/updater/guest-js/index.ts
+++ b/plugins/updater/guest-js/index.ts
@@ -22,6 +22,10 @@ interface CheckOptions {
    * Target identifier for the running application. This is sent to the backend.
    */
   target?: string
+  /**
+   * Allow downgrades to previous versions by not checking if the current version is greater than the available version.
+   */
+  allowDowngrades?: boolean
 }
 
 /** Options used when downloading an update */

--- a/plugins/updater/src/commands.rs
+++ b/plugins/updater/src/commands.rs
@@ -46,6 +46,7 @@ pub(crate) async fn check<R: Runtime>(
     timeout: Option<u64>,
     proxy: Option<String>,
     target: Option<String>,
+    allow_downgrades: Option<bool>,
 ) -> Result<Option<Metadata>> {
     let mut builder = webview.updater_builder();
     if let Some(headers) = headers {
@@ -62,6 +63,9 @@ pub(crate) async fn check<R: Runtime>(
     }
     if let Some(target) = target {
         builder = builder.target(target);
+    }
+    if allow_downgrades.unwrap_or(false) {
+        builder = builder.version_comparator(|current, update| update.version != current);
     }
 
     let updater = builder.build()?;


### PR DESCRIPTION
**Summary**
This PR adds support for enabling downgrades via a JavaScript-side parameter in the updater plugin. Previously, downgrades could only be configured from the Rust side.

**Additional Notes**
I've also prepared a corresponding documentation update here:
[tauri-docs PR](https://github.com/tauri-apps/tauri-docs/compare/v2...brendanosborne:tauri-docs:patch-1)

I assume this should be submitted once this PR is approved and merged?