### PR TITLE
feat(cli): add support for global CLI arguments

### DIFF
--- a/.changes/add-global-flag-cli.md
+++ b/.changes/add-global-flag-cli.md
@@ -1,0 +1,8 @@
+---
+"cli": minor
+"cli-js": minor
+---
+
+Added a new `global` boolean flag to the `CliArg` struct to support global CLI arguments. This flag allows arguments like `--verbose` to be marked as global and automatically propagated to all subcommands, enabling consistent availability throughout the CLI.
+
+The new field is optional and defaults to false.

--- a/plugins/cli/src/config.rs
+++ b/plugins/cli/src/config.rs
@@ -114,6 +114,12 @@ pub struct Arg {
     /// It does not define position in the argument list as a whole. When utilized with multiple=true,
     /// only the last positional argument may be defined as multiple (i.e. the one with the highest index).
     pub index: Option<usize>,
+    /// Specifies whether the argument should be global.
+    ///
+    /// Global arguments are propagated to all subcommands automatically,
+    /// making them available throughout the CLI regardless of where they are defined.
+    #[serde(default)]
+    pub global: bool,
 }
 
 /// describes a CLI configuration

--- a/plugins/cli/src/parser.rs
+++ b/plugins/cli/src/parser.rs
@@ -278,5 +278,7 @@ fn get_arg(arg_name: String, arg: &Arg) -> ClapArg {
     clap_arg = bind_value_arg!(arg, clap_arg, require_equals);
     clap_arg = bind_value_arg!(arg, clap_arg, index);
 
+    clap_arg = clap_arg.global(arg.global);
+
     clap_arg
 }


### PR DESCRIPTION
Added a new `global: bool` field to the CliArg struct to support global CLI arguments.

Global arguments are automatically propagated to all subcommands, making them available throughout the CLI regardless of where they are defined. This flag is placed near other top-level behavioral flags for better organization and readability.

This is useful for flags like --verbose that are commonly needed across all levels of a command hierarchy.

The new field is optional and defaults to false.