### PR TITLE
feat: [cli] Pass optional args to get matches

### DIFF
--- a/.changes/add-cli-matches-from.md
+++ b/.changes/add-cli-matches-from.md
@@ -1,5 +1,6 @@
 ---
 "cli": minor
+"cli-js": minor
 ---
 
 Added `Cli.matches_from(args)`. This can be combined with the `args` passed to the callback of `tauri_plugin_single_instance::init` to parse the command line arguments passed to subsequent instances of the application.

--- a/.changes/add-cli-matches-from.md
+++ b/.changes/add-cli-matches-from.md
@@ -1,0 +1,5 @@
+---
+"cli": minor
+---
+
+Added `Cli.matches_from(args)`. This can be combined with the `args` passed to the callback of `tauri_plugin_single_instance::init` to parse the command line arguments passed to subsequent instances of the application.

--- a/.changes/add-optional-args-cli.md
+++ b/.changes/add-optional-args-cli.md
@@ -1,5 +1,0 @@
----
-"cli": minor
----
-
-Added `tauri_plugin_cli::matches_from`. This can be combined with the `args` passed to the callback of `tauri_plugin_single_instance` to parse  the command line arguments passed to subsequent instances of the application.

--- a/.changes/add-optional-args-cli.md
+++ b/.changes/add-optional-args-cli.md
@@ -1,0 +1,5 @@
+---
+"cli": minor
+---
+
+Added `tauri_plugin_cli::matches_from`. This can be combined with the `args` passed to the callback of `tauri_plugin_single_instance` to parse  the command line arguments passed to subsequent instances of the application.

--- a/plugins/cli/src/lib.rs
+++ b/plugins/cli/src/lib.rs
@@ -28,8 +28,8 @@ pub use parser::{ArgData, Matches, SubcommandMatches};
 pub struct Cli<R: Runtime>(PluginApi<R, Config>);
 
 impl<R: Runtime> Cli<R> {
-    pub fn matches(&self) -> Result<parser::Matches> {
-        parser::get_matches(self.0.config(), self.0.app().package_info())
+    pub fn matches(&self, args: Option<Vec<String>>) -> Result<parser::Matches> {
+        parser::get_matches(self.0.config(), self.0.app().package_info(), args)
     }
 }
 
@@ -45,7 +45,7 @@ impl<R: Runtime, T: Manager<R>> CliExt<R> for T {
 
 #[tauri::command]
 fn cli_matches<R: Runtime>(_app: AppHandle<R>, cli: State<'_, Cli<R>>) -> Result<parser::Matches> {
-    cli.matches()
+    cli.matches(None::<Vec<String>>)
 }
 
 pub fn init<R: Runtime>() -> TauriPlugin<R, Config> {

--- a/plugins/cli/src/lib.rs
+++ b/plugins/cli/src/lib.rs
@@ -28,8 +28,12 @@ pub use parser::{ArgData, Matches, SubcommandMatches};
 pub struct Cli<R: Runtime>(PluginApi<R, Config>);
 
 impl<R: Runtime> Cli<R> {
-    pub fn matches(&self, args: Option<Vec<String>>) -> Result<parser::Matches> {
-        parser::get_matches(self.0.config(), self.0.app().package_info(), args)
+    pub fn matches(&self) -> Result<parser::Matches> {
+        parser::get_matches(self.0.config(), self.0.app().package_info(), None)
+    }
+
+    pub fn matches_from(&self, args: Vec<String>) -> Result<parser::Matches> {
+        parser::get_matches(self.0.config(), self.0.app().package_info(), Some(args))
     }
 }
 
@@ -45,7 +49,7 @@ impl<R: Runtime, T: Manager<R>> CliExt<R> for T {
 
 #[tauri::command]
 fn cli_matches<R: Runtime>(_app: AppHandle<R>, cli: State<'_, Cli<R>>) -> Result<parser::Matches> {
-    cli.matches(None::<Vec<String>>)
+    cli.matches()
 }
 
 pub fn init<R: Runtime>() -> TauriPlugin<R, Config> {

--- a/plugins/cli/src/parser.rs
+++ b/plugins/cli/src/parser.rs
@@ -97,10 +97,7 @@ pub fn get_matches(
         cli,
     );
 
-    let matches = if let Some(mut args) = args {
-        // try_get_matches_from assumes the first argument is the command name,
-        // so we prepend something to get the correct matches.
-        args.insert(0, package_info.name.clone());
+    let matches = if let Some(args) = args {
         app.try_get_matches_from(args)
     } else {
         app.try_get_matches()

--- a/plugins/cli/src/parser.rs
+++ b/plugins/cli/src/parser.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 mod macros;
 
 /// The resolution of a argument match.
-#[derive(Default, Debug, Serialize)]
+#[derive(Default, Debug, Serialize, Clone)]
 #[non_exhaustive]
 pub struct ArgData {
     /// - [`Value::Bool`] if it's a flag,
@@ -33,7 +33,7 @@ pub struct ArgData {
 }
 
 /// The matched subcommand.
-#[derive(Default, Debug, Serialize)]
+#[derive(Default, Debug, Serialize, Clone)]
 #[non_exhaustive]
 pub struct SubcommandMatches {
     /// The subcommand name.
@@ -43,7 +43,7 @@ pub struct SubcommandMatches {
 }
 
 /// The argument matches of a command.
-#[derive(Default, Debug, Serialize)]
+#[derive(Default, Debug, Serialize, Clone)]
 #[non_exhaustive]
 pub struct Matches {
     /// Data structure mapping each found arg with its resolution.

--- a/plugins/cli/src/parser.rs
+++ b/plugins/cli/src/parser.rs
@@ -79,7 +79,11 @@ impl Matches {
 ///     Ok(())
 ///   });
 /// ```
-pub fn get_matches(cli: &Config, package_info: &PackageInfo) -> crate::Result<Matches> {
+pub fn get_matches(
+    cli: &Config,
+    package_info: &PackageInfo,
+    args: Option<Vec<String>>,
+) -> crate::Result<Matches> {
     let about = cli
         .description()
         .unwrap_or(&package_info.description.to_string())
@@ -92,7 +96,17 @@ pub fn get_matches(cli: &Config, package_info: &PackageInfo) -> crate::Result<Ma
         Some(&about),
         cli,
     );
-    match app.try_get_matches() {
+
+    let matches = if let Some(mut args) = args {
+        // try_get_matches_from assumes the first argument is the command name,
+        // so we prepend something to get the correct matches.
+        args.insert(0, package_info.name.clone());
+        app.try_get_matches_from(args)
+    } else {
+        app.try_get_matches()
+    };
+
+    match matches {
         Ok(matches) => Ok(get_matches_internal(cli, &matches)),
         Err(e) => match e.kind() {
             ErrorKind::DisplayHelp => {


### PR DESCRIPTION
This makes it possible for people to use the CLI plugin in tandem with the single-instance plugin:

```rust
.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
  let matches = app.cli().matches(Some(args));
  match matches {
    Ok(matches) => {
      // Do something with matches
    }
    Err(e) => {
      eprintln!("Error parsing CLI arguments: {}", e);
    }
  }
}))
```

Note it's still a little awkward to actually use. If people want to send the matches to the client, they need to encode / decode them themselves as `emit_to` expects the data to be clone-able.

eg Here's what I have to do on the Rust side:

```rust
let serialized = serde_json::to_string(&matches).unwrap();
let _ = app.emit_to("main", "cli", serialized);
```

and on the client side:

```ts
listen<string>('cli', async (event) => {
  const matches: CliMatches = JSON.parse(event.payload)

  // Do something with matches
})
```

Closes #2785 