### PR TITLE
fix(dialog): remove use of ACTION_PICK

### DIFF
--- a/.changes/fix-dialog-android-filters.md
+++ b/.changes/fix-dialog-android-filters.md
@@ -1,0 +1,6 @@
+---
+dialog: patch
+dialog-js: patch
+---
+
+Fixed an issue that caused the file picker not to open on Android when extension filters were set.

--- a/plugins/dialog/android/src/main/java/DialogPlugin.kt
+++ b/plugins/dialog/android/src/main/java/DialogPlugin.kt
@@ -130,34 +130,6 @@ class DialogPlugin(private val activity: Activity): Plugin(activity) {
     return mimeTypes.toTypedArray()
   }
 
-  private fun setIntentMimeTypes(intent: Intent, mimeTypes: Array<String>) {
-    if (mimeTypes.isNotEmpty()) {
-      var uniqueMimeKind = true
-      var mimeKind: String? = null
-      for (mime in mimeTypes) {
-        val kind = mime.split("/")[0]
-        if (mimeKind == null) {
-          mimeKind = kind
-        } else if (mimeKind != kind) {
-          uniqueMimeKind = false
-        }
-      }
-
-      if (uniqueMimeKind) {
-        if (mimeTypes.size > 1) {
-          intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
-          intent.type = Intent.normalizeMimeType("$mimeKind/*")
-        } else {
-          intent.type = mimeTypes[0]
-        }
-      } else {
-        intent.type = "*/*"
-      }
-    } else {
-      intent.type = "*/*"
-    }
-  }
-
   @Command
   fun showMessageDialog(invoke: Invoke) {
     val args = invoke.parseArgs(MessageOptions::class.java)
@@ -211,10 +183,14 @@ class DialogPlugin(private val activity: Activity): Plugin(activity) {
       val parsedTypes = parseFiltersOption(args.filters)
 
       val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
-      setIntentMimeTypes(intent, parsedTypes)
-
       intent.addCategory(Intent.CATEGORY_OPENABLE)
       intent.putExtra(Intent.EXTRA_TITLE, args.fileName ?: "")
+      intent.type = "*/*"
+
+      if (parsedTypes.isNotEmpty()) {
+        intent.putExtra(Intent.EXTRA_MIME_TYPES, parsedTypes)
+      }
+
       startActivityForResult(invoke, intent, "saveFileDialogResult")
     } catch (ex: Exception) {
       val message = ex.message ?: "Failed to pick save file"

--- a/plugins/dialog/android/src/main/java/DialogPlugin.kt
+++ b/plugins/dialog/android/src/main/java/DialogPlugin.kt
@@ -56,20 +56,18 @@ class DialogPlugin(private val activity: Activity): Plugin(activity) {
     try {
       val args = invoke.parseArgs(FilePickerOptions::class.java)
       val parsedTypes = parseFiltersOption(args.filters)
-      
-      val intent = if (parsedTypes.isNotEmpty()) {
-        val intent = Intent(Intent.ACTION_PICK)
-        setIntentMimeTypes(intent, parsedTypes)
-        intent
-      } else {
-        val intent = Intent(Intent.ACTION_GET_CONTENT)
-        intent.addCategory(Intent.CATEGORY_OPENABLE)
-        intent.type = "*/*"
-        intent
+
+      // TODO: ACTION_OPEN_DOCUMENT ??
+      val intent = Intent(Intent.ACTION_GET_CONTENT)
+      intent.addCategory(Intent.CATEGORY_OPENABLE)
+      intent.type = "*/*"
+
+      if (parsedTypes.isNotEmpty()) {
+        intent.putExtra(Intent.EXTRA_MIME_TYPES, parsedTypes)
       }
 
       intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, args.multiple ?: false)
-      
+
       startActivityForResult(invoke, intent, "filePickerResult")
     } catch (ex: Exception) {
       val message = ex.message ?: "Failed to pick file"
@@ -115,7 +113,7 @@ class DialogPlugin(private val activity: Activity): Plugin(activity) {
     callResult.put("files", JSArray.from(uris.toTypedArray()))
     return callResult
   }
-  
+
   private fun parseFiltersOption(filters: Array<Filter>): Array<String> {
     val mimeTypes = mutableListOf<String>()
     for (filter in filters) {
@@ -159,11 +157,11 @@ class DialogPlugin(private val activity: Activity): Plugin(activity) {
       intent.type = "*/*"
     }
   }
-  
+
   @Command
   fun showMessageDialog(invoke: Invoke) {
     val args = invoke.parseArgs(MessageOptions::class.java)
-    
+
     if (activity.isFinishing) {
       invoke.reject("App is finishing")
       return
@@ -179,7 +177,7 @@ class DialogPlugin(private val activity: Activity): Plugin(activity) {
     Handler(Looper.getMainLooper())
       .post {
         val builder = AlertDialog.Builder(activity)
-        
+
         if (args.title != null) {
           builder.setTitle(args.title)
         }


### PR DESCRIPTION
fixes #2423
fixes #2826
closes #2866

from a bit of googling around it seems like there's no reason to use ACTION_PICK like ever. Replacing it with what we use when no filters are set was enough to fix the issue. From quite a bit of testing there also seems no reason for that `setIntentMimeTypes` function to exist. I did not see any difference in behavior so i'd prefer to remove it.

And yes, setting */* even if you set a single filter is totally fine.