### PR TITLE
(fix: #2884) iOS NFC: Ensure that Session is closed when an error causes it to become invalid

### DIFF
--- a/.changes/nfc-close-session.md
+++ b/.changes/nfc-close-session.md
@@ -1,0 +1,6 @@
+---
+nfc: patch
+nfc-js: patch
+---
+
+On iOS, the reader session will now get closed properly on errors, preventing dangling invalid sessions that could prevent subsequent write attempts.

--- a/plugins/nfc/ios/Sources/NfcPlugin.swift
+++ b/plugins/nfc/ios/Sources/NfcPlugin.swift
@@ -148,8 +148,8 @@ class NfcPlugin: Plugin, NFCTagReaderSessionDelegate, NFCNDEFReaderSessionDelega
 
   func tagReaderSession(_ session: NFCTagReaderSession, didInvalidateWithError error: Error) {
     Logger.error("Tag reader session error \(error)")
-    self.closeSession(session, error: "Tag reader session error: \(error)")
     self.session?.invoke.reject("session invalidated with error: \(error)")
+    self.session = nil
   }
 
   func readerSession(_ session: NFCNDEFReaderSession, didDetectNDEFs messages: [NFCNDEFMessage]) {
@@ -200,8 +200,8 @@ class NfcPlugin: Plugin, NFCTagReaderSessionDelegate, NFCNDEFReaderSessionDelega
       Logger.debug("readerSessionInvalidationErrorFirstNDEFTagRead")
     } else {
       Logger.error("NDEF reader session error \(error)")
-      self.closeSession(session, error: "NDEF reader session error: \(error)")
       self.session?.invoke.reject("session invalidated with error: \(error)")
+      self.session = nil
     }
   }
 

--- a/plugins/nfc/ios/Sources/NfcPlugin.swift
+++ b/plugins/nfc/ios/Sources/NfcPlugin.swift
@@ -148,6 +148,7 @@ class NfcPlugin: Plugin, NFCTagReaderSessionDelegate, NFCNDEFReaderSessionDelega
 
   func tagReaderSession(_ session: NFCTagReaderSession, didInvalidateWithError error: Error) {
     Logger.error("Tag reader session error \(error)")
+    self.closeSession(session, error: "Tag reader session error: \(error)")
     self.session?.invoke.reject("session invalidated with error: \(error)")
   }
 
@@ -199,6 +200,7 @@ class NfcPlugin: Plugin, NFCTagReaderSessionDelegate, NFCNDEFReaderSessionDelega
       Logger.debug("readerSessionInvalidationErrorFirstNDEFTagRead")
     } else {
       Logger.error("NDEF reader session error \(error)")
+      self.closeSession(session, error: "NDEF reader session error: \(error)")
       self.session?.invoke.reject("session invalidated with error: \(error)")
     }
   }


### PR DESCRIPTION
### Issue being fixed
Original issue: https://github.com/tauri-apps/plugins-workspace/issues/2884
Essentially, there are some cases where an NFC session becomes invalid, but the plugin doesn't properly close the session. This can occur if the user cancels the session before writing to a card, for example. In these cases, any subsequent writes fail immediately because a session is open, but it is invalid. 

### Changes made
In the case that a session is invalidated, instead of just logging the error and rejecting the invoke call, the session is also invalidated now. 