### PR TITLE
docs: Remove mirror install instructions

### DIFF
--- a/plugins/autostart/README.md
+++ b/plugins/autostart/README.md
@@ -33,21 +33,12 @@ tauri-plugin-autostart = { git = "https://github.com/tauri-apps/plugins-workspac
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-autostart
 # or
 npm add @tauri-apps/plugin-autostart
 # or
 yarn add @tauri-apps/plugin-autostart
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-autostart#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-autostart#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-autostart#v2
 ```
 
 ## Usage

--- a/plugins/barcode-scanner/README.md
+++ b/plugins/barcode-scanner/README.md
@@ -33,21 +33,12 @@ tauri-plugin-barcode-scanner = { git = "https://github.com/tauri-apps/plugins-wo
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-barcode-scanner
 # or
 npm add @tauri-apps/plugin-barcode-scanner
 # or
 yarn add @tauri-apps/plugin-barcode-scanner
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-barcode-scanner#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-barcode-scanner#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-barcode-scanner#v2
 ```
 
 ## Usage

--- a/plugins/biometric/README.md
+++ b/plugins/biometric/README.md
@@ -33,8 +33,6 @@ tauri-plugin-biometric = { git = "https://github.com/tauri-apps/plugins-workspac
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 <!-- Add the branch for installations using git! -->
 
 ```sh
@@ -43,13 +41,6 @@ pnpm add @tauri-apps/plugin-biometric
 npm add @tauri-apps/plugin-biometric
 # or
 yarn add @tauri-apps/plugin-biometric
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-biometric#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-biometric#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-biometric#v2
 ```
 
 ## Usage

--- a/plugins/cli/README.md
+++ b/plugins/cli/README.md
@@ -34,21 +34,12 @@ tauri-plugin-cli = { git = "https://github.com/tauri-apps/plugins-workspace", br
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-cli
 # or
 npm add @tauri-apps/plugin-cli
 # or
 yarn add @tauri-apps/plugin-cli
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-cli#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-cli#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-cli#v2
 ```
 
 ## Usage

--- a/plugins/clipboard-manager/README.md
+++ b/plugins/clipboard-manager/README.md
@@ -33,21 +33,12 @@ tauri-plugin-clipboard-manager = { git = "https://github.com/tauri-apps/plugins-
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-clipboard-manager
 # or
 npm add @tauri-apps/plugin-clipboard-manager
 # or
 yarn add @tauri-apps/plugin-clipboard-manager
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-clipboard-manager#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-clipboard-manager#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-clipboard-manager#v2
 ```
 
 ## Usage

--- a/plugins/deep-link/README.md
+++ b/plugins/deep-link/README.md
@@ -33,21 +33,12 @@ tauri-plugin-deep-link = { git = "https://github.com/tauri-apps/plugins-workspac
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-deep-link
 # or
 npm add @tauri-apps/plugin-deep-link
 # or
 yarn add @tauri-apps/plugin-deep-link
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-deep-link#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-deep-link#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-deep-link#v2
 ```
 
 ## Setting up

--- a/plugins/dialog/README.md
+++ b/plugins/dialog/README.md
@@ -33,21 +33,12 @@ tauri-plugin-dialog = { git = "https://github.com/tauri-apps/plugins-workspace",
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-dialog
 # or
 npm add @tauri-apps/plugin-dialog
 # or
 yarn add @tauri-apps/plugin-dialog
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-dialog#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-dialog#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-dialog#v2
 ```
 
 ## Usage

--- a/plugins/fs/README.md
+++ b/plugins/fs/README.md
@@ -33,21 +33,12 @@ tauri-plugin-fs = { git = "https://github.com/tauri-apps/plugins-workspace", bra
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-fs
 # or
 npm add @tauri-apps/plugin-fs
 # or
 yarn add @tauri-apps/plugin-fs
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-fs#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-fs#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-fs#v2
 ```
 
 ## Usage

--- a/plugins/geolocation/README.md
+++ b/plugins/geolocation/README.md
@@ -33,8 +33,6 @@ tauri-plugin-geolocation = { git = "https://github.com/tauri-apps/plugins-worksp
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 <!-- Add the branch for installations using git! -->
 
 ```sh
@@ -43,13 +41,6 @@ pnpm add @tauri-apps/plugin-geolocation
 npm add @tauri-apps/plugin-geolocation
 # or
 yarn add @tauri-apps/plugin-geolocation
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-geolocation#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-geolocation#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-geolocation#v2
 ```
 
 ## Setting up

--- a/plugins/global-shortcut/README.md
+++ b/plugins/global-shortcut/README.md
@@ -34,21 +34,12 @@ tauri-plugin-global-shortcut = { git = "https://github.com/tauri-apps/plugins-wo
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-global-shortcut
 # or
 npm add @tauri-apps/plugin-global-shortcut
 # or
 yarn add @tauri-apps/plugin-global-shortcut
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-global-shortcut#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-global-shortcut#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-global-shortcut#v2
 ```
 
 ## Usage

--- a/plugins/haptics/README.md
+++ b/plugins/haptics/README.md
@@ -35,8 +35,6 @@ tauri-plugin-haptics = { git = "https://github.com/tauri-apps/plugins-workspace"
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 <!-- Add the branch for installations using git! -->
 
 ```sh
@@ -45,13 +43,6 @@ pnpm add @tauri-apps/plugin-haptics
 npm add @tauri-apps/plugin-haptics
 # or
 yarn add @tauri-apps/plugin-haptics
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-haptics#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-haptics#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-haptics#v2
 ```
 
 ## Usage

--- a/plugins/http/README.md
+++ b/plugins/http/README.md
@@ -33,21 +33,12 @@ tauri-plugin-http = { git = "https://github.com/tauri-apps/plugins-workspace", b
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-http
 # or
 npm add @tauri-apps/plugin-http
 # or
 yarn add @tauri-apps/plugin-http
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-http#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-http#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-http#v2
 ```
 
 ## Usage

--- a/plugins/log/README.md
+++ b/plugins/log/README.md
@@ -35,21 +35,12 @@ If you want the single instance mechanism to only trigger for semver compatible 
 
 Then you can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-log
 # or
 npm add @tauri-apps/plugin-log
 # or
 yarn add @tauri-apps/plugin-log
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-log#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-log#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-log#v2
 ```
 
 ## Usage

--- a/plugins/nfc/README.md
+++ b/plugins/nfc/README.md
@@ -33,8 +33,6 @@ tauri-plugin-nfc = { git = "https://github.com/tauri-apps/plugins-workspace", br
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 <!-- Add the branch for installations using git! -->
 
 ```sh
@@ -43,13 +41,6 @@ pnpm add @tauri-apps/plugin-nfc
 npm add @tauri-apps/plugin-nfc
 # or
 yarn add @tauri-apps/plugin-nfc
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-nfc#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-nfc#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-nfc#v2
 ```
 
 ## Usage

--- a/plugins/notification/README.md
+++ b/plugins/notification/README.md
@@ -33,21 +33,12 @@ tauri-plugin-notification = { git = "https://github.com/tauri-apps/plugins-works
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-notification
 # or
 npm add @tauri-apps/plugin-notification
 # or
 yarn add @tauri-apps/plugin-notification
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-notification#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-notification#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-notification#v2
 ```
 
 ## Usage

--- a/plugins/opener/README.md
+++ b/plugins/opener/README.md
@@ -33,8 +33,6 @@ tauri-plugin-opener = { git = "https://github.com/tauri-apps/plugins-workspace",
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 <!-- Add the branch for installations using git! -->
 
 ```sh
@@ -43,13 +41,6 @@ pnpm add @tauri-apps/plugin-opener
 npm add @tauri-apps/plugin-opener
 # or
 yarn add @tauri-apps/plugin-opener
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-opener#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-opener#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-opener#v2
 ```
 
 ## Usage

--- a/plugins/os/README.md
+++ b/plugins/os/README.md
@@ -33,21 +33,12 @@ tauri-plugin-os = { git = "https://github.com/tauri-apps/plugins-workspace", bra
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-os
 # or
 npm add @tauri-apps/plugin-os
 # or
 yarn add @tauri-apps/plugin-os
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-os#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-os#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-os#v2
 ```
 
 ## Usage

--- a/plugins/positioner/README.md
+++ b/plugins/positioner/README.md
@@ -35,21 +35,12 @@ tauri-plugin-positioner = { git = "https://github.com/tauri-apps/plugins-workspa
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-positioner
 # or
 npm add @tauri-apps/plugin-positioner
 # or
 yarn add @tauri-apps/plugin-positioner
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-positioner#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-positioner#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-positioner#v2
 ```
 
 ## Usage

--- a/plugins/process/README.md
+++ b/plugins/process/README.md
@@ -33,21 +33,12 @@ tauri-plugin-process = { git = "https://github.com/tauri-apps/plugins-workspace"
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-process
 # or
 npm add @tauri-apps/plugin-process
 # or
 yarn add @tauri-apps/plugin-process
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-process#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-process#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-process#v2
 ```
 
 ## Usage

--- a/plugins/shell/README.md
+++ b/plugins/shell/README.md
@@ -33,21 +33,12 @@ tauri-plugin-shell = { git = "https://github.com/tauri-apps/plugins-workspace", 
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-shell
 # or
 npm add @tauri-apps/plugin-shell
 # or
 yarn add @tauri-apps/plugin-shell
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-shell#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-shell#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-shell#v2
 ```
 
 ## Usage

--- a/plugins/sql/README.md
+++ b/plugins/sql/README.md
@@ -35,21 +35,12 @@ branch = "v2"
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-sql
 # or
 npm add @tauri-apps/plugin-sql
 # or
 yarn add @tauri-apps/plugin-sql
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-sql#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-sql#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-sql#v2
 ```
 
 ## Usage

--- a/plugins/store/README.md
+++ b/plugins/store/README.md
@@ -33,21 +33,12 @@ tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", 
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-store
 # or
 npm add @tauri-apps/plugin-store
 # or
 yarn add @tauri-apps/plugin-store
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-store#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-store#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-store#v2
 ```
 
 ## Usage

--- a/plugins/stronghold/README.md
+++ b/plugins/stronghold/README.md
@@ -41,13 +41,6 @@ pnpm add @tauri-apps/plugin-stronghold
 npm add @tauri-apps/plugin-stronghold
 # or
 yarn add @tauri-apps/plugin-stronghold
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-stronghold#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-stronghold#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-stronghold#v2
 ```
 
 ## Usage

--- a/plugins/updater/README.md
+++ b/plugins/updater/README.md
@@ -34,21 +34,12 @@ tauri-plugin-updater = { git = "https://github.com/tauri-apps/plugins-workspace"
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-updater
 # or
 npm add @tauri-apps/plugin-updater
 # or
 yarn add @tauri-apps/plugin-updater
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-updater#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-updater#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-updater#v2
 ```
 
 ## Usage

--- a/plugins/upload/README.md
+++ b/plugins/upload/README.md
@@ -34,21 +34,12 @@ tauri-plugin-upload = { git = "https://github.com/tauri-apps/plugins-workspace",
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-upload
 # or
 npm add @tauri-apps/plugin-upload
 # or
 yarn add @tauri-apps/plugin-upload
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-upload#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-upload#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-upload#v2
 ```
 
 ## Usage

--- a/plugins/websocket/README.md
+++ b/plugins/websocket/README.md
@@ -33,21 +33,12 @@ tauri-plugin-websocket = { git = "https://github.com/tauri-apps/plugins-workspac
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-websocket
 # or
 npm add @tauri-apps/plugin-websocket
 # or
 yarn add @tauri-apps/plugin-websocket
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-websocket#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-websocket#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-websocket#v2
 ```
 
 ## Usage

--- a/plugins/window-state/README.md
+++ b/plugins/window-state/README.md
@@ -33,21 +33,12 @@ tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-works
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
 ```sh
 pnpm add @tauri-apps/plugin-window-state
 # or
 npm add @tauri-apps/plugin-window-state
 # or
 yarn add @tauri-apps/plugin-window-state
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-window-state#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-window-state#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-window-state#v2
 ```
 
 ## Usage

--- a/shared/template/README.md
+++ b/shared/template/README.md
@@ -33,23 +33,12 @@ tauri-plugin-PLUGIN_NAME = { git = "https://github.com/tauri-apps/plugins-worksp
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager:
 
-> Note: Since most JavaScript package managers are unable to install packages from git monorepos we provide read-only mirrors of each plugin. This makes installation option 2 more ergonomic to use.
-
-<!-- Add the branch for installations using git! -->
-
 ```sh
 pnpm add @tauri-apps/plugin-PLUGIN_NAME
 # or
 npm add @tauri-apps/plugin-PLUGIN_NAME
 # or
 yarn add @tauri-apps/plugin-PLUGIN_NAME
-
-# alternatively with Git:
-pnpm add https://github.com/tauri-apps/tauri-plugin-PLUGIN_NAME#v2
-# or
-npm add https://github.com/tauri-apps/tauri-plugin-PLUGIN_NAME#v2
-# or
-yarn add https://github.com/tauri-apps/tauri-plugin-PLUGIN_NAME#v2
 ```
 
 ## Usage


### PR DESCRIPTION
closes #2892

some of those plugins never got a mirror, the mirrors are kinda deprecated and i'd like to completely drop them in v3.