### PR TITLE
refactor(opener): rename to FailedToConvertPathToItemIdList

### DIFF
--- a/plugins/opener/src/error.rs
+++ b/plugins/opener/src/error.rs
@@ -31,8 +31,9 @@ pub enum Error {
     Win32Error(#[from] windows::core::Error),
     #[error("Path doesn't have a parent: {0}")]
     NoParent(PathBuf),
-    #[error("Path is invalid: {0}")]
-    InvalidPath(PathBuf),
+    #[cfg(windows)]
+    #[error("Failed to convert path '{0}' to ITEMIDLIST")]
+    FailedToConvertPathToItemIdList(PathBuf),
     #[error("Failed to convert path to file:// url")]
     FailedToConvertPathToFileUrl,
     #[error(transparent)]

--- a/plugins/opener/src/reveal_item_in_dir.rs
+++ b/plugins/opener/src/reveal_item_in_dir.rs
@@ -169,7 +169,9 @@ mod imp {
             let path_hstring = HSTRING::from(path);
             let item_id_list = unsafe { ILCreateFromPathW(&path_hstring) };
             if item_id_list.is_null() {
-                Err(crate::Error::InvalidPath(path.to_owned()))
+                Err(crate::Error::FailedToConvertPathToItemIdList(
+                    path.to_owned(),
+                ))
             } else {
                 Ok(Self {
                     hstring: path_hstring,


### PR DESCRIPTION
Before we publish #2897, wants to change `InvalidPath` to something more clear