### PR TITLE
feat(autostart): remove `&'static` constraint for `init(args)` parameter

### DIFF
--- a/.changes/autostart-remove-static-constraint.md
+++ b/.changes/autostart-remove-static-constraint.md
@@ -1,0 +1,6 @@
+---
+autostart: minor:enhance
+autostart-js: minor:enhance
+---
+
+Use the generic `IntoIterator<Item = impl Into<String>>` instead of `Vec<&'static str>` as the parameter type for `init(args)` to remove the `&'static` lifetime constraint.

--- a/plugins/autostart/src/lib.rs
+++ b/plugins/autostart/src/lib.rs
@@ -234,10 +234,14 @@ impl Builder {
 /// Initializes the plugin.
 ///
 /// `args` - are passed to your app on startup.
-pub fn init<R: Runtime>(
+pub fn init<R: Runtime, I, S>(
     #[allow(unused)] macos_launcher: MacosLauncher,
-    args: Option<Vec<&'static str>>,
-) -> TauriPlugin<R> {
+    args: Option<I>,
+) -> TauriPlugin<R>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
     let mut builder = Builder::new();
     if let Some(args) = args {
         builder = builder.args(args)

--- a/plugins/autostart/src/lib.rs
+++ b/plugins/autostart/src/lib.rs
@@ -234,6 +234,7 @@ impl Builder {
 /// Initializes the plugin.
 ///
 /// `args` - are passed to your app on startup.
+// TODO: Remove `init` function or `args` argument in v3
 pub fn init<R: Runtime, I, S>(
     #[allow(unused)] macos_launcher: MacosLauncher,
     args: Option<I>,


### PR DESCRIPTION
The `&'static str` makes `fn init` almost useless for [FFI scenarios](https://github.com/pytauri/pytauri/blob/87e0cd4d45e8ce5021428a8a7da16abc43e4b372/crates/pytauri-core/src/plugins/autostart/mod.rs#L74-L81). Therefore, I replaced it with `IntoIterator<Item = impl Into<String>>`, but this [could be a breaking change](https://doc.rust-lang.org/cargo/reference/semver.html#fn-generic-new).

What does the Tauri team think about this? If semantic compatibility prevents this improvement in v2, I am ok with temporarily implementing a new `init` downstream using a `Builder`.