### PR TITLE
fix(os): unlock serialize-to-javascript dependency version

### DIFF
--- a/.changes/os-serialize-to-javascript-version.md
+++ b/.changes/os-serialize-to-javascript-version.md
@@ -1,0 +1,6 @@
+---
+os: patch
+os-js: patch
+---
+
+Unlocked version of `serialize-to-javascript` from `=0.1.1` to `^0.1.1` for compatibility with Tauri's upcoming version `2.8`.

--- a/plugins/os/Cargo.toml
+++ b/plugins/os/Cargo.toml
@@ -32,4 +32,4 @@ thiserror = { workspace = true }
 os_info = "3"
 sys-locale = "0.3"
 gethostname = "1.0"
-serialize-to-javascript = "=0.1.1"
+serialize-to-javascript = "0.1.1"


### PR DESCRIPTION
from my limited testing cargo seems to be smart enough to derive the correct version from tauri's deps