### PR TITLE
fix: Specify Generic for readFile ArrayBuffer (fix #2914)

### DIFF
--- a/.changes/fs-write-uint8array-arraybuffer.md
+++ b/.changes/fs-write-uint8array-arraybuffer.md
@@ -1,0 +1,6 @@
+---
+fs: patch
+fs-js: patch
+---
+
+`readFile` now returns a more specific type `Promise<Uint8Array<ArrayBuffer>>` instead of the default `Promise<Uint8Array<ArrayBufferLike>`

--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -739,7 +739,7 @@ interface ReadFileOptions {
 async function readFile(
   path: string | URL,
   options?: ReadFileOptions
-): Promise<Uint8Array> {
+): Promise<Uint8Array<ArrayBuffer>> {
   if (path instanceof URL && path.protocol !== 'file:') {
     throw new TypeError('Must be a file URL.')
   }


### PR DESCRIPTION
Resolves #2914.

Here we specify the generic argument to `Uint8Array`, `Uint8Array<ArrayBuffer>`.

If unspecified, the default is `Uint8Array<ArrayBufferLike>`. However, both `new Uint8Array()` and `Uint8Array.from()` return `Uint8Array<ArrayBuffer>`.