### PR TITLE
refactor: add type annotation on `as_ref` for upcoming tauri 2.8

### DIFF
--- a/.changes/positioner-tauri-2.8.md
+++ b/.changes/positioner-tauri-2.8.md
@@ -1,0 +1,6 @@
+---
+positioner: patch
+positioner-js: patch
+---
+
+`readFile` now returns a more specific type `Promise<Uint8Array<ArrayBuffer>>` instead of the default `Promise<Uint8Array<ArrayBufferLike>`

--- a/.changes/positioner-tauri-2.8.md
+++ b/.changes/positioner-tauri-2.8.md
@@ -3,4 +3,4 @@ positioner: patch
 positioner-js: patch
 ---
 
-`readFile` now returns a more specific type `Promise<Uint8Array<ArrayBuffer>>` instead of the default `Promise<Uint8Array<ArrayBufferLike>`
+Add type annotation on `WebviewWindow::as_ref` calls in prepare for https://github.com/tauri-apps/tauri/pull/14012 that will be released in tauri 2.8

--- a/.changes/window-state-tauri-2.8.md
+++ b/.changes/window-state-tauri-2.8.md
@@ -3,4 +3,4 @@ window-state: patch
 window-state-js: patch
 ---
 
-`readFile` now returns a more specific type `Promise<Uint8Array<ArrayBuffer>>` instead of the default `Promise<Uint8Array<ArrayBufferLike>`
+Add type annotation on `WebviewWindow::as_ref` calls in prepare for https://github.com/tauri-apps/tauri/pull/14012 that will be released in tauri 2.8

--- a/.changes/window-state-tauri-2.8.md
+++ b/.changes/window-state-tauri-2.8.md
@@ -1,0 +1,6 @@
+---
+window-state: patch
+window-state-js: patch
+---
+
+`readFile` now returns a more specific type `Promise<Uint8Array<ArrayBuffer>>` instead of the default `Promise<Uint8Array<ArrayBufferLike>`

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -10,7 +10,7 @@ use serde_repr::Deserialize_repr;
 use tauri::Manager;
 #[cfg(feature = "tray-icon")]
 use tauri::Monitor;
-use tauri::{PhysicalPosition, PhysicalSize, Result, Runtime, WebviewWindow, Window};
+use tauri::{PhysicalPosition, PhysicalSize, Result, Runtime, Webview, WebviewWindow, Window};
 
 /// Well known window positions.
 #[derive(Debug, Deserialize_repr)]
@@ -57,12 +57,16 @@ pub trait WindowExt {
 
 impl<R: Runtime> WindowExt for WebviewWindow<R> {
     fn move_window(&self, pos: Position) -> Result<()> {
-        self.as_ref().window().move_window(pos)
+        // TODO: Use `let webview: &Window<R> = self.as_ref()` instead after tauri 2.8 released
+        let webview: &Webview<R> = self.as_ref();
+        webview.window().move_window(pos)
     }
 
     #[cfg(feature = "tray-icon")]
     fn move_window_constrained(&self, position: Position) -> Result<()> {
-        self.as_ref().window().move_window_constrained(position)
+        // TODO: Use `let webview: &Window<R> = self.as_ref()` instead after tauri 2.8 released
+        let webview: &Webview<R> = self.as_ref();
+        webview.window().move_window_constrained(position)
     }
 }
 

--- a/plugins/window-state/src/lib.rs
+++ b/plugins/window-state/src/lib.rs
@@ -14,8 +14,8 @@ use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 use tauri::{
     plugin::{Builder as PluginBuilder, TauriPlugin},
-    AppHandle, Manager, Monitor, PhysicalPosition, PhysicalSize, RunEvent, Runtime, WebviewWindow,
-    Window, WindowEvent,
+    AppHandle, Manager, Monitor, PhysicalPosition, PhysicalSize, RunEvent, Runtime, Webview,
+    WebviewWindow, Window, WindowEvent,
 };
 
 use std::{
@@ -158,7 +158,9 @@ pub trait WindowExt {
 
 impl<R: Runtime> WindowExt for WebviewWindow<R> {
     fn restore_state(&self, flags: StateFlags) -> tauri::Result<()> {
-        self.as_ref().window().restore_state(flags)
+        // TODO: Use `let webview: &Window<R> = self.as_ref()` instead after tauri 2.8 released
+        let webview: &Webview<R> = self.as_ref();
+        webview.window().restore_state(flags)
     }
 }
 
@@ -274,7 +276,9 @@ trait WindowExtInternal {
 
 impl<R: Runtime> WindowExtInternal for WebviewWindow<R> {
     fn update_state(&self, state: &mut WindowState, flags: StateFlags) -> tauri::Result<()> {
-        self.as_ref().window().update_state(state, flags)
+        // TODO: Use `let webview: &Window<R> = self.as_ref()` instead after tauri 2.8 released
+        let webview: &Webview<R> = self.as_ref();
+        webview.window().update_state(state, flags)
     }
 }
 


### PR DESCRIPTION
In https://github.com/tauri-apps/tauri/pull/14012/ we added `as_ref` to support casting to a `Window`, and these plugins will no longer compile due to that