### PR TITLE
fix(deep-link): Add command name to linux errors

### DIFF
--- a/.changes/deep-link-linux-errors.md
+++ b/.changes/deep-link-linux-errors.md
@@ -1,0 +1,6 @@
+---
+deep-link: patch
+deep-link-js: patch
+---
+
+On Linux, improved error messages when OS commands fail.

--- a/plugins/deep-link/src/error.rs
+++ b/plugins/deep-link/src/error.rs
@@ -23,6 +23,9 @@ pub enum Error {
     #[cfg(target_os = "linux")]
     #[error(transparent)]
     ParseIni(#[from] ini::ParseError),
+    #[cfg(target_os = "linux")]
+    #[error("Failed to run OS command `{0}`: {1}")]
+    Execute(&'static str, #[source] std::io::Error),
     #[cfg(mobile)]
     #[error(transparent)]
     PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -254,6 +254,7 @@ mod imp {
         ///
         /// ## Platform-specific:
         ///
+        /// - **Linux**: Needs the `xdg-mime` and `update-desktop-database` commands available on the system.
         /// - **macOS / Android / iOS**: Unsupported, will return [`Error::UnsupportedPlatform`](`crate::Error::UnsupportedPlatform`).
         pub fn register<S: AsRef<str>>(&self, _protocol: S) -> crate::Result<()> {
             #[cfg(windows)]
@@ -332,11 +333,13 @@ mod imp {
 
                 Command::new("update-desktop-database")
                     .arg(target)
-                    .status()?;
+                    .status()
+                    .map_err(|error| crate::Error::Execute("update-desktop-database", error))?;
 
                 Command::new("xdg-mime")
                     .args(["default", &file_name, mime_type.as_str()])
-                    .status()?;
+                    .status()
+                    .map_err(|error| crate::Error::Execute("xdg-mime", error))?;
 
                 Ok(())
             }
@@ -405,6 +408,7 @@ mod imp {
         ///
         /// ## Platform-specific:
         ///
+        /// - **Linux**: Needs the `xdg-mime` command available on the system.
         /// - **macOS / Android / iOS**: Unsupported, will return [`Error::UnsupportedPlatform`](`crate::Error::UnsupportedPlatform`).
         pub fn is_registered<S: AsRef<str>>(&self, _protocol: S) -> crate::Result<bool> {
             #[cfg(windows)]
@@ -439,7 +443,8 @@ mod imp {
                         "default",
                         &format!("x-scheme-handler/{}", _protocol.as_ref()),
                     ])
-                    .output()?;
+                    .output()
+                    .map_err(|error| crate::Error::Execute("xdg-mime", error))?;
 
                 Ok(String::from_utf8_lossy(&output.stdout).contains(&file_name))
             }


### PR DESCRIPTION
this is actually a breaking change but i don't think anyone cares about that on our error types. the only alternative (instead of waiting for v3) that comes to mind right now is to map the error to `std::io::Error::other("blabla + source.display()")`

closes #2922 