### PR TITLE
chore(deps): update serialize-to-javascript in `os` plugin

### DIFF
--- a/plugins/os/Cargo.toml
+++ b/plugins/os/Cargo.toml
@@ -32,4 +32,4 @@ thiserror = { workspace = true }
 os_info = "3"
 sys-locale = "0.3"
 gethostname = "1.0"
-serialize-to-javascript = "0.1.1"
+serialize-to-javascript = "0.1.2"


### PR DESCRIPTION
### Summary

This PR updates the dependency serialize-to-javascript in the tauri-plugin-os plugin to resolve a version conflict.

### Problem

Running cargo failed with the following error:
```
failed to select a version for `serialize-to-javascript`.
    ... required by package `tauri v2.8.0`
    ... which satisfies dependency `tauri = "^2.8"` of package `app`
versions that meet the requirements `^0.1.2` are: 0.1.2

all possible versions conflict with previously selected packages.

  previously selected package `serialize-to-javascript v0.1.1`
    ... which satisfies dependency `serialize-to-javascript = "=0.1.1"` of package `tauri-plugin-os v2.3.0`
    ... which satisfies dependency `tauri-plugin-os = "^2.3"` of package `app`
```

The tauri core package now requires serialize-to-javascript ^0.1.2, but tauri-plugin-os v2.3.0 pinned it to 0.1.1, causing a dependency resolution failure.