### PR TITLE
docs(fs): `fs:scope` usage

### DIFF
--- a/plugins/fs/permissions/autogenerated/reference.md
+++ b/plugins/fs/permissions/autogenerated/reference.md
@@ -3759,10 +3759,10 @@ An empty permission you can use to modify the global scope.
     {
       "identifier": "fs:scope",
       "allow": [
-        "$APPCONFIG/documents/**"
+        "$APPDATA/documents/**"
       ],
       "deny": [
-        "$APPCONFIG/documents/secret.txt"
+        "$APPDATA/documents/secret.txt"
       ]
     }
   ]

--- a/plugins/fs/permissions/autogenerated/reference.md
+++ b/plugins/fs/permissions/autogenerated/reference.md
@@ -3759,7 +3759,7 @@ An empty permission you can use to modify the global scope.
     {
       "identifier": "fs:scope",
       "allow": [
-        "$APPDATA/documents/**"
+        "$APPDATA/documents/**/*"
       ],
       "deny": [
         "$APPDATA/documents/secret.txt"

--- a/plugins/fs/permissions/autogenerated/reference.md
+++ b/plugins/fs/permissions/autogenerated/reference.md
@@ -3748,6 +3748,28 @@ This enables all index or metadata related commands without any pre-configured a
 
 An empty permission you can use to modify the global scope.
 
+## Example
+
+```json
+{
+  "identifier": "read-documents",
+  "windows": ["main"],
+  "permissions": [
+    "fs:allow-read",
+    {
+      "identifier": "fs:scope",
+      "allow": [
+        "$APPCONFIG/documents/**"
+      ],
+      "deny": [
+        "$APPCONFIG/documents/secret.txt"
+      ]
+    }
+  ]
+}
+```
+
+
 </td>
 </tr>
 

--- a/plugins/fs/permissions/schemas/schema.json
+++ b/plugins/fs/permissions/schemas/schema.json
@@ -2005,10 +2005,10 @@
           "markdownDescription": "This enables all index or metadata related commands without any pre-configured accessible paths."
         },
         {
-          "description": "An empty permission you can use to modify the global scope.",
+          "description": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPCONFIG/documents/**\"\n      ],\n      \"deny\": [\n        \"$APPCONFIG/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n",
           "type": "string",
           "const": "scope",
-          "markdownDescription": "An empty permission you can use to modify the global scope."
+          "markdownDescription": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPCONFIG/documents/**\"\n      ],\n      \"deny\": [\n        \"$APPCONFIG/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n"
         },
         {
           "description": "This enables all write related commands without any pre-configured accessible paths.",

--- a/plugins/fs/permissions/schemas/schema.json
+++ b/plugins/fs/permissions/schemas/schema.json
@@ -2005,10 +2005,10 @@
           "markdownDescription": "This enables all index or metadata related commands without any pre-configured accessible paths."
         },
         {
-          "description": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPCONFIG/documents/**\"\n      ],\n      \"deny\": [\n        \"$APPCONFIG/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n",
+          "description": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPDATA/documents/**\"\n      ],\n      \"deny\": [\n        \"$APPDATA/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n",
           "type": "string",
           "const": "scope",
-          "markdownDescription": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPCONFIG/documents/**\"\n      ],\n      \"deny\": [\n        \"$APPCONFIG/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n"
+          "markdownDescription": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPDATA/documents/**\"\n      ],\n      \"deny\": [\n        \"$APPDATA/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n"
         },
         {
           "description": "This enables all write related commands without any pre-configured accessible paths.",

--- a/plugins/fs/permissions/schemas/schema.json
+++ b/plugins/fs/permissions/schemas/schema.json
@@ -2005,10 +2005,10 @@
           "markdownDescription": "This enables all index or metadata related commands without any pre-configured accessible paths."
         },
         {
-          "description": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPDATA/documents/**\"\n      ],\n      \"deny\": [\n        \"$APPDATA/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n",
+          "description": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPDATA/documents/**/*\"\n      ],\n      \"deny\": [\n        \"$APPDATA/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n",
           "type": "string",
           "const": "scope",
-          "markdownDescription": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPDATA/documents/**\"\n      ],\n      \"deny\": [\n        \"$APPDATA/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n"
+          "markdownDescription": "An empty permission you can use to modify the global scope.\n\n## Example\n\n```json\n{\n  \"identifier\": \"read-documents\",\n  \"windows\": [\"main\"],\n  \"permissions\": [\n    \"fs:allow-read\",\n    {\n      \"identifier\": \"fs:scope\",\n      \"allow\": [\n        \"$APPDATA/documents/**/*\"\n      ],\n      \"deny\": [\n        \"$APPDATA/documents/secret.txt\"\n      ]\n    }\n  ]\n}\n```\n"
         },
         {
           "description": "This enables all write related commands without any pre-configured accessible paths.",

--- a/plugins/fs/permissions/scope.toml
+++ b/plugins/fs/permissions/scope.toml
@@ -16,7 +16,7 @@ An empty permission you can use to modify the global scope.
     {
       "identifier": "fs:scope",
       "allow": [
-        "$APPDATA/documents/**"
+        "$APPDATA/documents/**/*"
       ],
       "deny": [
         "$APPDATA/documents/secret.txt"

--- a/plugins/fs/permissions/scope.toml
+++ b/plugins/fs/permissions/scope.toml
@@ -16,10 +16,10 @@ An empty permission you can use to modify the global scope.
     {
       "identifier": "fs:scope",
       "allow": [
-        "$APPCONFIG/documents/**"
+        "$APPDATA/documents/**"
       ],
       "deny": [
-        "$APPCONFIG/documents/secret.txt"
+        "$APPDATA/documents/secret.txt"
       ]
     }
   ]

--- a/plugins/fs/permissions/scope.toml
+++ b/plugins/fs/permissions/scope.toml
@@ -2,4 +2,27 @@
 
 [[permission]]
 identifier = "scope"
-description = "An empty permission you can use to modify the global scope."
+description = """
+An empty permission you can use to modify the global scope.
+
+## Example
+
+```json
+{
+  "identifier": "read-documents",
+  "windows": ["main"],
+  "permissions": [
+    "fs:allow-read",
+    {
+      "identifier": "fs:scope",
+      "allow": [
+        "$APPCONFIG/documents/**"
+      ],
+      "deny": [
+        "$APPCONFIG/documents/secret.txt"
+      ]
+    }
+  ]
+}
+```
+"""


### PR DESCRIPTION
It's not obvious that this permission should be used in this syntax:

```json
{
  "identifier": "fs:scope",
  "allow": [
    "$APPDATA/documents/**/*"
  ],
  "deny": [
    "$APPDATA/documents/secret.txt"
  ]
}
```

adding in an example for this