### PR TITLE
fix(deep-link): revert the breaking change introduced by #2928

### DIFF
--- a/.changes/fix-deep-link-semver.md
+++ b/.changes/fix-deep-link-semver.md
@@ -1,0 +1,6 @@
+---
+deep-link: patch
+deep-link-js: patch
+---
+
+Revert the breaking change introduced by [#2928](https://github.com/tauri-apps/plugins-workspace/pull/2928).

--- a/plugins/deep-link/src/error.rs
+++ b/plugins/deep-link/src/error.rs
@@ -23,12 +23,19 @@ pub enum Error {
     #[cfg(target_os = "linux")]
     #[error(transparent)]
     ParseIni(#[from] ini::ParseError),
-    #[cfg(target_os = "linux")]
-    #[error("Failed to run OS command `{0}`: {1}")]
-    Execute(&'static str, #[source] std::io::Error),
     #[cfg(mobile)]
     #[error(transparent)]
     PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
+}
+
+// TODO(v3): change this into an error in v3,
+// see <https://github.com/tauri-apps/plugins-workspace/pull/2970#issuecomment-3244660138>.
+#[inline]
+#[cfg(target_os = "linux")]
+pub(crate) fn inspect_command_error<'a>(command: &'a str) -> impl Fn(&std::io::Error) + 'a {
+    move |e| {
+        tracing::error!("Failed to run OS command `{command}`: {e}");
+    }
 }
 
 impl Serialize for Error {

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -334,12 +334,14 @@ mod imp {
                 Command::new("update-desktop-database")
                     .arg(target)
                     .status()
-                    .map_err(|error| crate::Error::Execute("update-desktop-database", error))?;
+                    .inspect_err(crate::error::inspect_command_error(
+                        "update-desktop-database",
+                    ))?;
 
                 Command::new("xdg-mime")
                     .args(["default", &file_name, mime_type.as_str()])
                     .status()
-                    .map_err(|error| crate::Error::Execute("xdg-mime", error))?;
+                    .inspect_err(crate::error::inspect_command_error("xdg-mime"))?;
 
                 Ok(())
             }
@@ -444,7 +446,7 @@ mod imp {
                         &format!("x-scheme-handler/{}", _protocol.as_ref()),
                     ])
                     .output()
-                    .map_err(|error| crate::Error::Execute("xdg-mime", error))?;
+                    .inspect_err(crate::error::inspect_command_error("xdg-mime"))?;
 
                 Ok(String::from_utf8_lossy(&output.stdout).contains(&file_name))
             }


### PR DESCRIPTION
refer to <https://github.com/tauri-apps/plugins-workspace/pull/2928#issuecomment-3241824550>

@FabianLars Can we release a patch version as soon as possible? This issue caused the pytauri v0.8 release yesterday to be interrupted at the final stage.

---

Building on Windows results in differences in `**/schema.json` (different newline), any ideas? I'm concerned this might once again cause issue： https://github.com/tauri-apps/tauri/pull/13597
