### PR TITLE
feat(single-instance): add logging when closing a 2nd instance

### DIFF
--- a/plugins/single-instance/src/platform_impl/linux.rs
+++ b/plugins/single-instance/src/platform_impl/linux.rs
@@ -86,6 +86,9 @@ pub fn init<R: Runtime>(f: Box<SingleInstanceCallback<R>>) -> TauriPlugin<R> {
                             ),
                         );
                     }
+                    tracing::info!(
+                        "Closing this duplicate instance as DBus name {dbus_name} is already taken"
+                    );
                     app.cleanup_before_exit();
                     std::process::exit(0);
                 }


### PR DESCRIPTION
While debugging a Tauri app which was crashing on startup, I got into a state where every time I opened the app, it would close unexpectedly with exit code 0. I had to open `gdb`, `break exit` and use `bt` to figure out that it was actually Tauri closing the app due to the `single-instance` plugin. I had a zombie process taking the DBus `SingleInstance` name for my app.

This PR adds a `tracing::info` message when `exit(0)`ing the app on Linux if the single instance DBus name is already taken.