### PR TITLE
Remove logging of priority in Geolocation.kt

### DIFF
--- a/plugins/geolocation/android/src/main/java/Geolocation.kt
+++ b/plugins/geolocation/android/src/main/java/Geolocation.kt
@@ -91,8 +91,6 @@ public class Geolocation(private val context: Context) {
                 val lowPrio = if (networkEnabled) Priority.PRIORITY_BALANCED_POWER_ACCURACY else Priority.PRIORITY_LOW_POWER
                 val prio = if (enableHighAccuracy) Priority.PRIORITY_HIGH_ACCURACY else lowPrio
 
-                Logger.error(prio.toString())
-
                 val locationRequest = LocationRequest.Builder(10000)
                     .setMaxUpdateDelayMillis(timeout)
                     .setMinUpdateIntervalMillis(5000)


### PR DESCRIPTION
pr fixes this

<img width="477" height="269" alt="image" src="https://github.com/user-attachments/assets/a59a2928-5ce0-487a-a5d6-e3e5922f3604" />

when polling location it was rather annoying.

also there's a bug here: you have to poll location manually if you want <10s location updates because there seems to be hardcoded location update rates in https://github.com/tauri-apps/plugins-workspace/blob/v2/plugins/geolocation/android/src/main/java/Geolocation.kt#L96-L100


please forgive me for not abiding your contribution guidelines and formatting for the title, its not that i don't respect you guys its just that i dont have enough stimulants in me to put the effort into opening an issue 