### PR TITLE
fix(geolocation): use timeout for min,max,interval on android

### DIFF
--- a/.changes/geolocation-android-timeout.md
+++ b/.changes/geolocation-android-timeout.md
@@ -1,0 +1,6 @@
+---
+geolocation: patch
+geolocation-js: patch
+---
+
+On Android, use the `timeout` value for `setMinUpdateIntervalMillis`, `setMaxUpdateDelayMillis` and `setIntervalMillis` instead of just `minUpdateInterval`.

--- a/plugins/geolocation/android/src/main/java/Geolocation.kt
+++ b/plugins/geolocation/android/src/main/java/Geolocation.kt
@@ -91,9 +91,9 @@ public class Geolocation(private val context: Context) {
                 val lowPrio = if (networkEnabled) Priority.PRIORITY_BALANCED_POWER_ACCURACY else Priority.PRIORITY_LOW_POWER
                 val prio = if (enableHighAccuracy) Priority.PRIORITY_HIGH_ACCURACY else lowPrio
 
-                val locationRequest = LocationRequest.Builder(10000)
+                val locationRequest = LocationRequest.Builder(timeout)
                     .setMaxUpdateDelayMillis(timeout)
-                    .setMinUpdateIntervalMillis(5000)
+                    .setMinUpdateIntervalMillis(timeout)
                     .setPriority(prio)
                     .build()
 


### PR DESCRIPTION
closes #3009 

this really needs some more thinking at some point but i'm not that much into android at the moment so this PR is a bit of a bandage until then.