### PR TITLE
fix(deep-link): update the Exec= in handler if the executable path changes

### DIFF
--- a/.changes/deep-link-fix-different-exec.md
+++ b/.changes/deep-link-fix-different-exec.md
@@ -1,5 +1,6 @@
 ---
 "deep-link": patch
+"deep-link-js": patch
 ---
 
 Fix Exec= field in desktop handler if executable path changes

--- a/.changes/deep-link-fix-different-exec.md
+++ b/.changes/deep-link-fix-different-exec.md
@@ -1,0 +1,5 @@
+---
+"deep-link": patch
+---
+
+Fix Exec= field in desktop handler if executable path changes

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -317,7 +317,7 @@ mod imp {
                         }
 
                         // if the exec command doesnt match, update to the new one
-                        let old_exec = section.remove("Exec").unwrap_or(qualified_exec.clone());
+                        let old_exec = section.remove("Exec").unwrap_or_default();
                         if old_exec != qualified_exec {
                             section.append("Exec", qualified_exec);
                             change = true;

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -293,6 +293,7 @@ mod imp {
                     .unwrap_or_else(|| bin.into_os_string())
                     .to_string_lossy()
                     .to_string();
+                let qualified_exec = format!("{} %u", exec);
 
                 let target = self.app.path().data_dir()?.join("applications");
 
@@ -304,12 +305,28 @@ mod imp {
 
                 if let Ok(mut desktop_file) = ini::Ini::load_from_file(&target_file) {
                     if let Some(section) = desktop_file.section_mut(Some("Desktop Entry")) {
-                        // it's ok to remove it - we only write to the file if it's missing
-                        // and in that case we include old_mimes
                         let old_mimes = section.remove("MimeType").unwrap_or_default();
+                        let mut change = false;
 
+                        // if the mime type is not present, append it to the list
                         if !old_mimes.split(';').any(|mime| mime == mime_type) {
                             section.append("MimeType", format!("{mime_type};{old_mimes}"));
+                            change = true;
+                        } else {
+                            section.insert("MimeType".to_string(), old_mimes);
+                        }
+
+                        // if the exec command doesnt match, update to the new one
+                        let old_exec = section.remove("Exec").unwrap_or(qualified_exec.clone());
+                        if old_exec != qualified_exec {
+                            section.append("Exec", qualified_exec);
+                            change = true;
+                        } else {
+                            section.insert("Exec".to_string(), old_exec.to_string());
+                        }
+
+                        // if any property has changed, rewrite the .desktop file
+                        if change {
                             desktop_file.write_to_file(&target_file)?;
                         }
                     }
@@ -324,7 +341,7 @@ mod imp {
                                 .product_name
                                 .clone()
                                 .unwrap_or_else(|| file_name.clone()),
-                            exec = exec,
+                            qualified_exec = qualified_exec,
                             mime_type = mime_type
                         )
                         .as_bytes(),

--- a/plugins/deep-link/src/template.desktop
+++ b/plugins/deep-link/src/template.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name={name}
-Exec={exec} %u
+Exec={qualified_exec}
 Terminal=false
 MimeType={mime_type}
 NoDisplay=true


### PR DESCRIPTION
I noticed that deep-linking recently broke on my test application in Linux and debugged it to our project folder structure was reorganized leading to the executable path being different. The deep-linking plugin today doesn't check if the Exec field is different and requires it to be deleted manually in order to properly update.

This PR updates the `register` function to consider if the `Exec` path has changed and will update it if needed.