### PR TITLE
fix(single-instance): use a proper background thread to accept and receive unix socket streams

### DIFF
--- a/.changes/single-instance-macos-background-thread.md
+++ b/.changes/single-instance-macos-background-thread.md
@@ -1,0 +1,5 @@
+---
+"single-instance": patch
+---
+
+On macOS, accept and read incoming unix socket streams from a dedicated background thread instead of an async runtime task, so the blocking I/O calls don't stall the async executor.

--- a/plugins/single-instance/src/platform_impl/macos.rs
+++ b/plugins/single-instance/src/platform_impl/macos.rs
@@ -96,38 +96,37 @@ fn listen_for_other_instances<A: Runtime>(
     app: AppHandle<A>,
     mut cb: Box<SingleInstanceCallback<A>>,
 ) {
-    match UnixListener::bind(socket) {
-        Ok(listener) => {
-            tauri::async_runtime::spawn(async move {
-                for stream in listener.incoming() {
-                    match stream {
-                        Ok(mut stream) => {
-                            let mut s = String::new();
-                            match stream.read_to_string(&mut s) {
-                                Ok(_) => {
-                                    let (cwd, args) = s.split_once("\0\0").unwrap_or_default();
-                                    let args: Vec<String> =
-                                        args.split('\0').map(String::from).collect();
-                                    cb(app.app_handle(), args, cwd.to_string());
-                                }
-                                Err(e) => {
-                                    tracing::debug!("single_instance failed to be notified: {e}")
-                                }
-                            }
-                        }
-                        Err(err) => {
-                            tracing::debug!("single_instance failed to be notified: {}", err);
-                            continue;
-                        }
-                    }
-                }
-            });
-        }
+    let listener = match UnixListener::bind(socket) {
+        Ok(listener) => listener,
         Err(err) => {
             tracing::error!(
                 "single_instance failed to listen to other processes - launching normally: {}",
                 err
             );
+            return;
         }
-    }
+    };
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            match stream {
+                Ok(mut stream) => {
+                    let mut s = String::new();
+                    match stream.read_to_string(&mut s) {
+                        Ok(_) => {
+                            let (cwd, args) = s.split_once("\0\0").unwrap_or_default();
+                            let args: Vec<String> = args.split('\0').map(String::from).collect();
+                            cb(app.app_handle(), args, cwd.to_string());
+                        }
+                        Err(e) => {
+                            tracing::debug!("single_instance failed to be notified: {e}")
+                        }
+                    }
+                }
+                Err(err) => {
+                    tracing::debug!("single_instance failed to be notified: {}", err);
+                    continue;
+                }
+            }
+        }
+    });
 }


### PR DESCRIPTION
Previously this has blocked a whole tokio worker thread. Causing issues with task wakeups etc. We should never use blocking i/o operations inside an async task, that's why this PR moves that logic to a separate background thread. Alternatively we could still utilize an async task but we'd have to use the async aware UnixListener and co. which would require us to pull in a whole async runtime.

(There are still some things unknown to me because technically tokio should've been able to schedule the task on a different worker thread due to work stealing. But tokio-console shows that the hung task is still stuck in scheduling. EDIT: Ah I think this behavior I am seeing  might be the lifo optimization and it being non-stealable)