### PR TITLE
feat(barcode-scanner): update `androidx.camera` from `1.1.0` to `1.5.1` to support 16 KB memory page sizes

### DIFF
--- a/.changes/bump-androidx-camera.md
+++ b/.changes/bump-androidx-camera.md
@@ -1,0 +1,6 @@
+---
+"barcode-scanner": patch
+"barcode-scanner-js": patch
+---
+
+Update `androidx.camera` from `1.1.0` to `1.5.1` to support 16 KB memory page sizes.

--- a/plugins/barcode-scanner/android/build.gradle.kts
+++ b/plugins/barcode-scanner/android/build.gradle.kts
@@ -33,16 +33,14 @@ android {
 }
 
 dependencies {
-
+    val camerax_version = "1.5.1"
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.appcompat:appcompat:1.6.0")
     implementation("com.google.android.material:material:1.7.0")
-    implementation("androidx.camera:camera-core:1.1.0")
-    implementation("androidx.camera:camera-view:1.1.0")
-    implementation("androidx.camera:camera-lifecycle:1.1.0")
-    implementation("androidx.camera:camera-camera2:1.1.0")
-    implementation("androidx.camera:camera-lifecycle:1.1.0")
-    implementation("androidx.camera:camera-view:1.1.0")
+    implementation("androidx.camera:camera-core:${camerax_version}")
+    implementation("androidx.camera:camera-camera2:${camerax_version}")
+    implementation("androidx.camera:camera-lifecycle:${camerax_version}")
+    implementation("androidx.camera:camera-view:${camerax_version}")
     implementation("com.google.android.gms:play-services-mlkit-barcode-scanning:18.1.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")


### PR DESCRIPTION
Starting November 1st, 2025, all Android builds [are required to support 16 KB memory page sizes](https://developer.android.com/guide/practices/page-sizes).

The plugin `barcode-scanner` currently uses `androidx.camera` dependency in version `1.1.0` ([June 2022](https://developer.android.com/jetpack/androidx/releases/camera#1.1.0)).

Google Play flags the following libraries to be incompatible with 16 KB page sizes:
- **base/lib/arm64-v8a/libimage_processing_util_jni.so**
- **base/lib/x86_64/libimage_processing_util_jni.so**

Upgrading to the latest version of the `androidx.camera` should resolve the issue.
