### PR TITLE
updater: allow accepting invalid TLS certs/hostnames via config

### DIFF
--- a/.changes/updater-allow-invalid-tls.md
+++ b/.changes/updater-allow-invalid-tls.md
@@ -1,15 +1,6 @@
-```markdown
 ---
 "updater": minor
 "updater-js": minor
 ---
 
-Allow configuring the updater client to accept invalid TLS certificates and hostnames for
-internal/self-signed update servers. These options are available via the plugin config
-(`dangerousAcceptInvalidCerts`, `dangerousAcceptInvalidHostnames`) and via the
-`UpdaterBuilder` (`dangerous_accept_invalid_certs`, `dangerous_accept_invalid_hostnames`).
-
-These settings are gated behind the `dangerous-settings` Cargo feature and should only be
-used in trusted environments (tests, internal servers).
-
-```
+Allow configuring the updater client to accept invalid TLS certificates and hostnames for internal/self-signed update servers. These options are available via the plugin config (`dangerousAcceptInvalidCerts`, `dangerousAcceptInvalidHostnames`) and via the `UpdaterBuilder` (`dangerous_accept_invalid_certs`, `dangerous_accept_invalid_hostnames`).

--- a/.changes/updater-allow-invalid-tls.md
+++ b/.changes/updater-allow-invalid-tls.md
@@ -1,0 +1,15 @@
+```markdown
+---
+"updater": minor
+"updater-js": minor
+---
+
+Allow configuring the updater client to accept invalid TLS certificates and hostnames for
+internal/self-signed update servers. These options are available via the plugin config
+(`dangerousAcceptInvalidCerts`, `dangerousAcceptInvalidHostnames`) and via the
+`UpdaterBuilder` (`dangerous_accept_invalid_certs`, `dangerous_accept_invalid_hostnames`).
+
+These settings are gated behind the `dangerous-settings` Cargo feature and should only be
+used in trusted environments (tests, internal servers).
+
+```

--- a/plugins/updater/src/config.rs
+++ b/plugins/updater/src/config.rs
@@ -95,6 +95,10 @@ where
 pub struct Config {
     /// Dangerously allow using insecure transport protocols for update endpoints.
     pub dangerous_insecure_transport_protocol: bool,
+    /// Dangerously accept invalid TLS certificates for update requests.
+    pub dangerous_accept_invalid_certs: bool,
+    /// Dangerously accept invalid hostnames for TLS certificates for update requests.
+    pub dangerous_accept_invalid_hostnames: bool,
     /// Updater endpoints.
     pub endpoints: Vec<Url>,
     /// Signature public key.
@@ -113,6 +117,10 @@ impl<'de> Deserialize<'de> for Config {
         pub struct Config {
             #[serde(default, alias = "dangerous-insecure-transport-protocol")]
             pub dangerous_insecure_transport_protocol: bool,
+            #[serde(default, alias = "dangerous-accept-invalid-certs")]
+            pub dangerous_accept_invalid_certs: bool,
+            #[serde(default, alias = "dangerous-accept-invalid-hostnames")]
+            pub dangerous_accept_invalid_hostnames: bool,
             #[serde(default)]
             pub endpoints: Vec<Url>,
             pub pubkey: String,
@@ -129,6 +137,8 @@ impl<'de> Deserialize<'de> for Config {
 
         Ok(Self {
             dangerous_insecure_transport_protocol: config.dangerous_insecure_transport_protocol,
+            dangerous_accept_invalid_certs: config.dangerous_accept_invalid_certs,
+            dangerous_accept_invalid_hostnames: config.dangerous_accept_invalid_hostnames,
             endpoints: config.endpoints,
             pubkey: config.pubkey,
             windows: config.windows,

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -425,6 +425,12 @@ impl Updater {
             log::debug!("checking for updates {url}");
 
             let mut request = ClientBuilder::new().user_agent(UPDATER_USER_AGENT);
+            if self.config.dangerous_accept_invalid_certs {
+                request = request.danger_accept_invalid_certs(true);
+            }
+            if self.config.dangerous_accept_invalid_hostnames {
+                request = request.danger_accept_invalid_hostnames(true);
+            }
             if let Some(timeout) = self.timeout {
                 request = request.timeout(timeout);
             }
@@ -624,7 +630,13 @@ impl Update {
             headers.insert(ACCEPT, HeaderValue::from_static("application/octet-stream"));
         }
 
-        let mut request = ClientBuilder::new().user_agent(UPDATER_USER_AGENT);
+            let mut request = ClientBuilder::new().user_agent(UPDATER_USER_AGENT);
+            if self.config.dangerous_accept_invalid_certs {
+                request = request.danger_accept_invalid_certs(true);
+            }
+            if self.config.dangerous_accept_invalid_hostnames {
+                request = request.danger_accept_invalid_hostnames(true);
+            }
         if let Some(timeout) = self.timeout {
             request = request.timeout(timeout);
         }

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -630,13 +630,13 @@ impl Update {
             headers.insert(ACCEPT, HeaderValue::from_static("application/octet-stream"));
         }
 
-            let mut request = ClientBuilder::new().user_agent(UPDATER_USER_AGENT);
-            if self.config.dangerous_accept_invalid_certs {
-                request = request.danger_accept_invalid_certs(true);
-            }
-            if self.config.dangerous_accept_invalid_hostnames {
-                request = request.danger_accept_invalid_hostnames(true);
-            }
+        let mut request = ClientBuilder::new().user_agent(UPDATER_USER_AGENT);
+        if self.config.dangerous_accept_invalid_certs {
+            request = request.danger_accept_invalid_certs(true);
+        }
+        if self.config.dangerous_accept_invalid_hostnames {
+            request = request.danger_accept_invalid_hostnames(true);
+        }
         if let Some(timeout) = self.timeout {
             request = request.timeout(timeout);
         }


### PR DESCRIPTION
Problem: updater fails when contacting servers with self-signed or internal TLS certs and error message is generic.

Solution: add two plugin config flags `dangerousAcceptInvalidCerts` and `dangerousAcceptInvalidHostnames` and builder methods to override them. These mirror [http-plugin](https://v2.tauri.app/reference/javascript/http/#properties-1) and reqwest's `danger_accept_invalid_certs` and `danger_accept_invalid_hostnames`.

Security: these settings are dangerous and should only be used in trusted environments or testing.