### PR TITLE
feat(log): Allow a log formatter per target

### DIFF
--- a/.changes/allow-log-formatter-per-target.md
+++ b/.changes/allow-log-formatter-per-target.md
@@ -1,0 +1,5 @@
+---
+"log": "patch:enhance"
+---
+
+Allow specifying a log formatter per target using the `format` method on `Target`.

--- a/.changes/allow-log-formatter-per-target.md
+++ b/.changes/allow-log-formatter-per-target.md
@@ -1,6 +1,6 @@
 ---
-"log": "patch:enhance"
-"log-js": "patch"
+"log": "minor"
+"log-js": "minor"
 ---
 
 Allow specifying a log formatter per target using the `format` method on `Target`.

--- a/.changes/allow-log-formatter-per-target.md
+++ b/.changes/allow-log-formatter-per-target.md
@@ -1,6 +1,6 @@
 ---
 "log": "patch:enhance"
-"log-js": "patch:enhance"
+"log-js": "patch"
 ---
 
 Allow specifying a log formatter per target using the `format` method on `Target`.

--- a/.changes/allow-log-formatter-per-target.md
+++ b/.changes/allow-log-formatter-per-target.md
@@ -1,5 +1,6 @@
 ---
 "log": "patch:enhance"
+"log-js": "patch:enhance"
 ---
 
 Allow specifying a log formatter per target using the `format` method on `Target`.

--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -182,11 +182,13 @@ pub enum TargetKind {
     Dispatch(fern::Dispatch),
 }
 
+type Formatter = dyn Fn(FormatCallback, &Arguments, &Record) + Send + Sync + 'static;
+
 /// A log target.
 pub struct Target {
     kind: TargetKind,
     filters: Vec<Box<Filter>>,
-    formatter: Option<Box<dyn Fn(FormatCallback, &Arguments, &Record) + Send + Sync + 'static>>,
+    formatter: Option<Box<Formatter>>,
 }
 
 impl Target {

--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -186,6 +186,7 @@ pub enum TargetKind {
 pub struct Target {
     kind: TargetKind,
     filters: Vec<Box<Filter>>,
+    formatter: Option<Box<dyn Fn(FormatCallback, &Arguments, &Record) + Send + Sync + 'static>>,
 }
 
 impl Target {
@@ -194,6 +195,7 @@ impl Target {
         Self {
             kind,
             filters: Vec::new(),
+            formatter: None,
         }
     }
 
@@ -203,6 +205,15 @@ impl Target {
         F: Fn(&log::Metadata) -> bool + Send + Sync + 'static,
     {
         self.filters.push(Box::new(filter));
+        self
+    }
+
+    #[inline]
+    pub fn format<F>(mut self, formatter: F) -> Self
+    where
+        F: Fn(FormatCallback, &Arguments, &Record) + Send + Sync + 'static,
+    {
+        self.formatter.replace(Box::new(formatter));
         self
     }
 }
@@ -383,6 +394,9 @@ impl Builder {
             let mut target_dispatch = fern::Dispatch::new();
             for filter in target.filters {
                 target_dispatch = target_dispatch.filter(filter);
+            }
+            if let Some(formatter) = target.formatter {
+                target_dispatch = target_dispatch.format(formatter);
             }
 
             let logger = match target.kind {

--- a/plugins/log/src/lib.rs
+++ b/plugins/log/src/lib.rs
@@ -289,6 +289,13 @@ impl Builder {
         self
     }
 
+    pub fn clear_format(mut self) -> Self {
+        self.dispatch = self.dispatch.format(|out, message, _record| {
+            out.finish(format_args!("{message}"));
+        });
+        self
+    }
+
     pub fn format<F>(mut self, formatter: F) -> Self
     where
         F: Fn(FormatCallback, &Arguments, &Record) + Sync + Send + 'static,


### PR DESCRIPTION
This PR adds a `format` method to `Target`, allowing each target to have a different formatter. It also adds `reset_format` to the Builder to remove the default formatter.

# Motivation

When using the `with_colors` method with both a console-based and a file-based log target, the control codes for the colors are included in the log file. A custom formatter can be used when using `TargetKind::Dispatch`, but then you lose out on the automatic file rotation that the plugin provides.

Allowing a formatter per target solves this issue with techniques like the following:

```rust
Builder::new()
    .reset_format()
    .targets([
        Target::new(TargetKind::Stderr)
        .format(
            move |out, message, record| {
                // custom colorized output here
            },
        ),
        Target::new(TargetKind::LogDir { file_name: None })
        .format(move |out, message, record| {
            // custom non-colorized output here
        }),
    ])
    .build(),
```