### PR TITLE
feat: make `ExitStatus` code field public

### DIFF
--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -89,7 +89,7 @@ impl CommandChild {
 /// Describes the result of a process after it has terminated.
 #[derive(Debug)]
 pub struct ExitStatus {
-    code: Option<i32>,
+    pub code: Option<i32>,
 }
 
 impl ExitStatus {


### PR DESCRIPTION
All members of the `Output` struct are public. However, it is not possible to create its instance in the user code, since the code field of the `ExitStatus` struct is private.