### PR TITLE
chore(shell): clarify that the code field in `ExitStatus` is intentionally left private

### DIFF
--- a/.changes/clarify-exit-status-code-is-private.md
+++ b/.changes/clarify-exit-status-code-is-private.md
@@ -1,0 +1,6 @@
+---
+"shell": patch
+---
+
+Add a comment to clarify that the code field in `ExitStatus` is intentionally left private.
+

--- a/.changes/clarify-exit-status-code-is-private.md
+++ b/.changes/clarify-exit-status-code-is-private.md
@@ -1,6 +1,0 @@
----
-"shell": patch
----
-
-Add a comment to clarify that the code field in `ExitStatus` is intentionally left private.
-

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -89,6 +89,8 @@ impl CommandChild {
 /// Describes the result of a process after it has terminated.
 #[derive(Debug)]
 pub struct ExitStatus {
+    // This field is intentionally left private.
+    // See: https://github.com/tauri-apps/plugins-workspace/pull/3115.
     code: Option<i32>,
 }
 


### PR DESCRIPTION
Supercedes #3115.