### PR TITLE
fix(barcode-scanner): remove unnecessary permission checks on Android (fix #2312)

### DIFF
--- a/.changes/fix-android-barcode-scanner-permission-check.md
+++ b/.changes/fix-android-barcode-scanner-permission-check.md
@@ -1,0 +1,6 @@
+---
+"barcode-scanner": patch
+"barcode-scanner-js": patch
+---
+
+Remove unnecessary checks on Android when requesting camera permission.

--- a/plugins/barcode-scanner/android/src/main/java/BarcodeScannerPlugin.kt
+++ b/plugins/barcode-scanner/android/src/main/java/BarcodeScannerPlugin.kt
@@ -354,17 +354,6 @@ class BarcodeScannerPlugin(private val activity: Activity) : Plugin(activity),
         }
     }
 
-    private fun markFirstPermissionRequest() {
-        val sharedPreference: SharedPreferences =
-            activity.getSharedPreferences(PREFS_PERMISSION_FIRST_TIME_ASKING, MODE_PRIVATE)
-        sharedPreference.edit().putBoolean(PERMISSION_NAME, false).apply()
-    }
-
-    private fun firstPermissionRequest(): Boolean {
-        return activity.getSharedPreferences(PREFS_PERMISSION_FIRST_TIME_ASKING, MODE_PRIVATE)
-            .getBoolean(PERMISSION_NAME, true)
-    }
-
     @SuppressLint("ObsoleteSdkInt")
     @PermissionCallback
     fun cameraPermissionCallback(invoke: Invoke) {
@@ -401,20 +390,12 @@ class BarcodeScannerPlugin(private val activity: Activity) : Plugin(activity),
             requestPermissionResponse.put(PERMISSION_ALIAS_CAMERA, PermissionState.GRANTED)
         } else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                if (firstPermissionRequest() || activity.shouldShowRequestPermissionRationale(
-                        PERMISSION_NAME
-                    )
-                ) {
-                    markFirstPermissionRequest()
-                    requestPermissionForAlias(
-                        PERMISSION_ALIAS_CAMERA,
-                        invoke,
-                        "cameraPermissionCallback"
-                    )
-                    return
-                } else {
-                    requestPermissionResponse.put(PERMISSION_ALIAS_CAMERA, PermissionState.DENIED)
-                }
+                requestPermissionForAlias(
+                    PERMISSION_ALIAS_CAMERA,
+                    invoke,
+                    "cameraPermissionCallback"
+                )
+                return
             } else {
                 requestPermissionResponse.put(PERMISSION_ALIAS_CAMERA, PermissionState.GRANTED)
             }

--- a/plugins/barcode-scanner/android/src/main/java/BarcodeScannerPlugin.kt
+++ b/plugins/barcode-scanner/android/src/main/java/BarcodeScannerPlugin.kt
@@ -54,7 +54,6 @@ import java.util.concurrent.ExecutionException
 
 private const val PERMISSION_ALIAS_CAMERA = "camera"
 private const val PERMISSION_NAME = Manifest.permission.CAMERA
-private const val PREFS_PERMISSION_FIRST_TIME_ASKING = "PREFS_PERMISSION_FIRST_TIME_ASKING"
 
 @InvokeArg
 class ScanOptions {

--- a/plugins/barcode-scanner/android/src/main/java/BarcodeScannerPlugin.kt
+++ b/plugins/barcode-scanner/android/src/main/java/BarcodeScannerPlugin.kt
@@ -369,9 +369,7 @@ class BarcodeScannerPlugin(private val activity: Activity) : Plugin(activity),
             requestPermissionResponse.put(PERMISSION_ALIAS_CAMERA, PermissionState.GRANTED)
         } else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                if (!activity.shouldShowRequestPermissionRationale(PERMISSION_NAME)) {
-                    requestPermissionResponse.put(PERMISSION_ALIAS_CAMERA, PermissionState.DENIED)
-                }
+                requestPermissionResponse.put(PERMISSION_ALIAS_CAMERA, PermissionState.DENIED)
             } else {
                 requestPermissionResponse.put(PERMISSION_ALIAS_CAMERA, PermissionState.GRANTED)
             }


### PR DESCRIPTION
As reported in #2312, the barcode-scanner plugin currently checks if a permission request has already been made and never requests permissions a second time. This breaks Android's "ask every time" setting.

Additionally, the plugin is currently calling `shouldShowRequestPermissionRationale` to determine whether or not to request permissions again. The actual purpose of this function, however, is to display an in-app message to the user explaining why the permission is required ([documentation](https://developer.android.com/training/permissions/requesting#explain)).

I've removed both of these checks to make the plugin behave as expected according to user preference.