### PR TITLE
fix(dialog): rfd feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,9 @@ dependencies = [
  "serde_repr",
  "tokio",
  "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "zbus",
 ]
 
@@ -1570,6 +1573,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -5409,6 +5421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7997,6 +8015,7 @@ dependencies = [
  "cc",
  "downcast-rs",
  "rustix 0.38.44",
+ "scoped-tls",
  "smallvec",
  "wayland-sys",
 ]
@@ -8055,6 +8074,8 @@ version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
 dependencies = [
+ "dlib",
+ "log",
  "pkg-config",
 ]
 

--- a/plugins/dialog/Cargo.toml
+++ b/plugins/dialog/Cargo.toml
@@ -11,7 +11,7 @@ links = "tauri-plugin-dialog"
 
 [features]
 default = ["gtk3"]
-xdg-portal = ["rfd/xdg-portal"]
+xdg-portal = ["rfd/xdg-portal", "rfd/tokio", "rfd/wayland"]
 gtk3 = ["rfd/gtk3"]
 
 [package.metadata.docs.rs]
@@ -44,7 +44,6 @@ tauri = { workspace = true, features = ["wry"] }
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 rfd = { version = "0.16", default-features = false, features = [
-  "tokio",
   "common-controls-v6",
 ] }
 


### PR DESCRIPTION
wayland was missed in #3128 and tokio was always incorrect since it's not used for the gtk backend