### PR TITLE
fix(process): improve stdout encoding handling in read_line functions #1471

### DIFF
--- a/.changes/fix-stdout-readline-encoding.md
+++ b/.changes/fix-stdout-readline-encoding.md
@@ -1,0 +1,6 @@
+---
+"shell": patch
+"shell-js": patch
+---
+
+Fix incorrect stdout encoding when readline.

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -401,6 +401,7 @@ fn read_raw_bytes<F: Fn(Vec<u8>) -> CommandEvent + Send + Copy + 'static>(
     tx: Sender<CommandEvent>,
     wrapper: F,
 ) {
+    let encoder = get_system_encoding();
     loop {
         let result = reader.fill_buf();
         match result {
@@ -409,8 +410,10 @@ fn read_raw_bytes<F: Fn(Vec<u8>) -> CommandEvent + Send + Copy + 'static>(
                 if length == 0 {
                     break;
                 }
+                let (cow, _, _) = encoder.decode(buf);
+                let decode_bytes = cow.into_owned().into_bytes();
                 let tx_ = tx.clone();
-                let _ = block_on_task(async move { tx_.send(wrapper(buf.to_vec())).await });
+                let _ = block_on_task(async move { tx_.send(wrapper(decode_bytes)).await });
                 reader.consume(length);
             }
             Err(e) => {
@@ -428,6 +431,7 @@ fn read_line<F: Fn(Vec<u8>) -> CommandEvent + Send + Copy + 'static>(
     tx: Sender<CommandEvent>,
     wrapper: F,
 ) {
+    let encoder = get_system_encoding();
     loop {
         let mut buf = Vec::new();
         match tauri::utils::io::read_line(&mut reader, &mut buf) {
@@ -435,8 +439,10 @@ fn read_line<F: Fn(Vec<u8>) -> CommandEvent + Send + Copy + 'static>(
                 if n == 0 {
                     break;
                 }
+                let (cow, _, _) = encoder.decode(&buf);
+                let decode_bytes = cow.into_owned().into_bytes();
                 let tx_ = tx.clone();
-                let _ = block_on_task(async move { tx_.send(wrapper(buf)).await });
+                let _ = block_on_task(async move { tx_.send(wrapper(decode_bytes)).await });
             }
             Err(e) => {
                 let tx_ = tx.clone();
@@ -466,6 +472,21 @@ fn spawn_pipe_reader<F: Fn(Vec<u8>) -> CommandEvent + Send + Copy + 'static>(
             read_line(reader, tx, wrapper);
         }
     });
+}
+
+#[cfg(windows)]
+const fn get_system_encoding() -> &'static Encoding {
+    use encoding_rs::WINDOWS_1252;
+    WINDOWS_1252
+}
+
+#[cfg(unix)]
+const fn get_system_encoding() -> &'static Encoding {
+    // ! Remove afetr dev
+    use encoding_rs::WINDOWS_1252;
+    WINDOWS_1252
+    // use encoding_rs::UTF_8;
+    // UTF_8
 }
 
 // tests for the commands functions.

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -401,7 +401,6 @@ fn read_raw_bytes<F: Fn(Vec<u8>) -> CommandEvent + Send + Copy + 'static>(
     tx: Sender<CommandEvent>,
     wrapper: F,
 ) {
-    let encoder = get_system_encoding();
     loop {
         let result = reader.fill_buf();
         match result {
@@ -410,10 +409,8 @@ fn read_raw_bytes<F: Fn(Vec<u8>) -> CommandEvent + Send + Copy + 'static>(
                 if length == 0 {
                     break;
                 }
-                let (cow, _, _) = encoder.decode(buf);
-                let decode_bytes = cow.into_owned().into_bytes();
                 let tx_ = tx.clone();
-                let _ = block_on_task(async move { tx_.send(wrapper(decode_bytes)).await });
+                let _ = block_on_task(async move { tx_.send(wrapper(buf.to_vec())).await });
                 reader.consume(length);
             }
             Err(e) => {

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -23,6 +23,10 @@ const NEWLINE_BYTE: u8 = b'\n';
 use tauri::async_runtime::{block_on as block_on_task, channel, Receiver, Sender};
 
 pub use encoding_rs::Encoding;
+#[cfg(not(windows))]
+use encoding_rs::UTF_8;
+#[cfg(windows)]
+use encoding_rs::WINDOWS_1252;
 use os_pipe::{pipe, PipeReader, PipeWriter};
 use serde::Serialize;
 use shared_child::SharedChild;
@@ -473,17 +477,12 @@ fn spawn_pipe_reader<F: Fn(Vec<u8>) -> CommandEvent + Send + Copy + 'static>(
 
 #[cfg(windows)]
 const fn get_system_encoding() -> &'static Encoding {
-    use encoding_rs::WINDOWS_1252;
     WINDOWS_1252
 }
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 const fn get_system_encoding() -> &'static Encoding {
-    // ! Remove afetr dev
-    use encoding_rs::WINDOWS_1252;
-    WINDOWS_1252
-    // use encoding_rs::UTF_8;
-    // UTF_8
+    UTF_8
 }
 
 // tests for the commands functions.

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -24,9 +24,9 @@ use tauri::async_runtime::{block_on as block_on_task, channel, Receiver, Sender}
 
 pub use encoding_rs::Encoding;
 #[cfg(not(windows))]
-use encoding_rs::UTF_8;
+use encoding_rs::UTF_8 as SYSTEM_ENCODING;
 #[cfg(windows)]
-use encoding_rs::WINDOWS_1252;
+use encoding_rs::WINDOWS_1252 as SYSTEM_ENCODING;
 use os_pipe::{pipe, PipeReader, PipeWriter};
 use serde::Serialize;
 use shared_child::SharedChild;
@@ -432,7 +432,6 @@ fn read_line<F: Fn(Vec<u8>) -> CommandEvent + Send + Copy + 'static>(
     tx: Sender<CommandEvent>,
     wrapper: F,
 ) {
-    let encoder = get_system_encoding();
     loop {
         let mut buf = Vec::new();
         match tauri::utils::io::read_line(&mut reader, &mut buf) {
@@ -440,7 +439,7 @@ fn read_line<F: Fn(Vec<u8>) -> CommandEvent + Send + Copy + 'static>(
                 if n == 0 {
                     break;
                 }
-                let (cow, _, _) = encoder.decode(&buf);
+                let (cow, _, _) = SYSTEM_ENCODING.decode(&buf);
                 let decode_bytes = cow.into_owned().into_bytes();
                 let tx_ = tx.clone();
                 let _ = block_on_task(async move { tx_.send(wrapper(decode_bytes)).await });
@@ -473,16 +472,6 @@ fn spawn_pipe_reader<F: Fn(Vec<u8>) -> CommandEvent + Send + Copy + 'static>(
             read_line(reader, tx, wrapper);
         }
     });
-}
-
-#[cfg(windows)]
-const fn get_system_encoding() -> &'static Encoding {
-    WINDOWS_1252
-}
-
-#[cfg(not(windows))]
-const fn get_system_encoding() -> &'static Encoding {
-    UTF_8
 }
 
 // tests for the commands functions.


### PR DESCRIPTION
I developed on macOS, need to make sure encoding behavior same as Windows.
Sidecar:
```rust
use encoding_rs;
use std::io::{self, Write};
use std::thread;
use std::time::Duration;

fn main() {
    let stdout = io::stdout();
    let mut handle = stdout.lock();
    let utf8_output = "[download] Destination: PEDRO - Jaxomy, Agatino Romero, Raffaella Carrà (TikTok Song) [XzilCu9PcZk].f616.mp4\n";
    const TARGET_ENCODING: &'static encoding_rs::Encoding = encoding_rs::WINDOWS_1252;
    let (encoded_bytes, _, malformed) = TARGET_ENCODING.encode(utf8_output);
    if malformed {
        eprintln!("[SIM] Warning: some characters cannot be encoded in Windows-1252!");
    }
    loop {
        match handle.write_all(encoded_bytes.as_ref()) {
            Ok(_) => {
                eprintln!(
                    "[SIM] Simulated output: successfully wrote {} bytes.",
                    encoded_bytes.len()
                );
            }
            Err(e) => {
                eprintln!("[SIM] Error writing to stdout: {}", e);
                break;
            }
        }
        thread::sleep(Duration::from_millis(1000));
    }
    let check_a_grave = TARGET_ENCODING.encode("à").0;
    eprintln!(
        "[SIM] Check: 'à' is encoded in Windows-1252 as bytes {:?}",
        check_a_grave
    );
}
```

User side, code snippet
```rust
let command = app_handle
            .clone()
            .shell()
            .sidecar(EXTERNAL_BIN)
            .expect("bin");
        let (mut rx, _) = command.spawn().expect("spawn");

        tauri::async_runtime::spawn(async move {
            while let Some(event) = rx.recv().await {
                if let CommandEvent::Stdout(line) = event {
                    let output = match String::from_utf8(line) {
                        Ok(s) => s,
                        Err(e) => {
                            println!("Invalid UTF-8 sequence: {}", e);
                            String::from_utf8_lossy(&e.into_bytes()).into_owned()
                        },
                    };
                    println!("{}", output);
                }
            }
        });
```

Output with mainline
```
[download] Destination: PEDRO - Jaxomy, Agatino Romero, Raffaella Carr� (TikTok Song) [XzilCu9PcZk].f616.mp4
```

Output with PR
```
[download] Destination: PEDRO - Jaxomy, Agatino Romero, Raffaella Carrà (TikTok Song) [XzilCu9PcZk].f616.mp4
```
