### PR TITLE
refactor(store): hold a weak reference on store

### DIFF
--- a/plugins/store/src/lib.rs
+++ b/plugins/store/src/lib.rs
@@ -15,7 +15,7 @@ pub use serde_json::Value as JsonValue;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, Weak},
     time::Duration,
 };
 pub use store::{resolve_store_path, DeserializeFn, SerializeFn, Store, StoreBuilder};
@@ -37,13 +37,56 @@ struct ChangePayload<'a> {
     exists: bool,
 }
 
+type Stores<R> = HashMap<PathBuf, (Weak<Store<R>>, Option<ResourceId>)>;
+
 #[derive(Debug)]
-struct StoreState {
-    stores: Arc<Mutex<HashMap<PathBuf, ResourceId>>>,
+struct StoreState<R: Runtime> {
+    // The entry is removed in `Store`'s drop implementation,
+    // The `Weak<Store<R>>` will always point to a valid `Store` unless we're inside a `Store`'s deconstructor
+    // The `Option<ResourceId>` is only updated in `validate_or_add_resource`, so this is not always up to date
+    stores: Arc<Mutex<Stores<R>>>,
     serialize_fns: HashMap<String, SerializeFn>,
     deserialize_fns: HashMap<String, DeserializeFn>,
     default_serialize: SerializeFn,
     default_deserialize: DeserializeFn,
+}
+
+pub(crate) fn validate_or_add_resource<R: Runtime>(
+    app: &AppHandle<R>,
+    store_state: Option<&mut (Weak<Store<R>>, Option<ResourceId>)>,
+    add: bool,
+) -> Option<(Arc<Store<R>>, ResourceId)> {
+    let (weak_store, resource_id) = store_state?;
+    let store = weak_store.upgrade()?;
+
+    if let Some(rid) = resource_id {
+        if app
+            .resources_table()
+            .get::<Store<R>>(*rid)
+            .is_ok_and(|store_| Arc::ptr_eq(&store, &store_))
+        {
+            // Valid
+            return Some((store, *rid));
+        } else {
+            resource_id.take();
+        }
+    }
+
+    if add {
+        let rid = app.resources_table().add_arc(store.clone());
+        resource_id.replace(rid);
+        Some((store, rid))
+    } else {
+        None
+    }
+}
+
+pub(crate) fn validate_resource_id<R: Runtime>(
+    app: &AppHandle<R>,
+    store_state: Option<&mut (Weak<Store<R>>, Option<ResourceId>)>,
+) -> Option<ResourceId> {
+    let (_store, rid) = validate_or_add_resource(app, store_state, false)?;
+    Some(rid)
 }
 
 #[derive(Serialize, Deserialize)]
@@ -68,7 +111,7 @@ struct LoadStoreOptions {
 
 fn builder<R: Runtime>(
     app: AppHandle<R>,
-    store_state: State<'_, StoreState>,
+    store_state: State<'_, StoreState<R>>,
     path: PathBuf,
     options: Option<LoadStoreOptions>,
 ) -> Result<StoreBuilder<R>> {
@@ -124,7 +167,7 @@ fn builder<R: Runtime>(
 #[tauri::command]
 async fn load<R: Runtime>(
     app: AppHandle<R>,
-    store_state: State<'_, StoreState>,
+    store_state: State<'_, StoreState<R>>,
     path: PathBuf,
     options: Option<LoadStoreOptions>,
 ) -> Result<ResourceId> {
@@ -136,11 +179,14 @@ async fn load<R: Runtime>(
 #[tauri::command]
 async fn get_store<R: Runtime>(
     app: AppHandle<R>,
-    store_state: State<'_, StoreState>,
+    store_state: State<'_, StoreState<R>>,
     path: PathBuf,
 ) -> Result<Option<ResourceId>> {
-    let stores = store_state.stores.lock().unwrap();
-    Ok(stores.get(&resolve_store_path(&app, path)?).copied())
+    let mut stores = store_state.stores.lock().unwrap();
+    Ok(validate_resource_id(
+        &app,
+        stores.get_mut(&resolve_store_path(&app, path)?),
+    ))
 }
 
 #[tauri::command]
@@ -316,11 +362,11 @@ impl<R: Runtime, T: Manager<R>> StoreExt<R> for T {
     }
 
     fn get_store(&self, path: impl AsRef<Path>) -> Option<Arc<Store<R>>> {
-        let collection = self.state::<StoreState>();
+        let collection = self.state::<StoreState<R>>();
         let stores = collection.stores.lock().unwrap();
         stores
             .get(&resolve_store_path(self.app_handle(), path.as_ref()).ok()?)
-            .and_then(|rid| self.resources_table().get(*rid).ok())
+            .and_then(|(weak_store, _)| weak_store.upgrade())
     }
 }
 
@@ -436,7 +482,7 @@ impl Builder {
                 entries, reload, save,
             ])
             .setup(move |app_handle, _api| {
-                app_handle.manage(StoreState {
+                app_handle.manage(StoreState::<R> {
                     stores: Arc::new(Mutex::new(HashMap::new())),
                     serialize_fns: self.serialize_fns,
                     deserialize_fns: self.deserialize_fns,
@@ -447,10 +493,10 @@ impl Builder {
             })
             .on_event(|app_handle, event| {
                 if let RunEvent::Exit = event {
-                    let collection = app_handle.state::<StoreState>();
+                    let collection = app_handle.state::<StoreState<R>>();
                     let stores = collection.stores.lock().unwrap();
-                    for (path, rid) in stores.iter() {
-                        if let Ok(store) = app_handle.resources_table().get::<Store<R>>(*rid) {
+                    for (path, (weak_store, _)) in stores.iter() {
+                        if let Some(store) = weak_store.upgrade() {
                             if let Err(err) = store.save() {
                                 tracing::error!("failed to save store {path:?} with error {err:?}");
                             }

--- a/plugins/store/src/store.rs
+++ b/plugins/store/src/store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::{ChangePayload, StoreState};
+use crate::{validate_or_add_resource, validate_resource_id, ChangePayload, StoreState};
 use serde_json::Value as JsonValue;
 use std::{
     collections::HashMap,
@@ -56,7 +56,7 @@ impl<R: Runtime> StoreBuilder<R> {
     /// ```
     pub fn new<M: Manager<R>, P: AsRef<Path>>(manager: &M, path: P) -> Self {
         let app = manager.app_handle().clone();
-        let state = app.state::<StoreState>();
+        let state = app.state::<StoreState<R>>();
         let serialize_fn = state.default_serialize;
         let deserialize_fn = state.default_deserialize;
         Self {
@@ -187,17 +187,19 @@ impl<R: Runtime> StoreBuilder<R> {
     }
 
     pub(crate) fn build_inner(mut self) -> crate::Result<(Arc<Store<R>>, ResourceId)> {
-        let stores = self.app.state::<StoreState>().stores.clone();
+        let stores = self.app.state::<StoreState<R>>().stores.clone();
         let mut stores = stores.lock().unwrap();
 
         self.path = resolve_store_path(&self.app, self.path)?;
 
         if self.create_new {
-            if let Some(rid) = stores.remove(&self.path) {
+            if let Some(rid) = validate_resource_id(&self.app, stores.remove(&self.path).as_mut()) {
                 let _ = self.app.resources_table().take::<Store<R>>(rid);
             }
-        } else if let Some(rid) = stores.get(&self.path) {
-            return Ok((self.app.resources_table().get(*rid).unwrap(), *rid));
+        } else if let Some((store, rid)) =
+            validate_or_add_resource(&self.app, stores.get_mut(&self.path), true)
+        {
+            return Ok((store, rid));
         }
 
         // if stores.contains_key(&self.path) {
@@ -228,7 +230,7 @@ impl<R: Runtime> StoreBuilder<R> {
 
         let store = Arc::new(store);
         let rid = self.app.resources_table().add_arc(store.clone());
-        stores.insert(self.path, rid);
+        stores.insert(self.path, (Arc::downgrade(&store), Some(rid)));
 
         Ok((store, rid))
     }
@@ -237,7 +239,9 @@ impl<R: Runtime> StoreBuilder<R> {
     ///
     /// If a store with the same path has already been loaded its instance is returned.
     ///
-    /// # Examples
+    /// Note: to close the store, you need to call [`Store::close_resource`] besides dropping it
+    ///
+    /// ## Examples
     /// ```
     /// tauri::Builder::default()
     ///   .plugin(tauri_plugin_store::Builder::default().build())
@@ -399,14 +403,14 @@ impl<R: Runtime> StoreInner<R> {
     }
 
     fn emit_change_event(&self, key: &str, value: Option<&JsonValue>) -> crate::Result<()> {
-        let state = self.app.state::<StoreState>();
-        let stores = state.stores.lock().unwrap();
+        let state = self.app.state::<StoreState<R>>();
+        let mut stores = state.stores.lock().unwrap();
         let exists = value.is_some();
         self.app.emit(
             "store://change",
             ChangePayload {
                 path: &self.path,
-                resource_id: stores.get(&self.path).copied(),
+                resource_id: validate_resource_id(&self.app, stores.get_mut(&self.path)),
                 key,
                 value,
                 exists,
@@ -431,14 +435,7 @@ pub struct Store<R: Runtime> {
     store: Arc<Mutex<StoreInner<R>>>,
 }
 
-impl<R: Runtime> Resource for Store<R> {
-    fn close(self: Arc<Self>) {
-        let store = self.store.lock().unwrap();
-        let state = store.app.state::<StoreState>();
-        let mut stores = state.stores.lock().unwrap();
-        stores.remove(&store.path);
-    }
-}
+impl<R: Runtime> Resource for Store<R> {}
 
 impl<R: Runtime> Store<R> {
     // /// Do something with the inner store,
@@ -550,11 +547,9 @@ impl<R: Runtime> Store<R> {
     pub fn close_resource(&self) {
         let store = self.store.lock().unwrap();
         let app = store.app.clone();
-        let state = app.state::<StoreState>();
-        let stores = state.stores.lock().unwrap();
-        if let Some(rid) = stores.get(&store.path).copied() {
-            drop(store);
-            drop(stores);
+        let state = app.state::<StoreState<R>>();
+        let mut stores = state.stores.lock().unwrap();
+        if let Some(rid) = validate_resource_id(&app, stores.get_mut(&store.path)) {
             let _ = app.resources_table().close(rid);
         }
     }
@@ -607,5 +602,16 @@ impl<R: Runtime> Store<R> {
 impl<R: Runtime> Drop for Store<R> {
     fn drop(&mut self) {
         self.apply_pending_auto_save();
+
+        let store = self.store.lock().unwrap();
+        let state = store.app.state::<StoreState<R>>();
+        let mut stores = state.stores.lock().unwrap();
+        // This is to make sure that we're indeed removing ourselves, not the one added during the time
+        if stores
+            .get(&store.path)
+            .is_some_and(|(weak_store, _)| weak_store.strong_count() == 0)
+        {
+            stores.remove(&store.path);
+        }
     }
 }


### PR DESCRIPTION
Option 3 of https://github.com/tauri-apps/plugins-workspace/issues/3145#issuecomment-3626636292

We now always hold onto a weak reference on the `Store` until all the strong references to it get dropped, this ensures that we will only ever have 1 `Store` for a single path (except for when the user uses `create_new`)

This is similar to the implementation from the beginning of https://github.com/tauri-apps/plugins-workspace/pull/1860

Not sure if it's worth it to be honest though