### PR TITLE
fix(store): error instead of panic on invalid rid

### DIFF
--- a/.changes/store-panic-on-invalid-rid.md
+++ b/.changes/store-panic-on-invalid-rid.md
@@ -1,0 +1,6 @@
+---
+"store": patch
+"store-js": patch
+---
+
+Return an error instead of panic when the internally tracked resource id is invalid on creating new stores

--- a/plugins/store/src/store.rs
+++ b/plugins/store/src/store.rs
@@ -197,7 +197,10 @@ impl<R: Runtime> StoreBuilder<R> {
                 let _ = self.app.resources_table().take::<Store<R>>(rid);
             }
         } else if let Some(rid) = stores.get(&self.path) {
-            return Ok((self.app.resources_table().get(*rid).unwrap(), *rid));
+            // The resource id we stored can be invalid due to
+            // the resource table getting modified by an external source
+            // (e.g. `App::cleanup_before_exit` > `manager.resources_table.clear()`)
+            return Ok((self.app.resources_table().get(*rid)?, *rid));
         }
 
         // if stores.contains_key(&self.path) {


### PR DESCRIPTION
Option 1 of https://github.com/tauri-apps/plugins-workspace/issues/3145#issuecomment-3626636292

Fix #3145

Compared to #3156, this is lesser involved, we simply return an error if the resource table gets modified from elsewhere, and if the user holds onto a store after either calling `Store.close` or `Store::close_resource`, there could be more than 1 store on a single path in theory. We could always go with this one first though