### PR TITLE
docs(shell): update example to include Encoding usage in `Command::spawn`

### DIFF
--- a/.changes/doc-to-Encoding-usage-in-shell.md
+++ b/.changes/doc-to-Encoding-usage-in-shell.md
@@ -1,4 +1,6 @@
 ---
-"shell": patch
+shell: patch
+shell-js: patch
 ---
+
 Docs on example to Encoding usage in `Command::spawn`. No user facing changes.

--- a/.changes/doc-to-Encoding-usage-in-shell.md
+++ b/.changes/doc-to-Encoding-usage-in-shell.md
@@ -1,0 +1,4 @@
+---
+"shell": patch
+---
+Docs on example to Encoding usage in `Command::spawn`. No user facing changes.

--- a/.changes/doc-to-Encoding-usage-in-shell.md
+++ b/.changes/doc-to-Encoding-usage-in-shell.md
@@ -1,4 +1,4 @@
 ---
-"shell": patch:minor
+"shell": patch
 ---
 Docs on example to Encoding usage in `Command::spawn`. No user facing changes.

--- a/.changes/doc-to-Encoding-usage-in-shell.md
+++ b/.changes/doc-to-Encoding-usage-in-shell.md
@@ -1,4 +1,4 @@
 ---
-"shell": patch
+"shell": patch:minor
 ---
 Docs on example to Encoding usage in `Command::spawn`. No user facing changes.

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -271,8 +271,8 @@ impl Command {
     ///   .setup(|app| {
     ///     let handle = app.handle().clone();
     ///     tauri::async_runtime::spawn(async move {
-    ///       let (mut rx, mut child) = handle.shell().command("cargo")
-    ///         .args(["tauri", "dev"])
+    ///       let (mut rx, mut child) = handle.shell().command("some-program")
+    ///         .args(["some-arg"])
     ///         .spawn()
     ///         .expect("Failed to spawn cargo");
     ///

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -237,6 +237,35 @@ impl Command {
     /// # Examples
     ///
     /// ```rust,no_run
+    /// use tauri_plugin_shell::{process::CommandEvent, ShellExt};
+    /// tauri::Builder::default()
+    ///   .setup(|app| {
+    ///     let handle = app.handle().clone();
+    ///     tauri::async_runtime::spawn(async move {
+    ///       let (mut rx, mut child) = handle.shell().command("cargo")
+    ///         .args(["tauri", "dev"])
+    ///         .spawn()
+    ///         .expect("Failed to spawn cargo");
+    ///
+    ///       let mut i = 0;
+    ///       while let Some(event) = rx.recv().await {
+    ///         if let CommandEvent::Stdout(line) = event {
+    ///           println!("got: {}", String::from_utf8(line).unwrap());
+    ///           i += 1;
+    ///           if i == 4 {
+    ///             child.write("message from Rust\n".as_bytes()).unwrap();
+    ///             i = 0;
+    ///           }
+    ///         }
+    ///       }
+    ///     });
+    ///     Ok(())
+    /// });
+    /// ```
+    ///
+    /// # Examples Mannual Encoding
+    ///
+    /// ```rust,no_run
     /// use tauri_plugin_shell::{process::{CommandEvent, Encoding}, ShellExt};
     /// tauri::Builder::default()
     ///   .setup(|app| {
@@ -247,18 +276,11 @@ impl Command {
     ///         .spawn()
     ///         .expect("Failed to spawn cargo");
     ///
-    ///       let encoding = Encoding::for_label(b"utf-8").unwrap();
-    ///       let mut i = 0;
+    ///      let encoding = Encoding::for_label(b"utf-8").unwrap();
     ///       while let Some(event) = rx.recv().await {
     ///         if let CommandEvent::Stdout(line) = event {
     ///           let (decoded, _, _) = encoding.decode(&line);
-    ///           println!("got: {}", String::from_utf8(line).unwrap());
-    ///           println!("decoded: {}", decoded);
-    ///           i += 1;
-    ///           if i == 4 {
-    ///             child.write("message from Rust\n".as_bytes()).unwrap();
-    ///             i = 0;
-    ///           }
+    ///           println!("got: {}", decoded);
     ///         }
     ///       }
     ///     });

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -242,7 +242,9 @@ impl Command {
     ///   .setup(|app| {
     ///     let handle = app.handle().clone();
     ///     tauri::async_runtime::spawn(async move {
-    ///       let (mut rx, mut child) = handle.shell().command("cargo")
+    ///       let (mut rx, mut child) = handle
+    ///         .shell()
+    ///         .command("cargo")
     ///         .args(["tauri", "dev"])
     ///         .spawn()
     ///         .expect("Failed to spawn cargo");
@@ -260,7 +262,7 @@ impl Command {
     ///       }
     ///     });
     ///     Ok(())
-    /// });
+    ///   });
     /// ```
     ///
     /// Depending on the command you spawn, it might output in a specific encoding, to parse the output lines in this case:
@@ -271,12 +273,14 @@ impl Command {
     ///   .setup(|app| {
     ///     let handle = app.handle().clone();
     ///     tauri::async_runtime::spawn(async move {
-    ///       let (mut rx, mut child) = handle.shell().command("some-program")
-    ///         .args(["some-arg"])
+    ///       let (mut rx, mut child) = handle
+    ///         .shell()
+    ///         .command("some-program")
+    ///         .arg("some-arg")
     ///         .spawn()
-    ///         .expect("Failed to spawn cargo");
+    ///         .expect("Failed to spawn some-program");
     ///
-    ///      let encoding = Encoding::for_label(b"windows-1252").unwrap();
+    ///       let encoding = Encoding::for_label(b"windows-1252").unwrap();
     ///       while let Some(event) = rx.recv().await {
     ///         if let CommandEvent::Stdout(line) = event {
     ///           let (decoded, _, _) = encoding.decode(&line);
@@ -285,7 +289,7 @@ impl Command {
     ///       }
     ///     });
     ///     Ok(())
-    /// });
+    ///   });
     /// ```
     pub fn spawn(self) -> crate::Result<(Receiver<CommandEvent>, CommandChild)> {
         let raw = self.raw_out;

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -237,7 +237,7 @@ impl Command {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use tauri_plugin_shell::{process::CommandEvent, ShellExt};
+    /// use tauri_plugin_shell::{process::{CommandEvent, Encoding}, ShellExt};
     /// tauri::Builder::default()
     ///   .setup(|app| {
     ///     let handle = app.handle().clone();
@@ -247,10 +247,13 @@ impl Command {
     ///         .spawn()
     ///         .expect("Failed to spawn cargo");
     ///
+    ///       let encoding = Encoding::for_label(b"utf-8").unwrap();
     ///       let mut i = 0;
     ///       while let Some(event) = rx.recv().await {
     ///         if let CommandEvent::Stdout(line) = event {
+    ///           let (decoded, _, _) = encoding.decode(&line);
     ///           println!("got: {}", String::from_utf8(line).unwrap());
+    ///           println!("decoded: {}", decoded);
     ///           i += 1;
     ///           if i == 4 {
     ///             child.write("message from Rust\n".as_bytes()).unwrap();

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -276,7 +276,7 @@ impl Command {
     ///         .spawn()
     ///         .expect("Failed to spawn cargo");
     ///
-    ///      let encoding = Encoding::for_label(b"utf-8").unwrap();
+    ///      let encoding = Encoding::for_label(b"windows-1252").unwrap();
     ///       while let Some(event) = rx.recv().await {
     ///         if let CommandEvent::Stdout(line) = event {
     ///           let (decoded, _, _) = encoding.decode(&line);

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -263,7 +263,7 @@ impl Command {
     /// });
     /// ```
     ///
-    /// # Examples Mannual Encoding
+    /// Depending on the command you spawn, it might output in a specific encoding, to parse the output lines in this case:
     ///
     /// ```rust,no_run
     /// use tauri_plugin_shell::{process::{CommandEvent, Encoding}, ShellExt};

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -280,7 +280,7 @@ impl Command {
     ///       while let Some(event) = rx.recv().await {
     ///         if let CommandEvent::Stdout(line) = event {
     ///           let (decoded, _, _) = encoding.decode(&line);
-    ///           println!("got: {}", decoded);
+    ///           println!("got: {decoded}");
     ///         }
     ///       }
     ///     });


### PR DESCRIPTION
See context in issue #1471 and PR #3148

CC @Legend-Master 