### PR TITLE
fix(positioner): fallback to primary monitor when current_monitor is None instead of panicking

### DIFF
--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -152,7 +152,13 @@ fn calculate_position<R: Runtime>(
 ) -> Result<PhysicalPosition<i32>> {
     use Position::*;
 
-    let screen = window.current_monitor()?.unwrap();
+    let screen = window.current_monitor()?;
+    let screen = if let Some(screen) = screen {
+        screen
+    } else {
+        // falling back to primary fixes a crash on macOS when using multiple monitors but current_monitor() is None
+        window.primary_monitor()?.unwrap()
+    };
     // Only use the screen_position for the Tray independent positioning,
     // because a tray event may not be called on the currently active monitor.
     let screen_position = screen.position();

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -298,10 +298,15 @@ fn calculate_position<R: Runtime>(
         }
         #[cfg(feature = "tray-icon")]
         TrayBottomCenter => {
-            if let (Some((tray_x, tray_y)), Some((tray_width, _))) = (tray_position, tray_size) {
+            if let (Some((tray_x, tray_y)), Some((tray_width, tray_height))) =
+                (tray_position, tray_size)
+            {
                 PhysicalPosition {
                     x: tray_x + (tray_width / 2) - (window_size.width / 2),
-                    y: tray_y,
+                    // Bottom edge of the tray icon. Using tray_y placed the window's
+                    // top edge at the icon's *top*, which on a top menu bar puts it
+                    // flush with the screen edge rather than below the bar.
+                    y: tray_y + tray_height,
                 }
             } else {
                 panic!("Tray position not set");


### PR DESCRIPTION
This fixes a bug with the positioner plugin that causes a crash on macOS when there are at least two monitors.