### PR TITLE
fix(barcode-scanner): early return scanner if missing permissions

### DIFF
--- a/.changes/barcode-scanner-ios-crash.md
+++ b/.changes/barcode-scanner-ios-crash.md
@@ -1,0 +1,6 @@
+---
+barcode-scanner: patch
+barcode-scanner-js: patch
+---
+
+On iOS, fixed an application crash happening when the scanner was started when user denied permission before.

--- a/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
+++ b/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
@@ -261,6 +261,11 @@ class BarcodeScannerPlugin: Plugin, AVCaptureMetadataOutputObjectsDelegate {
   }
 
   private func runScanner(_ invoke: Invoke, args: ScanOptions) {
+    if getPermissionState() != "granted" {
+      invoke.reject("Camera permission denied or not yet requested")
+      return
+    }
+
     scanFormats = [AVMetadataObject.ObjectType]()
 
     (args.formats ?? []).forEach { format in


### PR DESCRIPTION
crashes the app otherwise