### PR TITLE
fix(barcode-scanner): start capture session on a separate thread

### DIFF
--- a/.changes/barcode-scanner-ios-thread.md
+++ b/.changes/barcode-scanner-ios-thread.md
@@ -1,0 +1,6 @@
+---
+barcode-scanner: patch
+barcode-scanner-js: patch
+---
+
+On iOS, start the scanning session on a separate thread to fix performance issues.

--- a/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
+++ b/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
@@ -286,7 +286,9 @@ class BarcodeScannerPlugin: Plugin, AVCaptureMetadataOutputObjectsDelegate {
     }
 
     self.metaOutput!.metadataObjectTypes = self.scanFormats
-    self.captureSession!.startRunning()
+    DispatchQueue.main.async {
+      self.captureSession!.startRunning()
+    }
 
     self.isScanning = true
   }


### PR DESCRIPTION
fixes the given warning:

Thread Performance Checker: -[AVCaptureSession startRunning] should be called from background thread. Calling it on the main thread can lead to UI unresponsiveness

which might cause a UI freeze