### PR TITLE
fix(shell): Make sidecars work in tests (fix #13767)

### DIFF
--- a/.changes/make-sidecars-work-in-tests.md
+++ b/.changes/make-sidecars-work-in-tests.md
@@ -1,0 +1,5 @@
+---
+'shell': 'patch:bug'
+---
+
+Make sidecars work in tests. Executable resolution is aware of the "deps" directory.

--- a/.changes/make-sidecars-work-in-tests.md
+++ b/.changes/make-sidecars-work-in-tests.md
@@ -1,5 +1,6 @@
 ---
 'shell': 'patch:bug'
+'shell-js': 'patch:bug'
 ---
 
 Make sidecars work in tests. Executable resolution is aware of the "deps" directory.

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -519,6 +519,8 @@ mod tests {
             .unwrap()
             .parent()
             .unwrap()
+            .parent() // Go up once more to get out of the "deps" directory
+            .unwrap()
             .to_owned();
         assert_eq!(
             relative_command_path(Path::new("Tauri.Example")).unwrap(),

--- a/plugins/shell/src/process/mod.rs
+++ b/plugins/shell/src/process/mod.rs
@@ -118,27 +118,38 @@ pub struct Output {
 }
 
 fn relative_command_path(command: &Path) -> crate::Result<PathBuf> {
-    match platform::current_exe()?.parent() {
-        #[cfg(windows)]
-        Some(exe_dir) => {
-            let mut command_path = exe_dir.join(command);
-            let already_exe = command_path.extension().is_some_and(|ext| ext == "exe");
-            if !already_exe {
-                // do not use with_extension to retain dots in the command filename
-                command_path.as_mut_os_string().push(".exe");
-            }
-            Ok(command_path)
+    let exe_path = platform::current_exe()?;
+
+    let exe_dir = exe_path
+        .parent()
+        .ok_or(crate::Error::CurrentExeHasNoParent)?;
+
+    // If a test is being run, the executable is in the "deps" directory, so we need to go up one level.
+    let base_dir = if exe_dir.ends_with("deps") {
+        exe_dir.parent().unwrap_or(exe_dir)
+    } else {
+        exe_dir
+    };
+
+    let mut command_path = base_dir.join(command);
+
+    #[cfg(windows)]
+    {
+        let already_exe = command_path.extension().is_some_and(|ext| ext == "exe");
+        if !already_exe {
+            // do not use with_extension to retain dots in the command filename
+            command_path.as_mut_os_string().push(".exe");
         }
-        #[cfg(not(windows))]
-        Some(exe_dir) => {
-            let mut command_path = exe_dir.join(command);
-            if command_path.extension().is_some_and(|ext| ext == "exe") {
-                command_path.set_extension("");
-            }
-            Ok(command_path)
-        }
-        None => Err(crate::Error::CurrentExeHasNoParent),
     }
+
+    #[cfg(not(windows))]
+    {
+        if command_path.extension().is_some_and(|ext| ext == "exe") {
+            command_path.set_extension("");
+        }
+    }
+
+    Ok(command_path)
 }
 
 impl From<Command> for StdCommand {


### PR DESCRIPTION
The work in this PR is based on [this one](https://github.com/tauri-apps/plugins-workspace/pull/2934).

When running tests, using `platform::current_exe().parent()` alone is not sufficient, since the executable is located inside the `deps` directory. To fix this, we need to go up one level.

Fixes https://github.com/tauri-apps/tauri/issues/13767