### PR TITLE
fix(fs): fix crash on getting file descriptor from android content uri

### DIFF
--- a/.changes/fix-fs-android-file-may-crash-for-content-uri.md
+++ b/.changes/fix-fs-android-file-may-crash-for-content-uri.md
@@ -1,0 +1,6 @@
+---
+fs: patch:bug
+fs-js: patch:bug
+---
+
+Fixes a crash that occurs when opening a file from an Android Content URI due to missing permissions or the file not existing.

--- a/plugins/fs/android/src/main/java/FsPlugin.kt
+++ b/plugins/fs/android/src/main/java/FsPlugin.kt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Tauri Programme within The Commons Conservancy
+// Copyright 2019-2026 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
@@ -45,7 +45,7 @@ class FsPlugin(private val activity: Activity): Plugin(activity) {
         if (args.uri.startsWith(app.tauri.TAURI_ASSETS_DIRECTORY_URI)) {
             val path = args.uri.substring(app.tauri.TAURI_ASSETS_DIRECTORY_URI.length)
             try {
-                val fd = activity.assets.openFd(path).parcelFileDescriptor?.detachFd()
+                val fd = activity.assets.openFd(path).parcelFileDescriptor.detachFd()
                 res.put("fd", fd)
             } catch (e: IOException) {
                 // if the asset is compressed, we cannot open a file descriptor directly
@@ -64,6 +64,7 @@ class FsPlugin(private val activity: Activity): Plugin(activity) {
                 Uri.parse(args.uri),
                 args.mode
             )?.parcelFileDescriptor?.detachFd()
+            if (fd == null) throw IOException("No file or permission")
             res.put("fd", fd)
         }
 

--- a/plugins/fs/src/mobile.rs
+++ b/plugins/fs/src/mobile.rs
@@ -83,14 +83,10 @@ impl<R: Runtime> Fs<R> {
                     mode: mode.into(),
                 },
             )?;
-            if let Some(fd) = result.fd {
-                Ok(unsafe {
-                    use std::os::fd::FromRawFd;
-                    std::fs::File::from_raw_fd(fd)
-                })
-            } else {
-                unimplemented!()
-            }
+            Ok(unsafe {
+                use std::os::fd::FromRawFd;
+                std::fs::File::from_raw_fd(result.fd)
+            })
         }
     }
 }

--- a/plugins/fs/src/models.rs
+++ b/plugins/fs/src/models.rs
@@ -14,5 +14,5 @@ pub struct GetFileDescriptorPayload {
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetFileDescriptorResponse {
-    pub fd: Option<i32>,
+    pub fd: i32,
 }


### PR DESCRIPTION
Fixes a crash that occurs when opening a file from an Android Content URI due to missing permissions or the file not existing.

# Details
Before the fix, Kotlin’s [getFileDescriptor](https://github.com/tauri-apps/plugins-workspace/blob/69a9d5771cc888b93ce71162b280b91408decc87/plugins/fs/android/src/main/java/FsPlugin.kt#L40) function would return `null` when the file was unavailable.

https://github.com/tauri-apps/plugins-workspace/blob/69a9d5771cc888b93ce71162b280b91408decc87/plugins/fs/android/src/main/java/FsPlugin.kt#L63-L67

However, on the Rust side that receives it, `null` triggers `unimplemented!()`, causing a panic.

https://github.com/tauri-apps/plugins-workspace/blob/69a9d5771cc888b93ce71162b280b91408decc87/plugins/fs/src/mobile.rs#L86-L93

And with this PR, the getFileDescriptor function will throw an error instead of returning null when the file is not available.