### PR TITLE
fix(window-state): Window coordinates depend on the monitor\’s scale_…

### DIFF
--- a/plugins/window-state/src/lib.rs
+++ b/plugins/window-state/src/lib.rs
@@ -87,6 +87,7 @@ struct WindowState {
     visible: bool,
     decorated: bool,
     fullscreen: bool,
+    scale_factor: f64,
 }
 
 impl Default for WindowState {
@@ -102,6 +103,7 @@ impl Default for WindowState {
             visible: true,
             decorated: true,
             fullscreen: Default::default(),
+            scale_factor: 1.0,
         }
     }
 }
@@ -136,6 +138,7 @@ impl<R: Runtime> AppHandleExt for tauri::AppHandle<R> {
             };
 
             if let Some(window) = window {
+                s.scale_factor = window.scale_factor()?;
                 window.update_state(s, flags)?;
             }
         }
@@ -182,6 +185,12 @@ impl<R: Runtime> WindowExt for Window<R> {
             .get(label)
             .filter(|state| state != &&WindowState::default())
         {
+            let scale = if let Ok(Some(monitor)) = self.current_monitor() {
+                monitor.scale_factor() / state.scale_factor
+            } else {
+                1.0
+            };
+
             if flags.contains(StateFlags::DECORATIONS) {
                 self.set_decorations(state.decorated)?;
             }
@@ -195,14 +204,14 @@ impl<R: Runtime> WindowExt for Window<R> {
                     if m.intersects(position, size) {
                         self.set_position(PhysicalPosition {
                             x: if state.maximized {
-                                state.prev_x
+                                (state.prev_x as f64 * scale) as i32
                             } else {
-                                state.x
+                                (state.x as f64 * scale) as i32
                             },
                             y: if state.maximized {
-                                state.prev_y
+                                (state.prev_y as f64 * scale) as i32
                             } else {
-                                state.y
+                                (state.y as f64 * scale) as i32
                             },
                         })?;
                     }
@@ -211,8 +220,8 @@ impl<R: Runtime> WindowExt for Window<R> {
 
             if flags.contains(StateFlags::SIZE) {
                 self.set_size(PhysicalSize {
-                    width: state.width,
-                    height: state.height,
+                    width: (state.width as f64 * scale) as i32,
+                    height: (state.height as f64 * scale) as i32,
                 })?;
             }
 


### PR DESCRIPTION
…factor because logical pixels are being interpreted as physical pixels

Workaround for window shrinking on MacBook with external non-Retina (1x) monitor.

When the app closes, the window is on a 1x monitor where logical and physical pixels match. The coordinates are saved to disk with scale_factor=1.0.

On next launch, the Window object is created before the WebView exists. At this point, tao/macOS determines scale_factor from the default display (the built-in Retina screen with scale_factor=2.0), not from the monitor where the window will actually be positioned.

When saved coordinates are applied, they are treated as physical pixels on a 2x display and get divided by 2 to convert to logical pixels, causing the window to shrink to half its intended size.

This workaround uses the scale_factor of the target monitor (determined by saved coordinates) instead of the current window's scale_factor.