### PR TITLE
refactor(store): replace load_from_store with TryFrom impl in example

### DIFF
--- a/plugins/store/examples/AppSettingsManager/src-tauri/src/app/settings.rs
+++ b/plugins/store/examples/AppSettingsManager/src-tauri/src/app/settings.rs
@@ -10,10 +10,8 @@ pub struct AppSettings {
     pub theme: String,
 }
 
-impl<R: tauri::Runtime> TryFrom<&Store<R>> for AppSettings {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(store: &Store) -> Result<Self, Self::Error> {
+impl<R: tauri::Runtime> From<&Store<R>> for AppSettings {
+    fn from(store: &Store<R>) -> Self {
         let launch_at_login = store
             .get("appSettings.launchAtLogin")
             .and_then(|v| v.as_bool())
@@ -24,9 +22,9 @@ impl<R: tauri::Runtime> TryFrom<&Store<R>> for AppSettings {
             .and_then(|v| v.as_str().map(String::from))
             .unwrap_or_else(|| "dark".to_owned());
 
-        Ok(AppSettings {
+        AppSettings {
             launch_at_login,
             theme,
-        })
+        }
     }
 }

--- a/plugins/store/examples/AppSettingsManager/src-tauri/src/app/settings.rs
+++ b/plugins/store/examples/AppSettingsManager/src-tauri/src/app/settings.rs
@@ -10,10 +10,10 @@ pub struct AppSettings {
     pub theme: String,
 }
 
-impl AppSettings {
-    pub fn load_from_store<R: tauri::Runtime>(
-        store: &Store<R>,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+impl<R: tauri::Runtime> TryFrom<&Store<R>> for AppSettings {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(store: &Store) -> Result<Self, Self::Error> {
         let launch_at_login = store
             .get("appSettings.launchAtLogin")
             .and_then(|v| v.as_bool())

--- a/plugins/store/examples/AppSettingsManager/src-tauri/src/main.rs
+++ b/plugins/store/examples/AppSettingsManager/src-tauri/src/main.rs
@@ -18,28 +18,22 @@ fn main() {
         .setup(|app| {
             // Init store and load it from disk
             let store = app.store("settings.json")?;
+
             app.listen("store://change", |event| {
                 dbg!(event);
             });
-            let app_settings = AppSettings::try_from(store.as_ref());
-            match app_settings {
-                Ok(app_settings) => {
-                    let theme = app_settings.theme;
-                    let launch_at_login = app_settings.launch_at_login;
 
-                    println!("theme {theme}");
-                    println!("launch_at_login {launch_at_login}");
-                    store.set(
-                        "appSettings",
-                        json!({ "theme": theme, "launchAtLogin": launch_at_login }),
-                    );
-                }
-                Err(err) => {
-                    eprintln!("Error loading settings: {err}");
-                    // Handle the error case if needed
-                    return Err(err); // Convert the error to a Box<dyn Error> and return Err(err) here
-                }
-            }
+            let app_settings = AppSettings::from(store.as_ref());
+            let theme = app_settings.theme;
+            let launch_at_login = app_settings.launch_at_login;
+
+            println!("theme {theme}");
+            println!("launch_at_login {launch_at_login}");
+            store.set(
+                "appSettings",
+                json!({ "theme": theme, "launchAtLogin": launch_at_login }),
+            );
+
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/plugins/store/examples/AppSettingsManager/src-tauri/src/main.rs
+++ b/plugins/store/examples/AppSettingsManager/src-tauri/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
             app.listen("store://change", |event| {
                 dbg!(event);
             });
-            let app_settings = AppSettings::load_from_store(&store);
+            let app_settings = AppSettings::try_from(store.as_ref());
             match app_settings {
                 Ok(app_settings) => {
                     let theme = app_settings.theme;


### PR DESCRIPTION
Replace `load_from_store` with a `TryFrom` impl for more idiomatic conversion from `Store` to `AppSettings`.

Note: since all fields currently have default fallbacks, this conversion never actually fails. A `From` impl might be more appropriate here, but kept `TryFrom` to match the existing error handling.