### PR TITLE
feat(notification): add Android chronometer support

### DIFF
--- a/.changes/notification-chronometer.md
+++ b/.changes/notification-chronometer.md
@@ -1,0 +1,6 @@
+---
+"tauri-plugin-notification": minor:feat
+"@tauri-apps/plugin-notification": minor:feat
+---
+
+Added chronometer support for Android notifications with `when`, `usesChronometer`, and `chronometerCountDown` options. This allows displaying an automatically updating elapsed time counter directly in the notification, useful for time-tracking apps, ongoing calls, or timers.

--- a/plugins/notification/android/src/main/java/Notification.kt
+++ b/plugins/notification/android/src/main/java/Notification.kt
@@ -38,6 +38,9 @@ class Notification {
   var sourceJson: String? = null
   var visibility: Int? = null
   var number: Int? = null
+  var `when`: Long? = null
+  var usesChronometer: Boolean = false
+  var chronometerCountDown: Boolean = false
 
   fun getSound(context: Context, defaultSound: Int): String? {
     var soundPath: String? = null

--- a/plugins/notification/android/src/main/java/TauriNotificationManager.kt
+++ b/plugins/notification/android/src/main/java/TauriNotificationManager.kt
@@ -199,6 +199,23 @@ class TauriNotificationManager(
     }
     mBuilder.setVisibility(notification.visibility ?: NotificationCompat.VISIBILITY_PRIVATE)
     mBuilder.setOnlyAlertOnce(true)
+
+    // Chronometer support
+    if (notification.`when` != null) {
+      mBuilder.setWhen(notification.`when`!!)
+      mBuilder.setShowWhen(true)
+    }
+    if (notification.usesChronometer) {
+      mBuilder.setUsesChronometer(true)
+      if (notification.`when` == null) {
+        mBuilder.setWhen(System.currentTimeMillis())
+        mBuilder.setShowWhen(true)
+      }
+    }
+    if (notification.chronometerCountDown) {
+      mBuilder.setChronometerCountDown(true)
+    }
+
     mBuilder.setSmallIcon(notification.getSmallIcon(context, getDefaultSmallIcon(context)))
     mBuilder.setLargeIcon(notification.getLargeIcon(context))
     val iconColor = notification.getIconColor(config?.iconColor ?: "")

--- a/plugins/notification/guest-js/index.ts
+++ b/plugins/notification/guest-js/index.ts
@@ -136,6 +136,31 @@ interface Options {
    * Sets the number of items this notification represents on Android.
    */
   number?: number
+  /**
+   * Set the time that the event occurred. Notifications in the panel are sorted by this time.
+   * Represented as milliseconds since the epoch (e.g. `Date.now()`).
+   *
+   * **Android only.**
+   */
+  when?: number
+  /**
+   * Show the {@link when} field as a stopwatch. Instead of presenting `when` as a timestamp,
+   * the notification will show an automatically updating display of the minutes and seconds
+   * since `when`. Useful when showing an elapsed time (like an ongoing phone call or timer).
+   *
+   * **Android only.**
+   */
+  usesChronometer?: boolean
+  /**
+   * Sets the Chronometer to count down instead of counting up.
+   * This is only relevant if {@link usesChronometer} is `true`.
+   * If `when` is set to a time in the future, the chronometer will count down to zero then stop.
+   *
+   * **Android only.**
+   *
+   * @since API 24 (Android 7.0+)
+   */
+  chronometerCountDown?: boolean
 }
 
 interface ScheduleInterval {

--- a/plugins/notification/src/lib.rs
+++ b/plugins/notification/src/lib.rs
@@ -205,6 +205,36 @@ impl<R: Runtime> NotificationBuilder<R> {
         self.data.silent = true;
         self
     }
+
+    /// Set the time that the event occurred (milliseconds since epoch).
+    /// Notifications in the panel are sorted by this time.
+    /// When used with `uses_chronometer`, the notification shows elapsed time since this value.
+    ///
+    /// **Android only.**
+    pub fn when(mut self, when: i64) -> Self {
+        self.data.when = Some(when);
+        self
+    }
+
+    /// Show the `when` field as a stopwatch.
+    /// Instead of presenting `when` as a timestamp, the notification will show an automatically
+    /// updating display of the minutes and seconds since `when`.
+    ///
+    /// **Android only.**
+    pub fn uses_chronometer(mut self) -> Self {
+        self.data.uses_chronometer = true;
+        self
+    }
+
+    /// Sets the Chronometer to count down instead of counting up.
+    /// Only relevant if `uses_chronometer` is true.
+    /// If `when` is set to a time in the future, the chronometer will count down to zero then stop.
+    ///
+    /// **Android only (API 24+).**
+    pub fn chronometer_count_down(mut self) -> Self {
+        self.data.chronometer_count_down = true;
+        self
+    }
 }
 
 /// Extensions to [`tauri::App`], [`tauri::AppHandle`], [`tauri::WebviewWindow`], [`tauri::Webview`] and [`tauri::Window`] to access the notification APIs.

--- a/plugins/notification/src/models.rs
+++ b/plugins/notification/src/models.rs
@@ -176,6 +176,19 @@ pub struct NotificationData {
     pub(crate) auto_cancel: bool,
     #[serde(default)]
     pub(crate) silent: bool,
+    /// Set the time that the event occurred (milliseconds since epoch).
+    /// Notifications in the panel are sorted by this time.
+    /// Android only.
+    pub(crate) when: Option<i64>,
+    /// Show the `when` field as a stopwatch (elapsed time).
+    /// Android only.
+    #[serde(default)]
+    pub(crate) uses_chronometer: bool,
+    /// Sets the Chronometer to count down instead of counting up.
+    /// Only relevant if `uses_chronometer` is true.
+    /// Android only (API 24+).
+    #[serde(default)]
+    pub(crate) chronometer_count_down: bool,
 }
 
 fn default_id() -> i32 {
@@ -205,6 +218,9 @@ impl Default for NotificationData {
             ongoing: false,
             auto_cancel: false,
             silent: false,
+            when: None,
+            uses_chronometer: false,
+            chronometer_count_down: false,
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Android chronometer support to notification payload via `when`, `usesChronometer`, and `chronometerCountDown`
- wire new fields across guest JS options, Rust `NotificationData`/builder API, and Android notification builder/model
- include a `.changes` entry with matching `minor:feat` bumps for both Rust and JS notification packages

## Motivation
- enable native elapsed/countdown timer notifications for Android use cases like time tracking and ongoing timers

## Platform behavior
- Android: maps fields to notification chronometer APIs
- non-Android: fields are ignored and keep current behavior

What it looks like:
<img width="1080" height="262" alt="image" src="https://github.com/user-attachments/assets/4c6f8b1f-2f7f-4742-9a62-caf0450ddcbf" />

Closes #3279