### PR TITLE
chore(deps): disable renovate bot on v1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "extends": ["config:recommended"],
-  "baseBranches": ["v2", "v1"],
   "enabledManagers": ["cargo", "npm"],
   "labels": ["dependencies"],
   "ignorePaths": [


### PR DESCRIPTION
We're not really actively working on v1 anymore, not sure if it's worth it to still keep updating its dependencies