### PR TITLE
fix(barcode-scanner): iOS windowed mode scan() promise never resolves

### DIFF
--- a/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
+++ b/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
@@ -123,6 +123,9 @@ class BarcodeScannerPlugin: Plugin, AVCaptureMetadataOutputObjectsDelegate {
       }
 
       invoke?.resolve(jsObject)
+      // Stop processing further detections immediately to prevent
+      // duplicate resolve calls during the delay window below.
+      self.isScanning = false
       // Delay destroy so the IPC response reaches the JS layer before
       // the webview properties (isOpaque, backgroundColor) are restored.
       // Without this, the promise returned by scan() never resolves in

--- a/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
+++ b/plugins/barcode-scanner/ios/Sources/BarcodeScannerPlugin.swift
@@ -123,7 +123,13 @@ class BarcodeScannerPlugin: Plugin, AVCaptureMetadataOutputObjectsDelegate {
       }
 
       invoke?.resolve(jsObject)
-      destroy()
+      // Delay destroy so the IPC response reaches the JS layer before
+      // the webview properties (isOpaque, backgroundColor) are restored.
+      // Without this, the promise returned by scan() never resolves in
+      // windowed mode on iOS.
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+        self?.destroy()
+      }
 
     }
   }


### PR DESCRIPTION
## Bug

When using the barcode scanner plugin on iOS with `windowed: true`, the JavaScript promise returned by `scan()` never resolves — even though the native side successfully detects the barcode and sends the IPC response.

### Root Cause

In `BarcodeScannerPlugin.swift`, the `metadataOutput` delegate calls `invoke?.resolve(jsObject)` immediately followed by `destroy()`:

```swift
invoke?.resolve(jsObject)
destroy()
```

The `destroy()` method restores `webView.isOpaque = true` and resets `webView.backgroundColor` synchronously on the main thread. Since `metadataOutput` is dispatched on the main queue (line 168: `metaOutput!.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)`), the webview property restoration happens before the IPC callback can be delivered to the JavaScript layer.

This causes the `await scan()` promise to hang indefinitely in windowed mode. In non-windowed mode (`windowed: false`), the `destroy()` method skips the webview property restoration (the `if windowed { ... }` block), so the issue does not occur.

### Evidence

- The IPC response is visible in Safari's network inspector (`plugin:barcode-scanner|scan` returns `{"content": "...", "format": "QR_CODE"}`)
- But the JavaScript `await scan()` never continues — no code after `await` executes
- `cancel()` works correctly because it calls `invoke?.reject()` (not `resolve`) and the reject path is not affected by the webview state change

### Fix

Delay the `destroy()` call by 300ms using `DispatchQueue.main.asyncAfter`, giving the IPC response time to reach the JavaScript layer before the webview properties are restored:

```swift
invoke?.resolve(jsObject)
DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
    self?.destroy()
}
```

### Testing

- **Before fix:** `scan({ windowed: true })` on iOS detects barcode but JS promise never resolves. User is stuck on the scanner view.
- **After fix:** `scan({ windowed: true })` on iOS resolves correctly with the scanned content. The scanner is properly dismissed after a short delay.
- **Non-windowed mode:** Unaffected (the `if windowed` guard in `destroy()` means non-windowed mode never touches `webView.isOpaque`).

### Environment

- iOS 18.7
- Tauri v2
- `@tauri-apps/plugin-barcode-scanner` v2.4.4
- `tauri-plugin-barcode-scanner` from `v2` branch