### PR TITLE
fix error that byte could be undefined

### DIFF
--- a/plugins/fs/guest-js/index.ts
+++ b/plugins/fs/guest-js/index.ts
@@ -280,7 +280,7 @@ function fromBytes(buffer: FixedSizeArray<number, 8>): number {
   let x = 0
   for (let i = 0; i < size; i++) {
     // eslint-disable-next-line security/detect-object-injection
-    const byte = bytes[i]
+    const byte = bytes[i] ?? 0
     x *= 0x100
     x += byte
   }


### PR DESCRIPTION
I get this error:

```
vite v7.3.1 building client environment for production...
transforming (3400) node_modules/@tabler/icons-vue/dist/esm/icons/IconLayout.mjsvendor/cargo/tauri-plugin-fs-2.4.5/guest-js/index.ts:272:10 - error TS18048: 'byte' is possibly 'undefined'.

272     x += byte
             ~~~~


Found 1 error in vendor/cargo/tauri-plugin-fs-2.4.5/guest-js/index.ts:277
```

I don't know why typescript reports this error, but here is an easy fix for it