### PR TITLE
chore(deps): remove used of tauri-utils build feature

### DIFF
--- a/.changes/fs-remove-tauri-utils-build.md
+++ b/.changes/fs-remove-tauri-utils-build.md
@@ -1,0 +1,6 @@
+---
+"fs": patch
+"fs-js": patch
+---
+
+Removed the dependency on `tauri-utils`'s `build` feature

--- a/plugins/fs/Cargo.toml
+++ b/plugins/fs/Cargo.toml
@@ -21,7 +21,7 @@ tauri-plugin = { workspace = true, features = ["build"] }
 schemars = { workspace = true }
 serde = { workspace = true }
 toml = "0.9"
-tauri-utils = { workspace = true, features = ["build"] }
+tauri-utils = { workspace = true }
 
 [dependencies]
 serde = { workspace = true }


### PR DESCRIPTION
The feature was added in #1964 but never used, and as we just merged https://github.com/tauri-apps/tauri/pull/14959, we want to remove the dependency on this feature whenever possible