### PR TITLE
fix(deep-link): remove quotes from Exec path in .desktop file on Linux (fix tauri-apps/tauri#10570)

### DIFF
--- a/.changes/fix-deep-link-linux-exec-quoting.md
+++ b/.changes/fix-deep-link-linux-exec-quoting.md
@@ -1,0 +1,6 @@
+---
+"deep-link": patch
+"deep-link-js": patch
+---
+
+Remove literal quotes around `Exec` path in generated `.desktop` file on Linux, fixing deep link registration via `xdg-open`.

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -293,7 +293,7 @@ mod imp {
                     .unwrap_or_else(|| bin.into_os_string())
                     .to_string_lossy()
                     .to_string();
-                let qualified_exec = format!("\"{}\" %u", exec);
+                let qualified_exec = format!("{} %u", exec);
 
                 let target = self.app.path().data_dir()?.join("applications");
 


### PR DESCRIPTION
The `register()` function wraps the `Exec` path in literal double quotes when generating `.desktop` files on Linux:

```rust
let qualified_exec = format!("\"{}\" %u", exec);
// produces: Exec="/usr/bin/kunobi" %u
```

Per the [freedesktop Desktop Entry Spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/), `Exec` values are not shell-parsed — the quotes become part of the binary path. When `xdg-open` handles a deep link URL, it extracts the first token (including the literal `"` characters) and fails to find it:

```
$ XDG_UTILS_DEBUG_LEVEL=2 xdg-open "myapp://callback"
/usr/bin/xdg-open: 811: : Permission denied
```

Removing the quotes fixes deep link delivery on Linux.

Intended to resolve https://github.com/tauri-apps/tauri/issues/10570