### PR TITLE
fix(deep-link): filter out web links instead of app links in deep link domains

### DIFF
--- a/.changes/fix-deep-link-ios-url-types.md
+++ b/.changes/fix-deep-link-ios-url-types.md
@@ -1,0 +1,10 @@
+---
+"deep-link": patch
+---
+
+Fixed an iOS regression where deep link URL types were generated from app links instead of custom URL schemes, which could prevent custom schemes from being registered correctly.
+
+Also updated the generated iOS `CFBundleURLName` to use `$(PRODUCT_BUNDLE_IDENTIFIER).{scheme}`.
+
+And added handling for `webcredentials:` in iOS entitlements
+

--- a/plugins/deep-link/build.rs
+++ b/plugins/deep-link/build.rs
@@ -128,7 +128,13 @@ fn main() {
                             .iter()
                             .filter(|d| d.is_app_link())
                             .filter_map(|d| d.host.as_ref())
-                            .map(|host| format!("applinks:{}", host).into())
+                            .flat_map(|host| {
+                                [
+                                    format!("applinks:{}", host),
+                                    format!("webcredentials:{}", host),
+                                ]
+                            })
+                            .map(Into::into)
                             .collect::<Vec<_>>()
                             .into(),
                     );
@@ -173,7 +179,8 @@ fn main() {
                                 );
                                 dict.insert(
                                     "CFBundleURLName".into(),
-                                    format!("$(PRODUCT_BUNDLE_IDENTIFIER).{}", domain.scheme[0]).into(),
+                                    format!("$(PRODUCT_BUNDLE_IDENTIFIER).{}", domain.scheme[0])
+                                        .into(),
                                 );
                                 plist::Value::Dictionary(dict)
                             })

--- a/plugins/deep-link/build.rs
+++ b/plugins/deep-link/build.rs
@@ -139,7 +139,7 @@ fn main() {
             let deep_link_domains = config
                 .mobile
                 .iter()
-                .filter(|domain| !domain.is_app_link())
+                .filter(|domain| !domain.is_web_link())
                 .collect::<Vec<_>>();
 
             if deep_link_domains.is_empty() {
@@ -173,7 +173,7 @@ fn main() {
                                 );
                                 dict.insert(
                                     "CFBundleURLName".into(),
-                                    domain.scheme[0].clone().into(),
+                                    format!("$(PRODUCT_BUNDLE_IDENTIFIER).{}", domain.scheme[0]).into(),
                                 );
                                 plist::Value::Dictionary(dict)
                             })


### PR DESCRIPTION

This fixes a bug where on ios, deeplinks just don't work because the final Info.plist file doesn't have them. And also used a better id for CFBundleURLName

Fixes regression from 28048039496e84b46847c008416d341f1349e30e