### PR TITLE
fix(deep-link): check update-desktop-database existence before executing

### DIFF
--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -348,12 +348,28 @@ mod imp {
                     )?;
                 }
 
-                Command::new("update-desktop-database")
+                match Command::new("update-desktop-database")
                     .arg(target)
                     .status()
-                    .inspect_err(crate::error::inspect_command_error(
-                        "update-desktop-database",
-                    ))?;
+                {
+                    Ok(status) => {
+                        if !status.success() {
+                            tracing::warn!(
+                                "`update-desktop-database` exited with status {status}"
+                            );
+                        }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        tracing::warn!(
+                            "`update-desktop-database` not found, skipping MIME database update. \
+                             Install `desktop-file-utils` to silence this warning."
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to run `update-desktop-database`: {e}");
+                        return Err(e.into());
+                    }
+                }
 
                 Command::new("xdg-mime")
                     .args(["default", &file_name, mime_type.as_str()])


### PR DESCRIPTION
## Summary

On Linux, `update-desktop-database` from `desktop-file-utils` may not be installed. KDE systems don't require it. The current code calls it unconditionally and fails with an IO error when the command is missing.

This changes the call to handle `ErrorKind::NotFound` gracefully - logs a warning and continues instead of failing. Non-NotFound errors still propagate.

## Changes

- `plugins/deep-link/src/lib.rs`: Wrap the `update-desktop-database` invocation in a match that handles `NotFound` with a warning instead of returning an error.

## Testing

- `cargo check -p tauri-plugin-deep-link` passes

Fixes #2265

This contribution was developed with AI assistance (Claude Code).