### PR TITLE
fix(upload): wrong progress callback parameter names in README

### DIFF
--- a/plugins/upload/README.md
+++ b/plugins/upload/README.md
@@ -66,7 +66,7 @@ import { upload, HttpMethod } from '@tauri-apps/plugin-upload'
 upload(
   'https://example.com/file-upload',
   './path/to/my/file.txt',
-  (progress, total) => console.log(`Uploaded ${progress} of ${total} bytes`), // a callback that will be called with the upload progress
+  (progressTotal, total) => console.log(`Uploaded ${progressTotal} of ${total} bytes`), // a callback that will be called with the upload progress
   { 'Content-Type': 'text/plain' } // optional headers to send with the request
 )
 
@@ -74,7 +74,7 @@ upload(
 upload(
   'https://example.com/file-upload',
   './path/to/my/file.txt',
-  (progress, total) => console.log(`Uploaded ${progress} of ${total} bytes`),
+  (progressTotal, total) => console.log(`Uploaded ${progressTotal} of ${total} bytes`),
   { 'Content-Type': 'text/plain' },
   HttpMethod.Put // Use HttpMethod enum - supports POST, PUT, PATCH
 )
@@ -86,7 +86,7 @@ import { download } from '@tauri-apps/plugin-upload'
 download(
   'https://example.com/file-download-link',
   './path/to/save/my/file.txt',
-  (progress, total) => console.log(`Downloaded ${progress} of ${total} bytes`), // a callback that will be called with the download progress
+  (progressTotal, total) => console.log(`Downloaded ${progressTotal} of ${total} bytes`), // a callback that will be called with the download progress
   { 'Content-Type': 'text/plain' } // optional headers to send with the request
 )
 ```

--- a/plugins/upload/README.md
+++ b/plugins/upload/README.md
@@ -75,7 +75,7 @@ upload(
 upload(
   'https://example.com/file-upload',
   './path/to/my/file.txt',
-  (progressTotal, total) =>
+  ({ progressTotal, total }) =>
     console.log(`Uploaded ${progressTotal} of ${total} bytes`),
   { 'Content-Type': 'text/plain' },
   HttpMethod.Put // Use HttpMethod enum - supports POST, PUT, PATCH
@@ -88,7 +88,7 @@ import { download } from '@tauri-apps/plugin-upload'
 download(
   'https://example.com/file-download-link',
   './path/to/save/my/file.txt',
-  (progressTotal, total) =>
+  ({ progressTotal, total }) =>
     console.log(`Downloaded ${progressTotal} of ${total} bytes`), // a callback that will be called with the download progress
   { 'Content-Type': 'text/plain' } // optional headers to send with the request
 )

--- a/plugins/upload/README.md
+++ b/plugins/upload/README.md
@@ -66,7 +66,7 @@ import { upload, HttpMethod } from '@tauri-apps/plugin-upload'
 upload(
   'https://example.com/file-upload',
   './path/to/my/file.txt',
-  (progressTotal, total) =>
+  ({ progressTotal, total }) =>
     console.log(`Uploaded ${progressTotal} of ${total} bytes`), // a callback that will be called with the upload progress
   { 'Content-Type': 'text/plain' } // optional headers to send with the request
 )

--- a/plugins/upload/README.md
+++ b/plugins/upload/README.md
@@ -66,7 +66,8 @@ import { upload, HttpMethod } from '@tauri-apps/plugin-upload'
 upload(
   'https://example.com/file-upload',
   './path/to/my/file.txt',
-  (progressTotal, total) => console.log(`Uploaded ${progressTotal} of ${total} bytes`), // a callback that will be called with the upload progress
+  (progressTotal, total) =>
+    console.log(`Uploaded ${progressTotal} of ${total} bytes`), // a callback that will be called with the upload progress
   { 'Content-Type': 'text/plain' } // optional headers to send with the request
 )
 
@@ -74,7 +75,8 @@ upload(
 upload(
   'https://example.com/file-upload',
   './path/to/my/file.txt',
-  (progressTotal, total) => console.log(`Uploaded ${progressTotal} of ${total} bytes`),
+  (progressTotal, total) =>
+    console.log(`Uploaded ${progressTotal} of ${total} bytes`),
   { 'Content-Type': 'text/plain' },
   HttpMethod.Put // Use HttpMethod enum - supports POST, PUT, PATCH
 )
@@ -86,7 +88,8 @@ import { download } from '@tauri-apps/plugin-upload'
 download(
   'https://example.com/file-download-link',
   './path/to/save/my/file.txt',
-  (progressTotal, total) => console.log(`Downloaded ${progressTotal} of ${total} bytes`), // a callback that will be called with the download progress
+  (progressTotal, total) =>
+    console.log(`Downloaded ${progressTotal} of ${total} bytes`), // a callback that will be called with the download progress
   { 'Content-Type': 'text/plain' } // optional headers to send with the request
 )
 ```


### PR DESCRIPTION
The current documentation/examples for the download and upload functions use an incorrect destructuring pattern in the progress callback.

Currently, the examples suggest using ({ progress, total }), but according to the [ProgressPayload](https://github.com/tauri-apps/plugins-workspace/blob/c463d8ab1422a4cf44f627a7b4e6ba9d3553f334/plugins/upload/guest-js/index.ts#L9) interface in the source code, progress represents the chunk size (delta), while progressTotal represents the accumulated downloaded bytes.