### PR TITLE
fix(positioner): prevent panic when monitor is not found on Wayland

### DIFF
--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -152,7 +152,11 @@ fn calculate_position<R: Runtime>(
 ) -> Result<PhysicalPosition<i32>> {
     use Position::*;
 
-    let screen = window.current_monitor()?.unwrap();
+    let screen = window
+        .current_monitor()?
+        .or_else(|| window.primary_monitor().ok().flatten())
+        .ok_or_else(|| tauri::Error::AssetNotFound("Monitor not found".to_string()))?;
+
     // Only use the screen_position for the Tray independent positioning,
     // because a tray event may not be called on the currently active monitor.
     let screen_position = screen.position();
@@ -225,7 +229,7 @@ fn calculate_position<R: Runtime>(
 
                 PhysicalPosition { x: tray_x, y }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -236,7 +240,7 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -257,7 +261,7 @@ fn calculate_position<R: Runtime>(
                     y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -268,7 +272,7 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -287,7 +291,7 @@ fn calculate_position<R: Runtime>(
 
                 PhysicalPosition { x, y }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -298,7 +302,7 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
     };


### PR DESCRIPTION
### Problem

On Linux (specifically Wayland/GNOME), the `tauri-plugin-positioner` library triggers a runtime panic when attempting to position a window that has not yet been assigned to a monitor (e.g., during initialization or while hidden). This is because `window.current_monitor()` returns `None`, and the code performs an unsafe `.unwrap()`.

### Solution

This PR:
1. Replaces the panicking `.unwrap()` with a safe fallback chain: `current_monitor() -> primary_monitor() -> Error`.
2. Replaces other `panic!` calls in tray positioning logic with proper `tauri::Result` error returns.
3. Improves overall robustness on Wayland compositors where window-to-monitor mapping can be delayed.

### Verification

Verified locally in a Tauri 2.0 project on Wayland by:
1. Creating a hidden window.
2. Attempting to position it using the plugin.
3. Confirming that the previous panic is gone and the window is positioned correctly relative to the primary monitor.
