### PR TITLE
fix(positioner): handle zero-size hidden windows and improve monitor detection

### DIFF
--- a/.changes/fix-positioner-wayland-sizing.md
+++ b/.changes/fix-positioner-wayland-sizing.md
@@ -1,0 +1,6 @@
+---
+"tauri-plugin-positioner": patch
+"@tauri-apps/plugin-positioner": patch
+---
+
+Handle zero-size hidden windows on Wayland and improve monitor detection to prevent panics.

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -152,18 +152,39 @@ fn calculate_position<R: Runtime>(
 ) -> Result<PhysicalPosition<i32>> {
     use Position::*;
 
-    let screen = window.current_monitor()?.unwrap();
-    // Only use the screen_position for the Tray independent positioning,
-    // because a tray event may not be called on the currently active monitor.
+    let screen = window
+        .current_monitor()?
+        .or_else(|| window.primary_monitor().ok().flatten())
+        .or_else(|| window.app_handle().primary_monitor().ok().flatten())
+        .or_else(|| {
+            window
+                .available_monitors()
+                .ok()
+                .and_then(|m| m.into_iter().next())
+        })
+        .ok_or_else(|| tauri::Error::AssetNotFound("Monitor not found".to_string()))?;
+
     let screen_position = screen.position();
     let screen_size = PhysicalSize::<i32> {
         width: screen.size().width as i32,
         height: screen.size().height as i32,
     };
-    let window_size = PhysicalSize::<i32> {
+    let mut window_size = PhysicalSize::<i32> {
         width: window.outer_size()?.width as i32,
         height: window.outer_size()?.height as i32,
     };
+
+    // Fallback: If the window is hidden, outer_size() often returns 0 on some platforms (e.g. Wayland).
+    // Try to get the inner_size() if outer_size is 0.
+    if window_size.width == 0 {
+        if let Ok(inner) = window.inner_size() {
+            if inner.width > 0 {
+                window_size.width = inner.width as i32;
+                window_size.height = inner.height as i32;
+            }
+        }
+    }
+
     #[cfg(feature = "tray-icon")]
     let (tray_position, tray_size) = window
         .state::<Tray>()
@@ -225,7 +246,7 @@ fn calculate_position<R: Runtime>(
 
                 PhysicalPosition { x: tray_x, y }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -236,7 +257,7 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -257,7 +278,7 @@ fn calculate_position<R: Runtime>(
                     y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -268,7 +289,7 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -287,7 +308,7 @@ fn calculate_position<R: Runtime>(
 
                 PhysicalPosition { x, y }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -298,7 +319,7 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::AssetNotFound("Tray position not set".to_string()));
             }
         }
     };


### PR DESCRIPTION
## Description
On Linux (especially Wayland), `window.outer_size()` often returns `0x0` for hidden windows. This causes the positioner logic to calculate coordinates as `(0,0)`, placing windows in the top-left instead of the requested position.

This PR adds a fallback to `inner_size()` if `outer_size()` is zero, which is more reliable for hidden windows on Wayland. It also improves monitor detection by adding retries and removing potentially panicking `unwrap()` calls when a monitor isn't immediately found.

## Changes
- Added `inner_size()` fallback in `calculate_position`.
- Refactored monitor detection to be more robust and panic-safe.
- Minimal logic changes to ensure compatibility.
