### PR TITLE
fix: replace panics with error returns

### DIFF
--- a/.changes/positioner-panic.md
+++ b/.changes/positioner-panic.md
@@ -1,0 +1,6 @@
+---
+positioner: patch
+positioner-js: patch
+---
+
+Removed panics and replaced them with error handling.

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -225,7 +225,9 @@ fn calculate_position<R: Runtime>(
 
                 PhysicalPosition { x: tray_x, y }
             } else {
-                return Err(tauri::Error::Runtime("Tray position not set".into()));
+                return Err(tauri::Error::Io(std::io::Error::other(
+                    "Tray position not set",
+                )));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -236,7 +238,9 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                return Err(tauri::Error::Runtime("Tray position not set".into()));
+                return Err(tauri::Error::Io(std::io::Error::other(
+                    "Tray position not set",
+                )));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -257,7 +261,9 @@ fn calculate_position<R: Runtime>(
                     y,
                 }
             } else {
-                return Err(tauri::Error::Runtime("Tray position not set".into()));
+                return Err(tauri::Error::Io(std::io::Error::other(
+                    "Tray position not set",
+                )));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -268,7 +274,9 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                return Err(tauri::Error::Runtime("Tray position not set".into()));
+                return Err(tauri::Error::Io(std::io::Error::other(
+                    "Tray position not set",
+                )));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -287,7 +295,9 @@ fn calculate_position<R: Runtime>(
 
                 PhysicalPosition { x, y }
             } else {
-                return Err(tauri::Error::Runtime("Tray position not set".into()));
+                return Err(tauri::Error::Io(std::io::Error::other(
+                    "Tray position not set",
+                )));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -298,7 +308,9 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                return Err(tauri::Error::Runtime("Tray position not set".into()));
+                return Err(tauri::Error::Io(std::io::Error::other(
+                    "Tray position not set",
+                )));
             }
         }
     };

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -225,7 +225,7 @@ fn calculate_position<R: Runtime>(
 
                 PhysicalPosition { x: tray_x, y }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::Runtime("Tray position not set".into()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -236,7 +236,7 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::Runtime("Tray position not set".into()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -257,7 +257,7 @@ fn calculate_position<R: Runtime>(
                     y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::Runtime("Tray position not set".into()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -268,7 +268,7 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::Runtime("Tray position not set".into()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -287,7 +287,7 @@ fn calculate_position<R: Runtime>(
 
                 PhysicalPosition { x, y }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::Runtime("Tray position not set".into()));
             }
         }
         #[cfg(feature = "tray-icon")]
@@ -298,7 +298,7 @@ fn calculate_position<R: Runtime>(
                     y: tray_y,
                 }
             } else {
-                panic!("Tray position not set");
+                return Err(tauri::Error::Runtime("Tray position not set".into()));
             }
         }
     };


### PR DESCRIPTION
These panics are causing all sorts of havoc in our app. This PR just removes the panics and returns `Err` instead.

Related issue: https://github.com/tauri-apps/plugins-workspace/issues/1583#issuecomment-2681486868