### PR TITLE
Add option to clear badge and notifications on app focus on iOS and Android

### DIFF
--- a/plugins/notification/README.md
+++ b/plugins/notification/README.md
@@ -73,6 +73,26 @@ Then you need to add the permissions to your capabilities file:
 
 Afterwards all the plugin's APIs are available through the JavaScript guest bindings:
 
+## Configuration
+
+In `tauri.conf.json`:
+
+```json
+{
+  "plugins": {
+    "notification": {
+      "clearNotificationsOnAppFocus": true
+    }
+  }
+}
+```
+
+| Option                         | Type      | Default | Description                                                                                                                    |
+| ------------------------------ | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `clearNotificationsOnAppFocus` | `boolean` | `false` | Whether the plugin should clear the notification badge and delivered notifications when the app is focused on iOS and Android. |
+
+## Usage
+
 ```javascript
 import {
   isPermissionGranted,

--- a/plugins/notification/android/src/main/java/NotificationPlugin.kt
+++ b/plugins/notification/android/src/main/java/NotificationPlugin.kt
@@ -30,6 +30,7 @@ class PluginConfig {
   var icon: String? = null
   var sound: String? = null
   var iconColor: String? = null
+  var clearNotificationsOnAppFocus: Boolean = false
 }
 
 @InvokeArg
@@ -82,6 +83,7 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
   private lateinit var notificationManager: NotificationManager
   private lateinit var notificationStorage: NotificationStorage
   private var channelManager = ChannelManager(activity)
+  private var config: PluginConfig? = null
 
   companion object {
     var instance: NotificationPlugin? = null
@@ -97,22 +99,30 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
     super.load(webView)
     this.webView = webView
     notificationStorage = NotificationStorage(activity, jsonMapper())
-    
+
+    this.config = getConfig(PluginConfig::class.java)
     val manager = TauriNotificationManager(
       notificationStorage,
       activity,
       activity,
-      getConfig(PluginConfig::class.java)
+      config
     )
     manager.createNotificationChannel()
-    
+
     this.manager = manager
-    
+
     notificationManager = activity.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
     val intent = activity.intent
     intent?.let {
       onIntent(it)
+    }
+  }
+
+  override fun onResume() {
+    super.onResume()
+    if (config?.clearNotificationsOnAppFocus == true) {
+      notificationManager.cancelAll()
     }
   }
 

--- a/plugins/notification/ios/Sources/NotificationPlugin.swift
+++ b/plugins/notification/ios/Sources/NotificationPlugin.swift
@@ -153,14 +153,48 @@ struct BatchArgs: Decodable {
   let notifications: [Notification]
 }
 
+struct Config: Decodable {
+  let clearNotificationsOnAppFocus: Bool
+}
+
 class NotificationPlugin: Plugin {
   let notificationHandler = NotificationHandler()
   let notificationManager = NotificationManager()
+  var config: Config?
 
   override init() {
     super.init()
     notificationManager.notificationHandler = notificationHandler
     notificationHandler.plugin = self
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(didBecomeActive),
+      name: UIApplication.didBecomeActiveNotification,
+      object: nil
+    )
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  @objc func setConfig(_ invoke: Invoke) throws {
+    config = try invoke.parseArgs(Config.self)
+    invoke.resolve()
+  }
+
+  @objc func didBecomeActive() {
+    if let config = config, config.clearNotificationsOnAppFocus {
+      UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+      DispatchQueue.main.async(execute: {
+        if #available(iOS 16.0, *) {
+          UNUserNotificationCenter.current().setBadgeCount(0)
+        } else {
+          UIApplication.shared.applicationIconBadgeNumber = 0
+        }
+      })
+    }
   }
 
   @objc public func show(_ invoke: Invoke) throws {

--- a/plugins/notification/src/lib.rs
+++ b/plugins/notification/src/lib.rs
@@ -31,6 +31,9 @@ mod commands;
 mod error;
 mod models;
 
+#[cfg(test)]
+mod tests;
+
 pub use error::{Error, Result};
 
 #[cfg(desktop)]
@@ -219,8 +222,8 @@ impl<R: Runtime, T: Manager<R>> crate::NotificationExt<R> for T {
 }
 
 /// Initializes the plugin.
-pub fn init<R: Runtime>() -> TauriPlugin<R> {
-    Builder::new("notification")
+pub fn init<R: Runtime>() -> TauriPlugin<R, PluginConfig> {
+    Builder::<R, PluginConfig>::new("notification")
         .invoke_handler(tauri::generate_handler![
             commands::notify,
             commands::request_permission,
@@ -232,7 +235,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
         ))
         .setup(|app, api| {
             #[cfg(mobile)]
-            let notification = mobile::init(app, api)?;
+            let notification = mobile::init(app, api, api.config().clone())?;
             #[cfg(desktop)]
             let notification = desktop::init(app, api)?;
             app.manage(notification);

--- a/plugins/notification/src/mobile.rs
+++ b/plugins/notification/src/mobile.rs
@@ -22,11 +22,16 @@ tauri::ios_plugin_binding!(init_plugin_notification);
 pub fn init<R: Runtime, C: DeserializeOwned>(
     _app: &AppHandle<R>,
     api: PluginApi<R, C>,
+    config: PluginConfig,
 ) -> crate::Result<Notification<R>> {
     #[cfg(target_os = "android")]
     let handle = api.register_android_plugin(PLUGIN_IDENTIFIER, "NotificationPlugin")?;
     #[cfg(target_os = "ios")]
-    let handle = api.register_ios_plugin(init_plugin_notification)?;
+    let handle = {
+        let handle = api.register_ios_plugin(init_plugin_notification)?;
+        handle.run_mobile_plugin("setConfig", config)?;
+        handle
+    };
     Ok(Notification(handle))
 }
 

--- a/plugins/notification/src/models.rs
+++ b/plugins/notification/src/models.rs
@@ -476,3 +476,10 @@ mod android {
         }
     }
 }
+
+#[derive(Debug, Default, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginConfig {
+    #[serde(default)]
+    pub clear_notifications_on_app_focus: bool,
+}

--- a/plugins/notification/src/tests.rs
+++ b/plugins/notification/src/tests.rs
@@ -1,0 +1,13 @@
+#[cfg(test)]
+#[test]
+fn test_config_deserialization() {
+    let config_json = serde_json::json!({
+        "clearNotificationsOnAppFocus": true
+    });
+    let config: crate::models::PluginConfig = serde_json::from_value(config_json).unwrap();
+    assert!(config.clear_notifications_on_app_focus);
+
+    let empty_config: crate::models::PluginConfig =
+        serde_json::from_value(serde_json::json!({})).unwrap();
+    assert!(!empty_config.clear_notifications_on_app_focus);
+}


### PR DESCRIPTION
While using the plugin-notification plugin in a production-ready app, I have encountered this issue on iOS and Android:

When receiving a notification:
- the app correctly shows the icon badge with the notifications count in it
- notifications are correctly displayed in the notification center
After opening the app:
- the badge icon is persisted, it is not cleared
- the notifications are persisted in the notifications center

There might be cases in which this behavior might be correct, but in most applications I believe it would be useful to have an option (not enabled by default) to allow auto-cleanup of the badge and of the notifications whenever the app is reopened.