### PR TITLE
fix(notification): cancel() crashes on Android with empty notifications list (fix #2341)

### DIFF
--- a/.changes/notification-cancel-all-android.md
+++ b/.changes/notification-cancel-all-android.md
@@ -1,0 +1,6 @@
+---
+"notification": patch
+"notification-js": patch
+---
+
+Fix `cancel` command crashing on Android with `UninitializedPropertyAccessException` when invoked with no `notifications` argument — i.e. when the JS `cancelAll()` API or the Rust `NotificationExt::cancel_all()` SDK method is used. `CancelArgs.notifications` is now an optional list defaulting to `[]`; the handler routes an empty list to a new `TauriNotificationManager.cancelAll()` that enumerates saved notification IDs from storage and cancels each.

--- a/plugins/notification/android/src/main/java/NotificationPlugin.kt
+++ b/plugins/notification/android/src/main/java/NotificationPlugin.kt
@@ -39,7 +39,7 @@ class BatchArgs {
 
 @InvokeArg
 class CancelArgs {
-  lateinit var notifications: List<Int>
+  var notifications: List<Int> = listOf()
 }
 
 @InvokeArg
@@ -152,7 +152,11 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
   @Command
   fun cancel(invoke: Invoke) {
     val args = invoke.parseArgs(CancelArgs::class.java)
-    manager.cancel(args.notifications)
+    if (args.notifications.isEmpty()) {
+      manager.cancelAll()
+    } else {
+      manager.cancel(args.notifications)
+    }
     invoke.resolve()
   }
 

--- a/plugins/notification/android/src/main/java/TauriNotificationManager.kt
+++ b/plugins/notification/android/src/main/java/TauriNotificationManager.kt
@@ -391,6 +391,10 @@ class TauriNotificationManager(
     }
   }
 
+  fun cancelAll() {
+    cancel(storage.getSavedNotificationIds().mapNotNull { it.toIntOrNull() })
+  }
+
   private fun cancelTimerForNotification(notificationId: Int) {
     val intent = Intent(context, TimedNotificationPublisher::class.java)
     var flags = 0


### PR DESCRIPTION
Fixes #2341 (the `cancelAll()` part — other items in that issue are unaddressed by this PR).

## Problem

`NotificationPlugin.kt:42` declares the cancel-command argument shape as:

```kotlin
@InvokeArg
class CancelArgs {
  lateinit var notifications: List<Int>
}
```

The handler then unconditionally reads `args.notifications` and forwards it to `manager.cancel(...)`. Both supported callers of "cancel all" hit this dead-end:

- JS `cancelAll()` from `@tauri-apps/plugin-notification` invokes `plugin:notification|cancel` with **no** `notifications` field.
- Rust SDK `NotificationExt::cancel_all()` (mobile.rs) does `run_mobile_plugin("cancel", ())` — same effect.

In both cases Kotlin throws `UninitializedPropertyAccessException` when the handler reads `args.notifications`. On the JS side this bubbles up as a rejected `invoke()` promise that the `sendNotification` polyfill silently drops, so callers see no notifications cancelled and no error.

This was observed downstream while shipping a reminder-style notification feature — debugging required tracing through the Rust SDK, the plugin's Android Kotlin, and finally `dumpsys alarm` to confirm that the schedule loop was being aborted by the failing `cancelAll()` before any `notify` call ever ran.

## Fix

Three small changes, all in `plugins/notification/android/src/main/java/`:

1. **`NotificationPlugin.kt`** — `CancelArgs.notifications` is now `var notifications: List<Int> = listOf()` (optional, defaults to empty). The handler routes an empty list through a new `manager.cancelAll()`; non-empty still goes through the existing `manager.cancel(ids)`.

2. **`TauriNotificationManager.kt`** — new `cancelAll()` method that enumerates saved IDs via the existing `NotificationStorage.getSavedNotificationIds()` and reuses the existing per-id `cancel()` cleanup path (dismiss visible + cancel timer + delete storage entry). No duplicated cleanup logic.

3. **`.changes/notification-cancel-all-android.md`** — patch bump on both `notification` and `notification-js` per the repo `.changes/readme.md` rule («both packages need to be bumped with the same increment even when only one side changed»).

## Tests

The plugin's `plugins/notification/android/src/test/` currently contains only the placeholder `ExampleUnitTest.kt` — there is no existing scaffold for handler/manager unit tests. I deliberately did not add a one-off test in this PR so the change stays minimal; happy to add a focused test for `cancel(empty)` if maintainers want the coverage and can confirm a preferred mocking approach for `Invoke` / `manager`.

## Compatibility

- JS `cancelAll()`: starts working as documented.
- JS `cancel([1, 2, 3])`: unchanged — still routed through `manager.cancel(ids)`.
- Rust `NotificationExt::cancel_all()`: starts working.
- Rust `NotificationExt::cancel(vec![1, 2, 3])`: unchanged.
- iOS / desktop: untouched (Android-only change).

No public API change. No migration needed.
