### PR TITLE
feat: Add Support for FreeBSD on Autostart

### DIFF
--- a/plugins/autostart/Cargo.toml
+++ b/plugins/autostart/Cargo.toml
@@ -24,4 +24,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tauri = { workspace = true }
 thiserror = { workspace = true }
-auto-launch = "0.5"
+auto-launch = "0.6"

--- a/plugins/autostart/src/lib.rs
+++ b/plugins/autostart/src/lib.rs
@@ -10,6 +10,8 @@
 )]
 #![cfg(not(any(target_os = "android", target_os = "ios")))]
 
+#[cfg(target_os = "macos")]
+use auto_launch::MacOSLaunchMode;
 use auto_launch::{AutoLaunch, AutoLaunchBuilder};
 use serde::{ser::Serializer, Serialize};
 use tauri::{
@@ -190,10 +192,10 @@ impl Builder {
 
                 #[cfg(target_os = "macos")]
                 {
-                    builder.set_use_launch_agent(matches!(
-                        self.macos_launcher,
-                        MacosLauncher::LaunchAgent
-                    ));
+                    builder.set_macos_launch_mode(match self.macos_launcher {
+                        MacosLauncher::LaunchAgent => MacOSLaunchMode::LaunchAgent,
+                        MacosLauncher::AppleScript => MacOSLaunchMode::AppleScript,
+                    });
                     // on macOS, current_exe gives path to /Applications/Example.app/MacOS/Example
                     // but this results in seeing a Unix Executable in macOS login items
                     // It must be: /Applications/Example.app
@@ -221,6 +223,11 @@ impl Builder {
                 } else {
                     builder.set_app_path(&current_exe.display().to_string());
                 }
+
+                // FreeBSD has no AppImage concept and tauri's `Env` has no
+                // `appimage` field under FreeBSD, so just use the current exe path.
+                #[cfg(target_os = "freebsd")]
+                builder.set_app_path(&current_exe.display().to_string());
 
                 app.manage(AutoLaunchManager(
                     builder.build().map_err(|e| e.to_string())?,


### PR DESCRIPTION
Add support for FreeBSD and update auto-start to version 0.6
This PR will be marked as ready-for-review until [PR #34 from auto-launch](https://github.com/zzzgydi/auto-launch/pull/34) is merged.