### PR TITLE
fix(sql): decode MySQL BINARY/VARBINARY columns

### DIFF
--- a/.changes/sql-mysql-varbinary.md
+++ b/.changes/sql-mysql-varbinary.md
@@ -1,0 +1,6 @@
+---
+"sql": patch
+"sql-js": patch
+---
+
+Fix MySQL `BINARY` and `VARBINARY` columns failing to decode with `unsupported datatype: VARBINARY`. This notably affects `VARCHAR` columns using a binary collation such as `utf8mb4_bin`, which MySQL reports as `VARBINARY`. They are now decoded as byte arrays like the other binary types. Also fix a typo (`TINIYBLOB`) that prevented `TINYBLOB` columns from being decoded.

--- a/plugins/sql/src/decode/mysql.rs
+++ b/plugins/sql/src/decode/mysql.rs
@@ -86,7 +86,7 @@ pub(crate) fn to_json(v: MySqlValueRef) -> Result<JsonValue, Error> {
             }
         }
         "JSON" => ValueRef::to_owned(&v).try_decode().unwrap_or_default(),
-        "TINIYBLOB" | "MEDIUMBLOB" | "BLOB" | "LONGBLOB" => {
+        "BINARY" | "VARBINARY" | "TINYBLOB" | "MEDIUMBLOB" | "BLOB" | "LONGBLOB" => {
             if let Ok(v) = ValueRef::to_owned(&v).try_decode::<Vec<u8>>() {
                 JsonValue::Array(v.into_iter().map(|n| JsonValue::Number(n.into())).collect())
             } else {


### PR DESCRIPTION
Closes #2274.

MySQL reports `VARCHAR` columns that use a **binary collation** (e.g. `utf8mb4_bin`) as `VARBINARY`. The MySQL decoder didn't handle `BINARY`/`VARBINARY`, so those columns fell through to the catch-all and failed with:

```
unsupported datatype: VARBINARY
```

(reported by several users, and the underlying behavior also tracked in [launchbadge/sqlx#3387](https://github.com/launchbadge/sqlx/issues/3387)).

### Changes
- Add `BINARY` and `VARBINARY` to the binary-decoding match arm in `plugins/sql/src/decode/mysql.rs`, so they are returned as byte arrays just like `BLOB`/`TINYBLOB`/etc. This fixes the error without downgrading `sqlx`.
- Fix a pre-existing typo `TINIYBLOB` → `TINYBLOB`, which meant `TINYBLOB` columns were never matched and silently fell through too.

`cargo check -p tauri-plugin-sql --features mysql` passes. Added a covector changefile (`sql`/`sql-js` patch).