### PR TITLE
remove unused dependency `byte-unit` from log plugin

### DIFF
--- a/.changes/rmdep.md
+++ b/.changes/rmdep.md
@@ -3,4 +3,4 @@
 "log-js": patch
 ---
 
-Removed an unused dependency.
+Removed an unused dependency `byte-unit`.

--- a/.changes/rmdep.md
+++ b/.changes/rmdep.md
@@ -1,5 +1,6 @@
 ---
-"tauri-plugin-log": minor
+"log": patch
+"log-js": patch
 ---
 
 Removed an unused dependency.

--- a/.changes/rmdep.md
+++ b/.changes/rmdep.md
@@ -1,0 +1,5 @@
+---
+"tauri-plugin-log": minor
+---
+
+Removed an unused dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,17 +773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "byte-unit"
-version = "5.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cd29c3c585209b0cbc7309bfe3ed7efd8c84c21b7af29c8bfae908f8777174"
-dependencies = [
- "rust_decimal",
- "serde",
- "utf8-width",
-]
-
-[[package]]
 name = "bytecheck"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6657,7 +6646,6 @@ name = "tauri-plugin-log"
 version = "2.8.0"
 dependencies = [
  "android_logger",
- "byte-unit",
  "fern",
  "log",
  "objc2 0.6.4",
@@ -7731,12 +7719,6 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8-width"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8_iter"

--- a/plugins/log/Cargo.toml
+++ b/plugins/log/Cargo.toml
@@ -25,7 +25,6 @@ serde_json = { workspace = true }
 tauri = { workspace = true }
 thiserror = { workspace = true }
 serde_repr = "0.1"
-byte-unit = "5"
 log = { workspace = true, features = ["kv_unstable"] }
 time = { version = "0.3", features = [
   "formatting",


### PR DESCRIPTION
It doesn't seem to be used anywhere, and seems to pull in a `syn 1.X` dep