### PR TITLE
fix(positioner): return error instead of panicking when window has no monitor

### DIFF
--- a/.changes/positioner-current-monitor-panic.md
+++ b/.changes/positioner-current-monitor-panic.md
@@ -1,0 +1,6 @@
+---
+positioner: patch
+positioner-js: patch
+---
+
+Replaced a panic in `calculate_position` with an error return when the window has no associated monitor (e.g. during display sleep or monitor reconfiguration).

--- a/plugins/positioner/src/ext.rs
+++ b/plugins/positioner/src/ext.rs
@@ -152,7 +152,9 @@ fn calculate_position<R: Runtime>(
 ) -> Result<PhysicalPosition<i32>> {
     use Position::*;
 
-    let screen = window.current_monitor()?.unwrap();
+    let screen = window.current_monitor()?.ok_or_else(|| {
+        tauri::Error::Io(std::io::Error::other("No monitor found for the window"))
+    })?;
     // Only use the screen_position for the Tray independent positioning,
     // because a tray event may not be called on the currently active monitor.
     let screen_position = screen.position();


### PR DESCRIPTION
`calculate_position` calls `window.current_monitor()?.unwrap()`. `current_monitor()` legitimately returns `Ok(None)` when the window is transiently not associated with any monitor — e.g. during display sleep or monitor reconfiguration — so the `unwrap` panics and takes the whole app down. We hit this in production: a tray click during a display transition crashed the app inside `move_window(Position::TrayCenter)`.

#3420 already converted the sibling `panic!("Tray position not set")` branches in this function to error returns; this PR applies the same treatment to the remaining `unwrap`, returning `tauri::Error::Io` in the same shape.

Includes a `.changes` patch entry for `positioner` and `positioner-js`, matching #3420.