### PR TITLE
docs(http): fix connectTimeout option in README

### DIFF
--- a/plugins/http/README.md
+++ b/plugins/http/README.md
@@ -62,7 +62,7 @@ Afterwards all the plugin's APIs are available through the JavaScript guest bind
 import { fetch } from '@tauri-apps/plugin-http'
 const response = await fetch('http://localhost:3003/users/2', {
   method: 'GET',
-  timeout: 30
+  connectTimeout: 30
 })
 ```
 


### PR DESCRIPTION
Closes #3365.

The HTTP plugin README example used `timeout`, but the JavaScript API exposes `connectTimeout` and the Rust command config receives it as `connect_timeout` via camelCase deserialization.

This PR updates the README example to use `connectTimeout` so it matches the existing API.

Checks:
- `git diff --check`
- `prettier --check plugins/http/README.md`

Docs-only change, so no changefile is included.
