### PR TITLE
fix(single-instance): Yield unix listener in macos

### DIFF
--- a/.changes/fix-yield-single-instance-macos.md
+++ b/.changes/fix-yield-single-instance-macos.md
@@ -1,0 +1,5 @@
+---
+"single-instance": minor-fix
+"single-instance": minor-fix
+---
+Fix blocked thread on the single-instance plugin for MacOS: replace standard `UnixListener` with `tokio::net::UnixListener`, so the task can yield.

--- a/.changes/fix-yield-single-instance-macos.md
+++ b/.changes/fix-yield-single-instance-macos.md
@@ -1,5 +1,4 @@
 ---
-"single-instance": minor-fix
-"single-instance": minor-fix
+"single-instance": patch
 ---
 Fix blocked thread on the single-instance plugin for MacOS: replace standard `UnixListener` with `tokio::net::UnixListener`, so the task can yield.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6793,6 +6793,7 @@ dependencies = [
  "tauri",
  "tauri-plugin-deep-link",
  "thiserror 2.0.12",
+ "tokio",
  "tracing",
  "windows-sys 0.60.2",
  "zbus",

--- a/plugins/single-instance/Cargo.toml
+++ b/plugins/single-instance/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 tauri-plugin-deep-link = { path = "../deep-link", version = "2.4.9", optional = true }
 semver = { version = "1", optional = true }
-tokio = "1"
+tokio = { version = "1", features = ["net"] }
 
 [target."cfg(target_os = \"windows\")".dependencies.windows-sys]
 version = "0.60"

--- a/plugins/single-instance/Cargo.toml
+++ b/plugins/single-instance/Cargo.toml
@@ -24,6 +24,7 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 tauri-plugin-deep-link = { path = "../deep-link", version = "2.4.9", optional = true }
 semver = { version = "1", optional = true }
+tokio = "1"
 
 [target."cfg(target_os = \"windows\")".dependencies.windows-sys]
 version = "0.60"

--- a/plugins/single-instance/src/platform_impl/macos.rs
+++ b/plugins/single-instance/src/platform_impl/macos.rs
@@ -4,7 +4,7 @@
 
 use std::{
     io::{BufWriter, Error, ErrorKind, Write},
-    os::unix::net::{UnixListener, UnixStream},
+    os::unix::net::UnixStream,
     path::PathBuf,
 };
 
@@ -32,7 +32,7 @@ pub fn init<R: Runtime>(cb: Box<SingleInstanceCallback<R>>) -> TauriPlugin<R> {
                         ErrorKind::NotFound | ErrorKind::ConnectionRefused => {
                             // This process claims itself as singleton as likely none exists
                             socket_cleanup(&socket);
-                            listen_for_other_instances(&socket, app.clone(), cb);
+                            listen_for_other_instances(socket, app.clone(), cb);
                         }
                         _ => {
                             tracing::debug!(
@@ -93,45 +93,40 @@ fn notify_singleton(socket: &PathBuf) -> Result<(), Error> {
 }
 
 fn listen_for_other_instances<A: Runtime>(
-    socket: &PathBuf,
+    socket: PathBuf,
     app: AppHandle<A>,
     mut cb: Box<SingleInstanceCallback<A>>,
 ) {
-    match UnixListener::bind(socket) {
-        Ok(std_listener) => {
-            std_listener.set_nonblocking(true).ok();
-            tauri::async_runtime::spawn(async move {
-                let listener = tokio::net::UnixListener::from_std(std_listener)
-                    .expect("failed to convert std UnixListener to tokio yielding UnixListener");
-                loop {
-                    match listener.accept().await {
-                        Ok((mut stream, _addr)) => {
-                            let mut s = String::new();
-                            match stream.read_to_string(&mut s).await {
-                                Ok(_) => {
-                                    let (cwd, args) = s.split_once("\0\0").unwrap_or_default();
-                                    let args: Vec<String> =
-                                        args.split('\0').map(String::from).collect();
-                                    cb(app.app_handle(), args, cwd.to_string());
-                                }
-                                Err(e) => {
-                                    tracing::debug!("single_instance failed to be notified: {e}")
-                                }
+    tauri::async_runtime::spawn(async move {
+        match tokio::net::UnixListener::bind(socket) {
+            Ok(listener) => loop {
+                match listener.accept().await {
+                    Ok((mut stream, _addr)) => {
+                        let mut s = String::new();
+                        match stream.read_to_string(&mut s).await {
+                            Ok(_) => {
+                                let (cwd, args) = s.split_once("\0\0").unwrap_or_default();
+                                let args: Vec<String> =
+                                    args.split('\0').map(String::from).collect();
+                                cb(app.app_handle(), args, cwd.to_string());
+                            }
+                            Err(e) => {
+                                tracing::debug!("single_instance failed to be notified: {e}")
                             }
                         }
-                        Err(err) => {
-                            tracing::debug!("single_instance failed to be notified: {}", err);
-                            continue;
-                        }
+                    }
+                    Err(err) => {
+                        tracing::debug!("single_instance failed to be notified: {}", err);
+                        continue;
                     }
                 }
-            });
+            },
+            Err(err) => {
+                tracing::error!(
+                    "single_instance failed to listen to other processes - launching normally: {}",
+                    err
+                );
+            }
         }
-        Err(err) => {
-            tracing::error!(
-                "single_instance failed to listen to other processes - launching normally: {}",
-                err
-            );
-        }
-    }
+    });
 }

--- a/plugins/single-instance/src/platform_impl/macos.rs
+++ b/plugins/single-instance/src/platform_impl/macos.rs
@@ -4,7 +4,7 @@
 
 use std::{
     io::{BufWriter, Error, ErrorKind, Write},
-    os::unix::net::UnixStream,
+    os::unix::net::{UnixListener, UnixStream},
     path::PathBuf,
 };
 
@@ -97,9 +97,12 @@ fn listen_for_other_instances<A: Runtime>(
     app: AppHandle<A>,
     mut cb: Box<SingleInstanceCallback<A>>,
 ) {
-    match tokio::net::UnixListener::bind(socket) {
-        Ok(listener) => {
+    match UnixListener::bind(socket) {
+        Ok(std_listener) => {
+            std_listener.set_nonblocking(true).ok();
             tauri::async_runtime::spawn(async move {
+                let listener = tokio::net::UnixListener::from_std(std_listener)
+                    .expect("failed to convert std UnixListener to tokio yielding UnixListener");
                 loop {
                     match listener.accept().await {
                         Ok((mut stream, _addr)) => {

--- a/plugins/single-instance/src/platform_impl/macos.rs
+++ b/plugins/single-instance/src/platform_impl/macos.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MIT
 
 use std::{
-    io::{BufWriter, Error, ErrorKind, Read, Write},
-    os::unix::net::{UnixListener, UnixStream},
+    io::{BufWriter, Error, ErrorKind, Write},
+    os::unix::net::UnixStream,
     path::PathBuf,
 };
 
@@ -15,6 +15,7 @@ use tauri::{
     plugin::{self, TauriPlugin},
     AppHandle, Config, Manager, RunEvent, Runtime,
 };
+use tokio::io::AsyncReadExt;
 
 pub fn init<R: Runtime>(cb: Box<SingleInstanceCallback<R>>) -> TauriPlugin<R> {
     plugin::Builder::new("single-instance")
@@ -96,14 +97,14 @@ fn listen_for_other_instances<A: Runtime>(
     app: AppHandle<A>,
     mut cb: Box<SingleInstanceCallback<A>>,
 ) {
-    match UnixListener::bind(socket) {
+    match tokio::net::UnixListener::bind(socket) {
         Ok(listener) => {
             tauri::async_runtime::spawn(async move {
-                for stream in listener.incoming() {
-                    match stream {
-                        Ok(mut stream) => {
+                loop {
+                    match listener.accept().await {
+                        Ok((mut stream, _addr)) => {
                             let mut s = String::new();
-                            match stream.read_to_string(&mut s) {
+                            match stream.read_to_string(&mut s).await {
                                 Ok(_) => {
                                     let (cwd, args) = s.split_once("\0\0").unwrap_or_default();
                                     let args: Vec<String> =


### PR DESCRIPTION
In the single-instance plugin, the macos implementation spawns a Tauri task that never yields. It uses a [standard UnixListener](https://doc.rust-lang.org/std/os/unix/net/struct.UnixListener.html) that blocks the thread while awaiting for incoming connections.

This PR proposes to use a non blocking `tokio::net::UnixListener` instead, so the task is yielded until the next incoming connection. This time, the thread will be available for other tasks in the runtime.