### PR TITLE
fix(deep-link): skip update-desktop-database when not installed (fix #2265)

### DIFF
--- a/.changes/deep-link-check-update-desktop-database.md
+++ b/.changes/deep-link-check-update-desktop-database.md
@@ -1,0 +1,6 @@
+---
+deep-link: patch
+deep-link-js: patch
+---
+
+On Linux, skip the `update-desktop-database` call during registration when the command is not installed (e.g. some KDE setups without `desktop-file-utils`) instead of failing.

--- a/plugins/deep-link/src/lib.rs
+++ b/plugins/deep-link/src/lib.rs
@@ -348,12 +348,24 @@ mod imp {
                     )?;
                 }
 
-                Command::new("update-desktop-database")
-                    .arg(target)
-                    .status()
-                    .inspect_err(crate::error::inspect_command_error(
-                        "update-desktop-database",
-                    ))?;
+                // `update-desktop-database` is provided by the `desktop-file-utils`
+                // package, which isn't necessarily installed (e.g. some KDE setups
+                // don't need it). Skip it when the command is missing instead of
+                // failing registration; any other error is still logged and
+                // propagated. See #2265.
+                match Command::new("update-desktop-database").arg(target).status() {
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        tracing::warn!(
+                            "`update-desktop-database` not found, skipping desktop database update \
+                             (this is expected on systems without `desktop-file-utils`, e.g. some KDE setups)"
+                        );
+                    }
+                    result => {
+                        result.inspect_err(crate::error::inspect_command_error(
+                            "update-desktop-database",
+                        ))?;
+                    }
+                }
 
                 Command::new("xdg-mime")
                     .args(["default", &file_name, mime_type.as_str()])


### PR DESCRIPTION
Closes #2265

On Linux, `register()` shells out to `update-desktop-database` (from the `desktop-file-utils` package) to refresh the desktop database. That package isn't always installed, e.g. some KDE setups don't need it, so the call fails with `ErrorKind::NotFound` and the whole registration errors out.

This skips the `update-desktop-database` step when the command isn't present (logging a `warn`) and still propagates any other error, matching the existing "binary not found" handling used elsewhere in the workspace (e.g. `single-instance`). No new dependency is added. `xdg-mime` is left as-is since it's genuinely required to set the handler.

This is Linux-only. Built and checked on Debian (in a Rust container that does not have `desktop-file-utils` installed): `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` all pass for `tauri-plugin-deep-link`.

Follow-up (out of scope here): the issue also suggests a KDE fallback (`kbuildsycoca6`/`kbuildsycoca5`) to refresh the cache; happy to do that separately if you'd like it.
