### PR TITLE
patch(log): use kv stable feature rather than unstable

### DIFF
--- a/.changes/log-kv-stable-feature.md
+++ b/.changes/log-kv-stable-feature.md
@@ -3,4 +3,4 @@
 "log-js": patch
 ---
 
-Log plugin is using the `kv_unstable` feature from the `log` crate. That feature was stabilized in [log v0.4.21](https://github.com/rust-lang/log/compare/0.4.20...0.4.21). And this workspace is using [v0.4.27](https://github.com/bajoca05/plugins-workspace/blob/v2/Cargo.lock#L3463), no need to keep using it.
+Migrated from the `log` crate's `kv_unstable` feature flag to the `kv` feature flag stabilized in `0.4.21`.

--- a/.changes/log-kv-stable-feature.md
+++ b/.changes/log-kv-stable-feature.md
@@ -1,0 +1,6 @@
+---
+"log": patch
+"log-js": patch
+---
+
+Log plugin is using the `kv_unstable` feature from the `log` crate. That feature was stabilized in [log v0.4.21](https://github.com/rust-lang/log/compare/0.4.20...0.4.21). And this workspace is using [v0.4.27](https://github.com/bajoca05/plugins-workspace/blob/v2/Cargo.lock#L3463), no need to keep using it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3463,9 +3463,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru-slab"
@@ -7744,12 +7741,6 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "value-bag"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
-log = "0.4"
+log = "0.4.27"
 tauri = { version = "2.10", default-features = false }
 tauri-build = "2.5"
 tauri-plugin = "2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
-log = "0.4.27"
+log = "0.4.21"
 tauri = { version = "2.10", default-features = false }
 tauri-build = "2.5"
 tauri-plugin = "2.5"

--- a/plugins/log/Cargo.toml
+++ b/plugins/log/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tauri = { workspace = true }
 thiserror = { workspace = true }
 serde_repr = "0.1"
-log = { workspace = true, features = ["kv_unstable"] }
+log = { workspace = true, features = ["kv"] }
 time = { version = "0.3", features = [
   "formatting",
   "local-offset",


### PR DESCRIPTION
Log plugin is using the `kv_unstable` feature from the `log` crate. That feature was stabilized in [log v0.4.21](https://github.com/rust-lang/log/compare/0.4.20...0.4.21). And this workspace is using [v0.4.27](https://github.com/bajoca05/plugins-workspace/blob/v2/Cargo.lock#L3463), no need to keep using it.