### PR TITLE
fix(single-instance): close race between mutex creation and event window on Windows

### DIFF
--- a/.changes/single-instance-windows-race.md
+++ b/.changes/single-instance-windows-race.md
@@ -1,0 +1,5 @@
+---
+single-instance: patch
+---
+
+Fix a race on Windows that could let a second app instance run unguarded: the first instance creates the single-instance mutex before its event target window, and a second launch inside that gap saw the mutex but no window and silently continued. The second instance now waits (up to 5 seconds) for either the primary's window to appear (then forwards its args and exits as usual) or for the mutex to be released or abandoned (then it takes over as the primary, which also makes updater-style respawns deterministic instead of timing-dependent).

--- a/plugins/single-instance/src/platform_impl/windows.rs
+++ b/plugins/single-instance/src/platform_impl/windows.rs
@@ -12,11 +12,14 @@ use tauri::{
     AppHandle, Manager, RunEvent, Runtime,
 };
 use windows_sys::Win32::{
-    Foundation::{CloseHandle, GetLastError, ERROR_ALREADY_EXISTS, HWND, LPARAM, LRESULT, WPARAM},
+    Foundation::{
+        CloseHandle, GetLastError, ERROR_ALREADY_EXISTS, HWND, LPARAM, LRESULT, WAIT_ABANDONED,
+        WAIT_OBJECT_0, WAIT_TIMEOUT, WPARAM,
+    },
     System::{
         DataExchange::COPYDATASTRUCT,
         LibraryLoader::GetModuleHandleW,
-        Threading::{CreateMutexW, ReleaseMutex},
+        Threading::{CreateMutexW, ReleaseMutex, WaitForSingleObject},
     },
     UI::WindowsAndMessaging::{
         self as w32wm, CreateWindowExW, DefWindowProcW, DestroyWindow, FindWindowW,
@@ -70,41 +73,75 @@ pub fn init<R: Runtime>(callback: Box<SingleInstanceCallback<R>>) -> TauriPlugin
                 unsafe { CreateMutexW(std::ptr::null(), true.into(), mutex_name.as_ptr()) };
 
             if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
-                unsafe {
-                    let hwnd = FindWindowW(class_name.as_ptr(), window_name.as_ptr());
+                // Another instance holds the mutex, but its event target window may not
+                // exist yet: the first instance creates the mutex before the window, and a
+                // second launch inside that gap used to see the mutex without a window and
+                // silently continue as an unguarded extra instance (the gap is normally
+                // microseconds, but heavy system load stretches it to hundreds of
+                // milliseconds). Poll for the window while waiting on the mutex, so this
+                // process either forwards its args to the primary once the window is up,
+                // or inherits the primary role when the holder releases the mutex or dies
+                // (WAIT_ABANDONED — e.g. an updater respawning the app while the old
+                // process is still exiting).
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+                loop {
+                    unsafe {
+                        let hwnd = FindWindowW(class_name.as_ptr(), window_name.as_ptr());
 
-                    if !hwnd.is_null() {
-                        let cwd = std::env::current_dir().unwrap_or_default();
-                        let cwd = cwd.to_str().unwrap_or_default();
+                        if !hwnd.is_null() {
+                            let cwd = std::env::current_dir().unwrap_or_default();
+                            let cwd = cwd.to_str().unwrap_or_default();
 
-                        let args = std::env::args().collect::<Vec<String>>().join("|");
+                            let args = std::env::args().collect::<Vec<String>>().join("|");
 
-                        let data = format!("{cwd}|{args}\0",);
+                            let data = format!("{cwd}|{args}\0",);
 
-                        let bytes = data.as_bytes();
-                        let cds = COPYDATASTRUCT {
-                            dwData: WMCOPYDATA_SINGLE_INSTANCE_DATA,
-                            cbData: bytes.len() as _,
-                            lpData: bytes.as_ptr() as _,
-                        };
+                            let bytes = data.as_bytes();
+                            let cds = COPYDATASTRUCT {
+                                dwData: WMCOPYDATA_SINGLE_INSTANCE_DATA,
+                                cbData: bytes.len() as _,
+                                lpData: bytes.as_ptr() as _,
+                            };
 
-                        SendMessageW(hwnd, WM_COPYDATA, 0, &cds as *const _ as _);
+                            SendMessageW(hwnd, WM_COPYDATA, 0, &cds as *const _ as _);
 
-                        app.cleanup_before_exit();
-                        std::process::exit(0);
+                            app.cleanup_before_exit();
+                            std::process::exit(0);
+                        }
+                    }
+
+                    if std::time::Instant::now() >= deadline {
+                        // No primary window appeared and nobody released the mutex
+                        // (e.g. the holder is wedged before creating its window).
+                        // Fail open rather than block startup forever.
+                        break;
+                    }
+
+                    match unsafe { WaitForSingleObject(hmutex, 50) } {
+                        // Ownership acquired: the previous holder released the mutex or
+                        // died holding it. Proceed as the primary instance.
+                        WAIT_OBJECT_0 | WAIT_ABANDONED => break,
+                        WAIT_TIMEOUT => {}
+                        // WAIT_FAILED: fail open.
+                        _ => break,
                     }
                 }
-            } else {
-                app.manage(MutexHandle(hmutex as _));
-
-                let userdata = UserData {
-                    app: app.clone(),
-                    callback,
-                };
-                let userdata = Box::into_raw(Box::new(userdata));
-                let hwnd = create_event_target_window::<R>(&class_name, &window_name, userdata);
-                app.manage(TargetWindowHandle(hwnd as _));
             }
+
+            // Reached as the primary instance (mutex created new, or ownership inherited
+            // from a dying holder) or via the fail-open paths above. Register the event
+            // target window in all cases so later launches can forward to this process;
+            // previously a fail-open instance created no window and leaked the mutex
+            // handle silently.
+            app.manage(MutexHandle(hmutex as _));
+
+            let userdata = UserData {
+                app: app.clone(),
+                callback,
+            };
+            let userdata = Box::into_raw(Box::new(userdata));
+            let hwnd = create_event_target_window::<R>(&class_name, &window_name, userdata);
+            app.manage(TargetWindowHandle(hwnd as _));
 
             Ok(())
         })


### PR DESCRIPTION
On Windows, `setup` creates the named mutex first and the event target window later. A second launch that lands in between sees `ERROR_ALREADY_EXISTS`, but `FindWindowW` comes back null, so the check falls through to `Ok(())`. The second process doesn't forward anything or exit; it just keeps running as a normal, unguarded instance. It also never creates a window of its own, and its leaked handle keeps the mutex name alive, so a third launch can slip through the same way even after the first instance is gone.

The gap between the two calls is tiny on an idle machine, but it stretches badly under load. We hit this in a real app: two instances started a few hundred milliseconds apart on a busy machine and both passed the check.

The fix keeps the second instance in the check instead of giving up. When the mutex exists but the window isn't there yet, it polls for the window while waiting on the mutex in 50 ms slices, up to 5 seconds total. If the window shows up (the primary finished its setup), it forwards the args and exits, same as before. If `WaitForSingleObject` returns `WAIT_OBJECT_0` or `WAIT_ABANDONED`, the holder released the mutex or died with it, and this process takes over as the primary; that also helps updaters that respawn the app while the old process is still exiting, which currently only works because the old process usually dies before the new one reaches this check. On timeout or `WAIT_FAILED` it fails open like the current code does, so a wedged process that never made a window can't block the app from starting forever.

The primary path (managing the mutex handle and creating the event window) is now unconditional. A fail-open instance therefore still creates its window, so later launches can forward to it, and the mutex handle is managed instead of leaking silently.

Normal startups are unaffected: a fresh start creates the mutex and proceeds immediately, and a second launch against a healthy primary finds the window on the first probe, before any wait. No public API changes, nothing touched on Linux or macOS.

Tested on Windows with `cargo check -p tauri-plugin-single-instance` and clippy, and the same wait logic exercised in a real app: bursts of simultaneous launches leave exactly one process, a launch during an artificially widened mutex-to-window gap forwards and exits instead of duplicating, and killing the primary while a second instance waits hands the primary role over through `WAIT_ABANDONED`.
