### PR TITLE
fix(store): `StoreOptions.defaults` should not be required

### DIFF
--- a/.changes/store-optional-defaults.md
+++ b/.changes/store-optional-defaults.md
@@ -1,0 +1,6 @@
+---
+store: patch
+store-js: patch
+---
+
+Fix `StoreOptions` requires `defaults` field

--- a/plugins/store/guest-js/index.ts
+++ b/plugins/store/guest-js/index.ts
@@ -21,7 +21,7 @@ export type StoreOptions = {
   /**
    * Default value of the store
    */
-  defaults: { [key: string]: unknown }
+  defaults?: { [key: string]: unknown }
   /**
    * Auto save on modification with debounce duration in milliseconds, it's 100ms by default, pass in `false` to disable it
    */


### PR DESCRIPTION
Fix https://github.com/tauri-apps/tauri-docs/pull/3974, regression from #2857

I didn't notice this until 🤦‍♂️