### PR TITLE
fix(dialog): use parsed MIME type for Android save dialog(#issue 3498)

### DIFF
--- a/plugins/dialog/android/src/main/java/DialogPlugin.kt
+++ b/plugins/dialog/android/src/main/java/DialogPlugin.kt
@@ -204,9 +204,10 @@ class DialogPlugin(private val activity: Activity): Plugin(activity) {
       val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
       intent.addCategory(Intent.CATEGORY_OPENABLE)
       intent.putExtra(Intent.EXTRA_TITLE, args.fileName ?: "")
-      intent.type = parsedTypes.firstOrNull() ?: "*/*"
-
-      if (parsedTypes.isNotEmpty()) {
+      if (parsedTypes.size == 1) {
+        intent.type = parsedTypes.first()
+      } else {
+        intent.type = "*/*"
         intent.putExtra(Intent.EXTRA_MIME_TYPES, parsedTypes)
       }
 

--- a/plugins/dialog/android/src/main/java/DialogPlugin.kt
+++ b/plugins/dialog/android/src/main/java/DialogPlugin.kt
@@ -204,7 +204,7 @@ class DialogPlugin(private val activity: Activity): Plugin(activity) {
       val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
       intent.addCategory(Intent.CATEGORY_OPENABLE)
       intent.putExtra(Intent.EXTRA_TITLE, args.fileName ?: "")
-      intent.type = "*/*"
+      intent.type = parsedTypes.firstOrNull() ?: "*/*"
 
       if (parsedTypes.isNotEmpty()) {
         intent.putExtra(Intent.EXTRA_MIME_TYPES, parsedTypes)


### PR DESCRIPTION
## Summary

This PR updates the Android `saveFileDialog` implementation to use the first parsed MIME type as the `Intent` type instead of always using `*/*`.

```kotlin
intent.type = parsedTypes.firstOrNull() ?: "*/*"
```

If no MIME type can be determined, the existing `*/*` fallback is preserved.

## Motivation

The dialog plugin already parses the selected file filters into MIME types using `parseFiltersOption(args.filters)`, but the parsed MIME types are only passed through `Intent.EXTRA_MIME_TYPES` and are not used as the primary `Intent` type.

Using the first parsed MIME type provides Android with a more specific document type while preserving the current behavior for unknown file types.

## Changes

- Use the first parsed MIME type for `intent.type` when available.
- Preserve the existing `*/*` fallback if no MIME type is available.
- No behavior changes for callers that do not provide file filters.

Closes #3498