### PR TITLE
fix(updater): check `ShellExecuteW` results

### DIFF
--- a/.changes/updater-check-shell-execute-result.md
+++ b/.changes/updater-check-shell-execute-result.md
@@ -1,0 +1,6 @@
+---
+"updater": patch
+"updater-js": patch
+---
+
+On Windows, returns an error if failed to spawn the installer in `install` through `ShellExecuteW`

--- a/plugins/notification/guest-js/index.ts
+++ b/plugins/notification/guest-js/index.ts
@@ -73,7 +73,8 @@ interface Options {
   /**
    * The sound resource name or file path for the notification.
    *
-   * Platform specific behavior:
+   * ## Platform-specific behavior:
+   *
    * - On macOS: use system sounds (e.g., "Ping", "Blow") or sound files in the app bundle
    * - On Linux: use XDG theme sounds (e.g., "message-new-instant") or file paths
    * - On Windows: use file paths to sound files (.wav format)

--- a/plugins/updater/README.md
+++ b/plugins/updater/README.md
@@ -69,6 +69,7 @@ import { relaunch } from '@tauri-apps/plugin-process'
 const update = await check()
 if (update) {
   await update.downloadAndInstall()
+  // Relaunch the app on macOS and Linux to run the newly install version
   await relaunch()
 }
 ```

--- a/plugins/updater/guest-js/index.ts
+++ b/plugins/updater/guest-js/index.ts
@@ -84,7 +84,7 @@ class Update extends Resource {
     this.rawJson = metadata.rawJson
   }
 
-  /** Download the updater package */
+  /** Download the updater package. Call {@linkcode install} later to install it */
   async download(
     onEvent?: (progress: DownloadEvent) => void,
     options?: DownloadOptions
@@ -102,7 +102,14 @@ class Update extends Resource {
     this.downloadedBytes = new Resource(downloadedBytesRid)
   }
 
-  /** Install downloaded updater package */
+  /**
+   * Install downloaded updater package. Must be called after {@linkcode download}.
+   *
+   * ## Platform-specific:
+   *
+   * - **Windows:** This function exits the app after launching the updater installer successfully
+   * - **macOS / Linux:** You need to relaunch the app to run the newly install version
+   */
   async install(options?: InstallOptions): Promise<void> {
     if (!this.downloadedBytes) {
       throw new Error('Update.install called before Update.download')
@@ -118,7 +125,14 @@ class Update extends Resource {
     this.downloadedBytes = undefined
   }
 
-  /** Downloads the updater package and installs it */
+  /**
+   * Downloads the updater package and installs it
+   *
+   * ## Platform-specific:
+   *
+   * - **Windows:** This function exits the app after launching the updater installer successfully
+   * - **macOS / Linux:** You need to relaunch the app to run the newly install version
+   */
   async downloadAndInstall(
     onEvent?: (progress: DownloadEvent) => void,
     options?: DownloadOptions & InstallOptions

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -849,7 +849,7 @@ impl Update {
         let file = encode_wide(file);
         let parameters = encode_wide(parameters);
 
-        unsafe {
+        let result = unsafe {
             ShellExecuteW(
                 std::ptr::null_mut(),
                 w!("open"),
@@ -859,6 +859,9 @@ impl Update {
                 SW_SHOW,
             )
         };
+        if result as isize <= 32 {
+            return Err(crate::Error::Io(std::io::Error::last_os_error()));
+        }
 
         std::process::exit(0);
     }

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -743,11 +743,21 @@ impl Update {
     }
 
     /// Installs the updater package downloaded by [`Update::download`]
+    ///
+    /// ## Platform-specific:
+    ///
+    /// - **Windows:** This function exits the app after launching the updater installer successfully
+    /// - **macOS / Linux:** You need to relaunch the app to run the newly install version
     pub fn install(&self, bytes: impl AsRef<[u8]>) -> Result<()> {
         self.install_inner(bytes.as_ref())
     }
 
     /// Downloads and installs the updater package
+    ///
+    /// ## Platform-specific:
+    ///
+    /// - **Windows:** This function exits the app after launching the updater installer successfully
+    /// - **macOS / Linux:** You need to relaunch the app to run the newly install version
     pub async fn download_and_install<C: FnMut(usize, Option<u64>), D: FnOnce()>(
         &self,
         on_chunk: C,


### PR DESCRIPTION
On Windows, returns an error if failed to spawn the installer in `install` through `ShellExecuteW`, and documented the exit behavior.

Closes #3514
