### PR TITLE
chore: exclude dev-only files from published crates

### DIFF
--- a/plugins/autostart/Cargo.toml
+++ b/plugins/autostart/Cargo.toml
@@ -8,7 +8,13 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-autostart"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/autostart/Cargo.toml
+++ b/plugins/autostart/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-autostart"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/barcode-scanner/Cargo.toml
+++ b/plugins/barcode-scanner/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-barcode-scanner"
-
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 [package.metadata.docs.rs]
 targets = ["x86_64-linux-android"]
 

--- a/plugins/barcode-scanner/Cargo.toml
+++ b/plugins/barcode-scanner/Cargo.toml
@@ -8,7 +8,13 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-barcode-scanner"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 [package.metadata.docs.rs]
 targets = ["x86_64-linux-android"]
 

--- a/plugins/biometric/Cargo.toml
+++ b/plugins/biometric/Cargo.toml
@@ -7,6 +7,7 @@ authors = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-biometric"
+exclude = ["/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-linux-android"]

--- a/plugins/cli/Cargo.toml
+++ b/plugins/cli/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-cli"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/cli/Cargo.toml
+++ b/plugins/cli/Cargo.toml
@@ -8,7 +8,13 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-cli"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/clipboard-manager/Cargo.toml
+++ b/plugins/clipboard-manager/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-clipboard-manager"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.docs.rs]
 

--- a/plugins/clipboard-manager/Cargo.toml
+++ b/plugins/clipboard-manager/Cargo.toml
@@ -8,7 +8,13 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-clipboard-manager"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.docs.rs]
 

--- a/plugins/deep-link/Cargo.toml
+++ b/plugins/deep-link/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-deep-link"
+exclude = ["/banner.png", "/examples", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-linux-android"]

--- a/plugins/deep-link/Cargo.toml
+++ b/plugins/deep-link/Cargo.toml
@@ -8,7 +8,14 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-deep-link"
-exclude = ["/banner.png", "/examples", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/examples",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-linux-android"]

--- a/plugins/dialog/Cargo.toml
+++ b/plugins/dialog/Cargo.toml
@@ -8,7 +8,14 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-dialog"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/test", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/test",
+  "/tsconfig.json",
+]
 
 [features]
 default = ["gtk3"]

--- a/plugins/dialog/Cargo.toml
+++ b/plugins/dialog/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-dialog"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/test", "/tsconfig.json"]
 
 [features]
 default = ["gtk3"]

--- a/plugins/fs/Cargo.toml
+++ b/plugins/fs/Cargo.toml
@@ -8,7 +8,13 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-fs"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "Apps installed via MSI or NSIS in `perMachine` and `both` mode require admin permissions for write access in `$RESOURCES` folder" }

--- a/plugins/fs/Cargo.toml
+++ b/plugins/fs/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-fs"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "Apps installed via MSI or NSIS in `perMachine` and `both` mode require admin permissions for write access in `$RESOURCES` folder" }

--- a/plugins/geolocation/Cargo.toml
+++ b/plugins/geolocation/Cargo.toml
@@ -7,6 +7,7 @@ authors = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-geolocation"
+exclude = ["/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-linux-android"]

--- a/plugins/global-shortcut/Cargo.toml
+++ b/plugins/global-shortcut/Cargo.toml
@@ -8,7 +8,13 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-global-shortcut"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/global-shortcut/Cargo.toml
+++ b/plugins/global-shortcut/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-global-shortcut"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/haptics/Cargo.toml
+++ b/plugins/haptics/Cargo.toml
@@ -7,6 +7,7 @@ authors = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-haptics"
+exclude = ["/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-linux-android"]

--- a/plugins/http/Cargo.toml
+++ b/plugins/http/Cargo.toml
@@ -8,7 +8,13 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-http"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/http/Cargo.toml
+++ b/plugins/http/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-http"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/localhost/Cargo.toml
+++ b/plugins/localhost/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
+exclude = ["/banner.png"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/log/Cargo.toml
+++ b/plugins/log/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-log"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/log/Cargo.toml
+++ b/plugins/log/Cargo.toml
@@ -8,7 +8,13 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-log"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/nfc/Cargo.toml
+++ b/plugins/nfc/Cargo.toml
@@ -7,6 +7,7 @@ authors = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-nfc"
+exclude = ["/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-linux-android"]

--- a/plugins/notification/Cargo.toml
+++ b/plugins/notification/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-notification"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/test", "/tsconfig.json"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-linux-android"]

--- a/plugins/notification/Cargo.toml
+++ b/plugins/notification/Cargo.toml
@@ -8,7 +8,14 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-notification"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/test", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/test",
+  "/tsconfig.json",
+]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-linux-android"]

--- a/plugins/opener/Cargo.toml
+++ b/plugins/opener/Cargo.toml
@@ -11,6 +11,8 @@ links = "tauri-plugin-opener"
 # Platforms supported by the plugin
 # Support levels are "full", "partial", "none", "unknown"
 # Details of the support level are left to plugin maintainer
+exclude = ["/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }
 linux = { level = "full", notes = "" }

--- a/plugins/os/Cargo.toml
+++ b/plugins/os/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-os"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/os/Cargo.toml
+++ b/plugins/os/Cargo.toml
@@ -8,7 +8,13 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-os"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/persisted-scope/Cargo.toml
+++ b/plugins/persisted-scope/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
+exclude = ["/banner.png"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/positioner/Cargo.toml
+++ b/plugins/positioner/Cargo.toml
@@ -8,7 +8,13 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-positioner"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/positioner/Cargo.toml
+++ b/plugins/positioner/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-positioner"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/process/Cargo.toml
+++ b/plugins/process/Cargo.toml
@@ -8,7 +8,13 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-process"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/process/Cargo.toml
+++ b/plugins/process/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-process"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/shell/Cargo.toml
+++ b/plugins/shell/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-shell"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/test", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/shell/Cargo.toml
+++ b/plugins/shell/Cargo.toml
@@ -8,7 +8,14 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-shell"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/test", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/test",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/single-instance/Cargo.toml
+++ b/plugins/single-instance/Cargo.toml
@@ -7,7 +7,7 @@ license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
-exclude = ["/examples"]
+exclude = ["/banner.png", "/examples"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/sql/Cargo.toml
+++ b/plugins/sql/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-sql"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.docs.rs]
 features = ["sqlite"]

--- a/plugins/sql/Cargo.toml
+++ b/plugins/sql/Cargo.toml
@@ -8,7 +8,13 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-sql"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.docs.rs]
 features = ["sqlite"]

--- a/plugins/store/Cargo.toml
+++ b/plugins/store/Cargo.toml
@@ -8,7 +8,14 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-store"
-exclude = ["/banner.png", "/examples", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/examples",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/store/Cargo.toml
+++ b/plugins/store/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-store"
+exclude = ["/banner.png", "/examples", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/stronghold/Cargo.toml
+++ b/plugins/stronghold/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-stronghold"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/stronghold/Cargo.toml
+++ b/plugins/stronghold/Cargo.toml
@@ -8,7 +8,13 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-stronghold"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/updater/Cargo.toml
+++ b/plugins/updater/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-updater"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tests", "/tsconfig.json"]
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/plugins/updater/Cargo.toml
+++ b/plugins/updater/Cargo.toml
@@ -8,7 +8,14 @@ license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-updater"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tests", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tests",
+  "/tsconfig.json",
+]
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/plugins/upload/Cargo.toml
+++ b/plugins/upload/Cargo.toml
@@ -8,7 +8,14 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-upload"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/test", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/test",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/upload/Cargo.toml
+++ b/plugins/upload/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-upload"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/test", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/websocket/Cargo.toml
+++ b/plugins/websocket/Cargo.toml
@@ -8,7 +8,14 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-websocket"
-exclude = ["/banner.png", "/examples", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/examples",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/websocket/Cargo.toml
+++ b/plugins/websocket/Cargo.toml
@@ -8,7 +8,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-websocket"
-exclude = ["/examples"]
+exclude = ["/banner.png", "/examples", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/window-state/Cargo.toml
+++ b/plugins/window-state/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-window-state"
+exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }

--- a/plugins/window-state/Cargo.toml
+++ b/plugins/window-state/Cargo.toml
@@ -8,7 +8,13 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
 links = "tauri-plugin-window-state"
-exclude = ["/banner.png", "/guest-js", "/package.json", "/rollup.config.js", "/tsconfig.json"]
+exclude = [
+  "/banner.png",
+  "/guest-js",
+  "/package.json",
+  "/rollup.config.js",
+  "/tsconfig.json",
+]
 
 [package.metadata.platforms.support]
 windows = { level = "full", notes = "" }


### PR DESCRIPTION
as part of an [e18e](https://e18e.dev) effort to slim down published crates across the Rust ecosystem, this PR adds `exclude` lists to all 30 plugin crates so the published `.crate` files no longer ship dev-only assets: `banner.png`, `guest-js/` TypeScript sources, JS tooling configs (`package.json`, `rollup.config.js`, `tsconfig.json`), and `test`/`tests`/`examples` directories where present. 

**why `exclude` instead of an `include` allowlist (e.g. `cargo diet`):** these crates ship non-obvious files that are load-bearing at *downstream* build time and every plugin's `build.rs` references `android/`, `ios/`, `api-iife.js`, and `permissions/`, and `build.rs` runs when a consumer's app compiles the published crate.

**Total: 2.78 MB → 1.50 MB (−46%)** across all crates.

| Crate | Before | After | Saved |
|---|---:|---:|---:|
| tauri-plugin-clipboard-manager | 118.9 KB | 49.0 KB | −58.8% |
| tauri-plugin-global-shortcut | 105.9 KB | 41.1 KB | −61.2% |
| tauri-plugin-notification | 139.2 KB | 75.1 KB | −46.0% |
| tauri-plugin-dialog | 126.5 KB | 65.3 KB | −48.4% |
| tauri-plugin-fs | 141.2 KB | 80.5 KB | −43.0% |
| tauri-plugin-process | 96.1 KB | 35.8 KB | −62.7% |
| tauri-plugin-updater | 122.2 KB | 62.9 KB | −48.5% |
| tauri-plugin-os | 97.0 KB | 39.1 KB | −59.7% |
| tauri-plugin-shell | 115.8 KB | 58.5 KB | −49.5% |
| tauri-plugin-cli | 98.7 KB | 41.6 KB | −57.9% |
| tauri-plugin-http | 108.7 KB | 53.4 KB | −50.9% |
| tauri-plugin-barcode-scanner | 112.6 KB | 62.3 KB | −44.6% |
| tauri-plugin-deep-link | 111.1 KB | 61.2 KB | −44.9% |
| tauri-plugin-store | 98.3 KB | 49.3 KB | −49.9% |
| tauri-plugin-persisted-scope | 82.8 KB | 36.4 KB | −56.1% |
| tauri-plugin-single-instance | 90.3 KB | 44.0 KB | −51.3% |
| tauri-plugin-window-state | 91.6 KB | 45.6 KB | −50.2% |
| tauri-plugin-stronghold | 96.1 KB | 50.2 KB | −47.8% |
| tauri-plugin-autostart | 83.1 KB | 38.0 KB | −54.3% |
| tauri-plugin-positioner | 85.4 KB | 40.9 KB | −52.1% |
| tauri-plugin-localhost | 79.0 KB | 34.9 KB | −55.8% |
| tauri-plugin-upload | 87.0 KB | 44.3 KB | −49.1% |
| tauri-plugin-sql | 91.4 KB | 49.5 KB | −45.9% |
| tauri-plugin-websocket | 83.5 KB | 42.0 KB | −49.7% |
| tauri-plugin-log | 90.2 KB | 49.0 KB | −45.7% |
| tauri-plugin-nfc | 59.5 KB | 57.5 KB | −3.5% |
| tauri-plugin-opener | 56.3 KB | 54.6 KB | −3.1% |
| tauri-plugin-haptics | 59.7 KB | 58.3 KB | −2.3% |
| tauri-plugin-geolocation | 63.7 KB | 62.5 KB | −2.0% |
| tauri-plugin-biometric | 54.7 KB | 53.9 KB | −1.6% |

>[!NOTE] 
>Sizes are compressed `.crate` tarballs from `cargo package`.