### PR TITLE
feat(clipboard-manager): add readImagePNG to read clipboard image as PNG bytes

### DIFF
--- a/.changes/clipboard-read-image-png.md
+++ b/.changes/clipboard-read-image-png.md
@@ -1,0 +1,6 @@
+---
+"clipboard-manager": minor:feat
+"clipboard-manager-js": minor:feat
+---
+
+Added `readImagePNG` to read the clipboard image as PNG-encoded bytes instead of a raw decoded RGBA buffer, which is significantly smaller to transfer for large images (e.g. UHD screenshots).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6496,6 +6496,7 @@ name = "tauri-plugin-clipboard-manager"
 version = "2.3.2"
 dependencies = [
  "arboard",
+ "image",
  "log",
  "serde",
  "serde_json",

--- a/plugins/clipboard-manager/Cargo.toml
+++ b/plugins/clipboard-manager/Cargo.toml
@@ -43,3 +43,4 @@ tauri = { workspace = true, features = ["wry"] }
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 arboard = { version = "3", features = ["wayland-data-control"] }
+image = { version = "0.25", default-features = false, features = ["png"] }

--- a/plugins/clipboard-manager/build.rs
+++ b/plugins/clipboard-manager/build.rs
@@ -7,6 +7,7 @@ const COMMANDS: &[&str] = &[
     "read_text",
     "write_image",
     "read_image",
+    "read_image_png",
     "write_html",
     "clear",
 ];

--- a/plugins/clipboard-manager/guest-js/index.ts
+++ b/plugins/clipboard-manager/guest-js/index.ts
@@ -103,6 +103,33 @@ async function readImage(): Promise<Image> {
 }
 
 /**
+ * Gets the clipboard content as a PNG-encoded byte array, instead of the raw
+ * decoded RGBA buffer `readImage` returns. Useful when you just need to
+ * transfer or persist the image, since a PNG is typically far smaller than
+ * the equivalent uncompressed bitmap.
+ *
+ * #### Platform-specific
+ *
+ * - **Android / iOS:** Not supported.
+ *
+ * @example
+ * ```typescript
+ * import { readImagePNG } from '@tauri-apps/plugin-clipboard-manager';
+ *
+ * const pngBytes = await readImagePNG();
+ * const blob = new Blob([pngBytes], { type: 'image/png' })
+ * const url = URL.createObjectURL(blob)
+ * ```
+ * @since 2.4.0
+ */
+async function readImagePNG(): Promise<Uint8Array> {
+  const arr = await invoke<ArrayBuffer | number[]>(
+    'plugin:clipboard-manager|read_image_png'
+  )
+  return arr instanceof ArrayBuffer ? new Uint8Array(arr) : Uint8Array.from(arr)
+}
+
+/**
  * * Writes HTML or fallbacks to write provided plain text to the clipboard.
  *
  * #### Platform-specific
@@ -148,4 +175,12 @@ async function clear(): Promise<void> {
   await invoke('plugin:clipboard-manager|clear')
 }
 
-export { writeText, readText, writeHtml, clear, readImage, writeImage }
+export {
+  writeText,
+  readText,
+  writeHtml,
+  clear,
+  readImage,
+  readImagePNG,
+  writeImage
+}

--- a/plugins/clipboard-manager/permissions/autogenerated/commands/read_image_png.toml
+++ b/plugins/clipboard-manager/permissions/autogenerated/commands/read_image_png.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-read-image-png"
+description = "Enables the read_image_png command without any pre-configured scope."
+commands.allow = ["read_image_png"]
+
+[[permission]]
+identifier = "deny-read-image-png"
+description = "Denies the read_image_png command without any pre-configured scope."
+commands.deny = ["read_image_png"]

--- a/plugins/clipboard-manager/permissions/autogenerated/reference.md
+++ b/plugins/clipboard-manager/permissions/autogenerated/reference.md
@@ -70,6 +70,32 @@ Denies the read_image command without any pre-configured scope.
 <tr>
 <td>
 
+`clipboard-manager:allow-read-image-png`
+
+</td>
+<td>
+
+Enables the read_image_png command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`clipboard-manager:deny-read-image-png`
+
+</td>
+<td>
+
+Denies the read_image_png command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `clipboard-manager:allow-read-text`
 
 </td>

--- a/plugins/clipboard-manager/permissions/schemas/schema.json
+++ b/plugins/clipboard-manager/permissions/schemas/schema.json
@@ -319,6 +319,18 @@
           "markdownDescription": "Denies the read_image command without any pre-configured scope."
         },
         {
+          "description": "Enables the read_image_png command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-read-image-png",
+          "markdownDescription": "Enables the read_image_png command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the read_image_png command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-read-image-png",
+          "markdownDescription": "Denies the read_image_png command without any pre-configured scope."
+        },
+        {
           "description": "Enables the read_text command without any pre-configured scope.",
           "type": "string",
           "const": "allow-read-text",

--- a/plugins/clipboard-manager/src/commands.rs
+++ b/plugins/clipboard-manager/src/commands.rs
@@ -62,6 +62,14 @@ pub(crate) async fn read_image<R: Runtime>(
 }
 
 #[command]
+pub(crate) async fn read_image_png<R: Runtime>(
+    _app: AppHandle<R>,
+    clipboard: State<'_, Clipboard<R>>,
+) -> Result<tauri::ipc::Response> {
+    clipboard.read_image_png().map(tauri::ipc::Response::new)
+}
+
+#[command]
 pub(crate) async fn write_html<R: Runtime>(
     _app: AppHandle<R>,
     clipboard: State<'_, Clipboard<R>>,

--- a/plugins/clipboard-manager/src/desktop.rs
+++ b/plugins/clipboard-manager/src/desktop.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 use arboard::ImageData;
+use image::ImageEncoder;
 use serde::de::DeserializeOwned;
 use tauri::{image::Image, plugin::PluginApi, AppHandle, Runtime};
 
@@ -110,6 +111,28 @@ impl<R: Runtime> Clipboard<R> {
                     image.height as u32,
                 );
                 Ok(image)
+            }
+            Err(e) => Err(crate::Error::Clipboard(e.to_string())),
+        }
+    }
+
+    /// Warning: This method should not be used on the main thread! Otherwise the underlying libraries may deadlock on Linux, freezing the whole app, when trying to copy data copied from this app, for example if the user copies text from the WebView.
+    pub fn read_image_png(&self) -> crate::Result<Vec<u8>> {
+        match &self.clipboard {
+            Ok(clipboard) => {
+                let image = clipboard.lock().unwrap().as_mut().unwrap().get_image()?;
+
+                let mut png_bytes = Vec::new();
+                image::codecs::png::PngEncoder::new(&mut png_bytes)
+                    .write_image(
+                        &image.bytes,
+                        image.width as u32,
+                        image.height as u32,
+                        image::ExtendedColorType::Rgba8,
+                    )
+                    .map_err(|e| crate::Error::Clipboard(e.to_string()))?;
+
+                Ok(png_bytes)
             }
             Err(e) => Err(crate::Error::Clipboard(e.to_string())),
         }

--- a/plugins/clipboard-manager/src/lib.rs
+++ b/plugins/clipboard-manager/src/lib.rs
@@ -47,6 +47,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::write_text,
             commands::read_text,
             commands::read_image,
+            commands::read_image_png,
             commands::write_image,
             commands::write_html,
             commands::clear

--- a/plugins/clipboard-manager/src/mobile.rs
+++ b/plugins/clipboard-manager/src/mobile.rs
@@ -80,6 +80,12 @@ impl<R: Runtime> Clipboard<R> {
         ))
     }
 
+    pub fn read_image_png(&self) -> crate::Result<Vec<u8>> {
+        Err(crate::Error::Clipboard(
+            "Unsupported on this platform".to_string(),
+        ))
+    }
+
     // Treat HTML as unsupported on mobile until tested
     pub fn write_html<'a, T: Into<Cow<'a, str>>>(
         &self,


### PR DESCRIPTION
## Problem

`readImage()` returns the full uncompressed RGBA buffer — over 100MB for a UHD screenshot — which is slow to transfer over IPC (#2225).

## Fix

Added `readImagePNG()`, which PNG-encodes the same clipboard image (via the `image` crate, `default-features = false, features = ["png"]` to keep the dependency light) before returning it, so large screenshots transfer as a fraction of the size.

- `desktop.rs`: `Clipboard::read_image_png()` — same arboard `get_image()` call as `read_image()`, PNG-encodes the result.
- `mobile.rs`: matching `"Unsupported on this platform"` stub, same as every other image method on mobile.
- `commands.rs` / `lib.rs` / `build.rs`: new `read_image_png` command, registered and wired through `tauri::ipc::Response` (matches the `fs` plugin's `readFile` pattern for binary transfer, rather than JSON-serializing a `Vec<u8>`).
- `guest-js/index.ts`: `readImagePNG(): Promise<Uint8Array>`, handling both the `ArrayBuffer` and `number[]` IPC shapes like `readFile` does.
- Added a changeset (`minor:feat` for both `clipboard-manager` and `clipboard-manager-js`).

I did look at the PNG-handling code linked in the issue (from before #1986 removed it) — that version was actually buggy: it made `read_image` *always* return PNG bytes mislabeled as raw RGBA (see #1985/#1986), which is why it got reverted rather than kept. This PR adds PNG support back as a genuinely separate method instead of reintroducing that bug.

## Testing

- `cargo check` / `cargo clippy -p tauri-plugin-clipboard-manager --all-targets`: clean, no warnings.
- `tsc --noEmit` on the plugin package and `eslint` on the changed file: clean.
- Verified the actual encode path end-to-end against a real OS clipboard (not just compiled): wrote a synthetic RGBA image via `arboard`, ran it through the same `PngEncoder` call `read_image_png` uses, decoded the resulting PNG back with `image::load_from_memory`, and confirmed the pixels are byte-identical to the original buffer.

Per the AI tool policy in CONTRIBUTING.md: I used AI assistance to write this, but reviewed and tested everything above myself before opening the PR — happy to answer questions or make changes in review.