### PR TITLE
feat(http): add transport extension hooks

### DIFF
--- a/.changes/http-transport-extensions.md
+++ b/.changes/http-transport-extensions.md
@@ -1,0 +1,6 @@
+---
+"http": minor
+"http-js": minor
+---
+
+Add native transport extension hooks for request validation, final `reqwest::ClientBuilder` configuration, setup, and structured transport error mapping.

--- a/plugins/http/README.md
+++ b/plugins/http/README.md
@@ -66,6 +66,45 @@ const response = await fetch('http://localhost:3003/users/2', {
 })
 ```
 
+## Native transport extensions
+
+Trusted native code can extend the request transport while preserving the
+existing JavaScript API. Extensions can validate request metadata, configure
+the final `reqwest::ClientBuilder`, and map transport failures to structured
+errors:
+
+```rust
+use tauri_plugin_http::{
+    ExtensionError, HttpTransportExtension, RequestContext,
+};
+
+struct CustomTransport;
+
+impl<R: tauri::Runtime> HttpTransportExtension<R> for CustomTransport {
+    fn configure(
+        &self,
+        builder: reqwest::ClientBuilder,
+        _request: &RequestContext,
+    ) -> Result<reqwest::ClientBuilder, ExtensionError> {
+        Ok(builder.https_only(true))
+    }
+}
+
+fn main() {
+    tauri::Builder::default()
+        .plugin(
+            tauri_plugin_http::Builder::new()
+                .extension(CustomTransport)
+                .build(),
+        )
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+```
+
+Extensions run in registration order and are trusted to replace transport
+settings. Request bodies are not exposed through `RequestContext`.
+
 ## Contributing
 
 PRs accepted. Please make sure to read the Contributing Guide before making a pull request.

--- a/plugins/http/src/commands.rs
+++ b/plugins/http/src/commands.rs
@@ -17,7 +17,7 @@ use tokio::sync::oneshot::{channel, Receiver, Sender};
 
 use crate::{
     scope::{Entry, Scope},
-    Error, Http, Result,
+    Error, Http, RequestContext, Result,
 };
 
 const HTTP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
@@ -177,7 +177,7 @@ fn attach_proxy(
 #[command]
 pub async fn fetch<R: Runtime>(
     webview: Webview<R>,
-    state: State<'_, Http>,
+    state: State<'_, Http<R>>,
     client_config: ClientConfig,
     command_scope: CommandScope<Entry>,
     global_scope: GlobalScope<Entry>,
@@ -228,6 +228,33 @@ pub async fn fetch<R: Runtime>(
             )
             .is_allowed(&url)
             {
+                let extensions = state.extensions.clone();
+                let connect_timeout = connect_timeout.map(Duration::from_millis);
+                let (danger_accept_invalid_certs, danger_accept_invalid_hostnames) = danger
+                    .as_ref()
+                    .map(|settings| {
+                        (
+                            settings.accept_invalid_certs,
+                            settings.accept_invalid_hostnames,
+                        )
+                    })
+                    .unwrap_or_default();
+                let request_context = RequestContext::new(
+                    method.clone(),
+                    url.clone(),
+                    headers.clone(),
+                    data.is_some(),
+                    connect_timeout,
+                    max_redirections,
+                    proxy.is_some(),
+                    danger_accept_invalid_certs,
+                    danger_accept_invalid_hostnames,
+                );
+
+                for extension in extensions.iter() {
+                    extension.validate(&request_context)?;
+                }
+
                 let mut builder = reqwest::ClientBuilder::new();
 
                 if let Some(danger_config) = danger {
@@ -249,7 +276,7 @@ pub async fn fetch<R: Runtime>(
                 }
 
                 if let Some(timeout) = connect_timeout {
-                    builder = builder.connect_timeout(Duration::from_millis(timeout));
+                    builder = builder.connect_timeout(timeout);
                 }
 
                 if let Some(max_redirections) = max_redirections {
@@ -267,6 +294,10 @@ pub async fn fetch<R: Runtime>(
                 #[cfg(feature = "cookies")]
                 {
                     builder = builder.cookie_provider(state.cookies_jar.clone());
+                }
+
+                for extension in extensions.iter() {
+                    builder = extension.configure(builder, &request_context)?;
                 }
 
                 let mut request = builder.build()?.request(method.clone(), url);
@@ -317,7 +348,17 @@ pub async fn fetch<R: Runtime>(
                 #[cfg(feature = "tracing")]
                 tracing::trace!("{:?}", request);
 
-                let fut = async move { request.send().await.map_err(Into::into) };
+                let fut = async move {
+                    request.send().await.map_err(|error| {
+                        extensions
+                            .iter()
+                            .find_map(|extension| {
+                                extension.map_transport_error(&error, &request_context)
+                            })
+                            .map(Error::from)
+                            .unwrap_or_else(|| Error::from(error))
+                    })
+                };
 
                 let mut resources_table = webview.resources_table();
                 let rid = resources_table.add_request(Box::pin(fut));

--- a/plugins/http/src/error.rs
+++ b/plugins/http/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     #[error(transparent)]
     Network(#[from] reqwest::Error),
     #[error(transparent)]
+    Extension(#[from] crate::ExtensionError),
+    #[error(transparent)]
     Http(#[from] http::Error),
     #[error(transparent)]
     HttpInvalidHeaderName(#[from] http::header::InvalidHeaderName),
@@ -50,8 +52,41 @@ impl Serialize for Error {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_string().as_ref())
+        match self {
+            Self::Extension(error) => error.value().serialize(serializer),
+            _ => serializer.serialize_str(self.to_string().as_ref()),
+        }
     }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extension_errors_keep_their_json_shape() {
+        let error = Error::Extension(crate::ExtensionError::from_value(serde_json::json!({
+            "code": "POLICY_REJECTED",
+            "host": "example.test"
+        })));
+
+        assert_eq!(
+            serde_json::to_value(error).unwrap(),
+            serde_json::json!({
+                "code": "POLICY_REJECTED",
+                "host": "example.test"
+            })
+        );
+    }
+
+    #[test]
+    fn existing_errors_remain_strings() {
+        let error = Error::RequestCanceled;
+        assert_eq!(
+            serde_json::to_value(error).unwrap(),
+            serde_json::Value::String("Request canceled".into())
+        );
+    }
+}

--- a/plugins/http/src/extension.rs
+++ b/plugins/http/src/extension.rs
@@ -1,0 +1,208 @@
+// Copyright 2019-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use std::{fmt, sync::Arc, time::Duration};
+
+use http::{HeaderMap, Method};
+use serde::Serialize;
+use tauri::{AppHandle, Runtime};
+use url::Url;
+
+/// A transport extension invoked for every scoped HTTP(S) request.
+///
+/// Extensions are trusted native components registered with [`crate::Builder`].
+/// They can validate request metadata before a client is built, configure the
+/// final [`reqwest::ClientBuilder`], and classify transport errors without
+/// changing the JavaScript API.
+pub trait HttpTransportExtension<R: Runtime>: Send + Sync + 'static {
+    /// Initializes the extension when the plugin is set up.
+    fn setup(&self, _app: &AppHandle<R>) -> Result<(), ExtensionError> {
+        Ok(())
+    }
+
+    /// Validates a request before any network client is built.
+    fn validate(&self, _request: &RequestContext) -> Result<(), ExtensionError> {
+        Ok(())
+    }
+
+    /// Configures the final request client after the plugin has applied its
+    /// timeout, redirect, proxy, cookie, and feature-gated TLS settings.
+    fn configure(
+        &self,
+        builder: reqwest::ClientBuilder,
+        _request: &RequestContext,
+    ) -> Result<reqwest::ClientBuilder, ExtensionError> {
+        Ok(builder)
+    }
+
+    /// Maps an already-failed transport error to an extension-owned error.
+    ///
+    /// Returning `None` preserves the original [`reqwest::Error`].
+    fn map_transport_error(
+        &self,
+        _error: &reqwest::Error,
+        _request: &RequestContext,
+    ) -> Option<ExtensionError> {
+        None
+    }
+}
+
+/// An extension-owned error value forwarded through the plugin IPC boundary.
+///
+/// The HTTP plugin treats the JSON value as opaque. This lets extensions keep
+/// their own stable error contracts without adding extension-specific variants
+/// to the plugin's error enum.
+#[derive(Debug, Clone)]
+pub struct ExtensionError(serde_json::Value);
+
+impl ExtensionError {
+    /// Creates an extension error from any serializable value.
+    pub fn new(value: impl Serialize) -> Result<Self, serde_json::Error> {
+        serde_json::to_value(value).map(Self)
+    }
+
+    /// Creates an extension error from an existing JSON value.
+    pub fn from_value(value: serde_json::Value) -> Self {
+        Self(value)
+    }
+
+    /// Returns the opaque JSON value supplied by the extension.
+    pub fn value(&self) -> &serde_json::Value {
+        &self.0
+    }
+}
+
+impl fmt::Display for ExtensionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0.to_string())
+    }
+}
+
+impl std::error::Error for ExtensionError {}
+
+/// Immutable request metadata exposed to transport extensions.
+///
+/// The request body is never exposed. Extensions only receive whether a body
+/// exists, along with the URL, method, filtered headers, and client options.
+#[derive(Debug, Clone)]
+pub struct RequestContext {
+    method: Method,
+    url: Url,
+    headers: HeaderMap,
+    has_body: bool,
+    connect_timeout: Option<Duration>,
+    max_redirections: Option<usize>,
+    proxy_requested: bool,
+    danger_accept_invalid_certs: bool,
+    danger_accept_invalid_hostnames: bool,
+}
+
+impl RequestContext {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        method: Method,
+        url: Url,
+        headers: HeaderMap,
+        has_body: bool,
+        connect_timeout: Option<Duration>,
+        max_redirections: Option<usize>,
+        proxy_requested: bool,
+        danger_accept_invalid_certs: bool,
+        danger_accept_invalid_hostnames: bool,
+    ) -> Self {
+        Self {
+            method,
+            url,
+            headers,
+            has_body,
+            connect_timeout,
+            max_redirections,
+            proxy_requested,
+            danger_accept_invalid_certs,
+            danger_accept_invalid_hostnames,
+        }
+    }
+
+    pub fn method(&self) -> &Method {
+        &self.method
+    }
+
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    pub fn has_body(&self) -> bool {
+        self.has_body
+    }
+
+    pub fn connect_timeout(&self) -> Option<Duration> {
+        self.connect_timeout
+    }
+
+    pub fn max_redirections(&self) -> Option<usize> {
+        self.max_redirections
+    }
+
+    pub fn proxy_requested(&self) -> bool {
+        self.proxy_requested
+    }
+
+    pub fn danger_accept_invalid_certs(&self) -> bool {
+        self.danger_accept_invalid_certs
+    }
+
+    pub fn danger_accept_invalid_hostnames(&self) -> bool {
+        self.danger_accept_invalid_hostnames
+    }
+}
+
+pub(crate) type ExtensionList<R> = Arc<Vec<Arc<dyn HttpTransportExtension<R>>>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extension_error_preserves_structured_json() {
+        let error = ExtensionError::new(serde_json::json!({
+            "code": "POLICY_REJECTED",
+            "host": "example.test"
+        }))
+        .unwrap();
+
+        assert_eq!(
+            error.to_string(),
+            r#"{"code":"POLICY_REJECTED","host":"example.test"}"#
+        );
+        assert_eq!(error.value()["code"], "POLICY_REJECTED");
+    }
+
+    #[test]
+    fn request_context_exposes_owned_request_metadata() {
+        let context = RequestContext::new(
+            Method::POST,
+            Url::parse("https://example.test/path").unwrap(),
+            HeaderMap::new(),
+            true,
+            Some(Duration::from_secs(2)),
+            Some(3),
+            true,
+            false,
+            false,
+        );
+
+        assert_eq!(context.method(), Method::POST);
+        assert_eq!(context.url().host_str(), Some("example.test"));
+        assert!(context.has_body());
+        assert_eq!(context.connect_timeout(), Some(Duration::from_secs(2)));
+        assert_eq!(context.max_redirections(), Some(3));
+        assert!(context.proxy_requested());
+        assert!(!context.danger_accept_invalid_certs());
+        assert!(!context.danger_accept_invalid_hostnames());
+    }
+}

--- a/plugins/http/src/lib.rs
+++ b/plugins/http/src/lib.rs
@@ -29,7 +29,7 @@
 //! - **brotli**: Provides response body brotli decompression.
 //! - **zstd**: Provides response body zstd decompression.
 //! - **deflate**: Provides response body deflate decompression.
-//! - **json**: Provides serialization and deserialization for JSON bodies.
+//! - **json**: Provides serialization and deserialization of JSON bodies.
 //! - **multipart**: Provides functionality for multipart forms.
 //! - **stream**: Adds support for futures::Stream.
 //! - **socks**: Provides SOCKS5 proxy support.
@@ -45,15 +45,20 @@
 //! - **dangerous-settings**: Allows dangerous client settings such as accepting invalid certificates or hostnames.
 
 pub use reqwest;
+
+use std::sync::Arc;
+
 use tauri::{
-    plugin::{Builder, TauriPlugin},
+    plugin::{Builder as PluginBuilder, TauriPlugin},
     Manager, Runtime,
 };
 
 pub use error::{Error, Result};
+pub use extension::{ExtensionError, HttpTransportExtension, RequestContext};
 
 mod commands;
 mod error;
+mod extension;
 #[cfg(feature = "cookies")]
 mod reqwest_cookie_store;
 mod scope;
@@ -61,71 +66,120 @@ mod scope;
 #[cfg(feature = "cookies")]
 const COOKIES_FILENAME: &str = ".cookies";
 
-pub(crate) struct Http {
+pub(crate) struct Http<R: Runtime> {
+    extensions: extension::ExtensionList<R>,
     #[cfg(feature = "cookies")]
-    cookies_jar: std::sync::Arc<crate::reqwest_cookie_store::CookieStoreMutex>,
+    cookies_jar: Arc<crate::reqwest_cookie_store::CookieStoreMutex>,
 }
 
-pub fn init<R: Runtime>() -> TauriPlugin<R> {
-    Builder::<R>::new("http")
-        .setup(|app, _| {
-            #[cfg(feature = "cookies")]
-            let cookies_jar = {
-                use crate::reqwest_cookie_store::*;
-                use std::fs::File;
-                use std::io::BufReader;
+/// Builds the HTTP plugin with optional native transport extensions.
+pub struct Builder<R: Runtime> {
+    extensions: Vec<Arc<dyn HttpTransportExtension<R>>>,
+}
 
-                let cache_dir = app.path().app_cache_dir()?;
-                std::fs::create_dir_all(&cache_dir)?;
+impl<R: Runtime> Default for Builder<R> {
+    fn default() -> Self {
+        Self {
+            extensions: Vec::new(),
+        }
+    }
+}
 
-                let path = cache_dir.join(COOKIES_FILENAME);
-                let file = File::options()
-                    .create(true)
-                    .append(true)
-                    .read(true)
-                    .open(&path)?;
+impl<R: Runtime> Builder<R> {
+    /// Creates an HTTP plugin builder without transport extensions.
+    pub fn new() -> Self {
+        Self::default()
+    }
 
-                let reader = BufReader::new(file);
-                CookieStoreMutex::load(path.clone(), reader).unwrap_or_else(|_e| {
-                    #[cfg(feature = "tracing")]
-                    tracing::warn!(
-                        "failed to load cookie store: {_e}, falling back to empty store"
-                    );
-                    CookieStoreMutex::new(path, Default::default())
-                })
-            };
+    /// Registers a native transport extension.
+    ///
+    /// Extensions run in registration order. Only trusted native code should
+    /// be registered because extensions can replace the request transport.
+    pub fn extension(mut self, extension: impl HttpTransportExtension<R>) -> Self {
+        self.extensions.push(Arc::new(extension));
+        self
+    }
 
-            let state = Http {
+    /// Registers a shared native transport extension.
+    pub fn extension_arc(mut self, extension: Arc<dyn HttpTransportExtension<R>>) -> Self {
+        self.extensions.push(extension);
+        self
+    }
+
+    /// Builds the HTTP plugin.
+    pub fn build(self) -> TauriPlugin<R> {
+        let extensions = Arc::new(self.extensions);
+
+        PluginBuilder::<R>::new("http")
+            .setup(|app, _| {
                 #[cfg(feature = "cookies")]
-                cookies_jar: std::sync::Arc::new(cookies_jar),
-            };
+                let cookies_jar = {
+                    use crate::reqwest_cookie_store::*;
+                    use std::fs::File;
+                    use std::io::BufReader;
 
-            app.manage(state);
+                    let cache_dir = app.path().app_cache_dir()?;
+                    std::fs::create_dir_all(&cache_dir)?;
 
-            Ok(())
-        })
-        .on_event(|app, event| {
-            #[cfg(feature = "cookies")]
-            if let tauri::RunEvent::Exit = event {
-                let state = app.state::<Http>();
+                    let path = cache_dir.join(COOKIES_FILENAME);
+                    let file = File::options()
+                        .create(true)
+                        .append(true)
+                        .read(true)
+                        .open(&path)?;
 
-                match state.cookies_jar.request_save() {
-                    Ok(rx) => {
-                        let _ = rx.recv();
-                    }
-                    Err(_e) => {
+                    let reader = BufReader::new(file);
+                    CookieStoreMutex::load(path.clone(), reader).unwrap_or_else(|_e| {
                         #[cfg(feature = "tracing")]
-                        tracing::error!("failed to save cookie jar: {_e}");
+                        tracing::warn!(
+                            "failed to load cookie store: {_e}, falling back to empty store"
+                        );
+                        CookieStoreMutex::new(path, Default::default())
+                    })
+                };
+
+                for extension in extensions.iter() {
+                    extension.setup(app)?;
+                }
+
+                let state = Http {
+                    extensions,
+                    #[cfg(feature = "cookies")]
+                    cookies_jar: Arc::new(cookies_jar),
+                };
+
+                app.manage(state);
+
+                Ok(())
+            })
+            .on_event(|_app, _event| {
+                #[cfg(feature = "cookies")]
+                if let tauri::RunEvent::Exit = _event {
+                    let state = _app.state::<Http<R>>();
+
+                    match state.cookies_jar.request_save() {
+                        Ok(rx) => {
+                            let _ = rx.recv();
+                        }
+                        Err(_e) => {
+                            #[cfg(feature = "tracing")]
+                            tracing::error!("failed to save cookie jar: {_e}");
+                        }
                     }
                 }
-            }
-        })
-        .invoke_handler(tauri::generate_handler![
-            commands::fetch,
-            commands::fetch_cancel,
-            commands::fetch_send,
-            commands::fetch_read_body,
-            commands::fetch_cancel_body,
-        ])
-        .build()
+            })
+            .invoke_handler(tauri::generate_handler![
+                commands::fetch,
+                commands::fetch_cancel,
+                commands::fetch_send,
+                commands::fetch_read_body,
+                commands::fetch_cancel_body,
+            ])
+            .build()
+    }
+}
+
+/// Creates the HTTP plugin with the default transport behavior.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new().build()
 }


### PR DESCRIPTION
## Motivation

`tauri-plugin-http` currently creates an internal `reqwest::ClientBuilder` for every request without exposing a native customization point. Applications that need transport-level policies or custom TLS backends must therefore replace the fetch-compatible plugin surface with custom commands.

This change adds trusted native transport extensions while preserving the existing JavaScript API and default `init()` behavior.

## Design

- `tauri_plugin_http::Builder<R>` registers extensions in deterministic order.
- `HttpTransportExtension<R>` exposes fallible setup, request validation, final `reqwest::ClientBuilder` configuration, and transport-error mapping.
- `RequestContext` provides owned request metadata without exposing request bodies.
- `ExtensionError` forwards extension-owned structured JSON through IPC while existing plugin errors remain strings.
- Stock timeout, redirect, proxy, cookie, and feature-gated TLS settings are applied before transport extensions configure the final client.

This provides a general foundation for native transport concerns such as custom TLS verification, mTLS, request policy enforcement, and transport diagnostics. SPKI pinning from #3414 can be implemented as a separate extension on top of this API.


Follow-up implementation: #3539.
