### PR TITLE
feat(http): add SPKI pinning extension (fix #3414)

### DIFF
--- a/.changes/http-spki-pinning.md
+++ b/.changes/http-spki-pinning.md
@@ -1,0 +1,6 @@
+---
+"http": minor
+"http-js": minor
+---
+
+Add an optional native Rustls SPKI pinning transport extension with exact-host pin sets, backup pins for key rotation, normal WebPKI validation, and fail-closed redirect coverage.

--- a/.changes/http-transport-extensions.md
+++ b/.changes/http-transport-extensions.md
@@ -1,0 +1,6 @@
+---
+"http": minor
+"http-js": minor
+---
+
+Add native transport extension hooks for request validation, final `reqwest::ClientBuilder` configuration, setup, and structured transport error mapping.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1478,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -3759,6 +3812,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4098,6 +4161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4310,6 +4382,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -4807,6 +4889,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "read-progress-stream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5155,6 +5250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -6606,15 +6710,19 @@ dependencies = [
 name = "tauri-plugin-http"
 version = "2.5.9"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "cookie_store",
  "data-url",
  "http",
+ "rcgen",
  "regex",
  "reqwest 0.12.28",
+ "rustls",
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
@@ -6623,6 +6731,8 @@ dependencies = [
  "tracing",
  "url",
  "urlpattern",
+ "webpki-roots 1.0.6",
+ "x509-parser",
 ]
 
 [[package]]
@@ -8847,6 +8957,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8861,6 +8988,15 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/plugins/http/Cargo.toml
+++ b/plugins/http/Cargo.toml
@@ -47,7 +47,15 @@ url = { workspace = true }
 data-url = "0.3"
 cookie_store = { version = "0.22", optional = true, features = ["serde"] }
 bytes = { version = "1.9", optional = true }
+base64 = { version = "0.22", optional = true }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"], optional = true }
+sha2 = { version = "0.10", optional = true }
+webpki-roots = { version = "1", optional = true }
+x509-parser = { version = "0.18", optional = true }
 tracing = { workspace = true, optional = true }
+
+[dev-dependencies]
+rcgen = "0.13.2"
 
 [features]
 default = ["rustls-tls", "http2", "charset", "system-proxy", "cookies"]
@@ -74,6 +82,14 @@ charset = ["reqwest/charset"]
 # Deprecated, switch to system-proxy
 macos-system-configuration = ["reqwest/macos-system-configuration"]
 system-proxy = ["reqwest/system-proxy"]
+spki-pinning = [
+  "reqwest/rustls-tls-manual-roots",
+  "dep:base64",
+  "dep:rustls",
+  "dep:sha2",
+  "dep:webpki-roots",
+  "dep:x509-parser",
+]
 
 unsafe-headers = []
 tracing = ["dep:tracing"]

--- a/plugins/http/README.md
+++ b/plugins/http/README.md
@@ -105,6 +105,39 @@ fn main() {
 Extensions run in registration order and are trusted to replace transport
 settings. Request bodies are not exposed through `RequestContext`.
 
+### SPKI pinning
+
+Enable the `spki-pinning` Cargo feature to configure exact-host leaf public-key
+pins entirely in native Rust:
+
+```toml
+[dependencies]
+tauri-plugin-http = { version = "2", features = ["spki-pinning"] }
+```
+
+```rust
+let pinning = tauri_plugin_http::SpkiPinning::new()
+    .pin(
+        "api.example.com",
+        "sha256/BASE64_ENCODED_SHA256_OF_SUBJECT_PUBLIC_KEY_INFO",
+    )?
+    .pin("api.example.com", "sha256/BACKUP_PIN_FOR_KEY_ROTATION")?;
+
+tauri::Builder::default()
+    .plugin(
+        tauri_plugin_http::Builder::new()
+            .extension(pinning)
+            .build(),
+    );
+```
+
+Normal WebPKI chain and hostname validation runs before the leaf SPKI digest is
+checked. By default every HTTPS host, including redirect targets, requires
+configured pins. `allow_unpinned_hosts()` explicitly keeps normal WebPKI
+validation for hosts without pins. The client is HTTPS-only by default so
+redirects cannot downgrade to plain HTTP; `allow_http()` is an explicit native
+opt-in. Dangerous certificate and hostname settings are rejected.
+
 ## Contributing
 
 PRs accepted. Please make sure to read the Contributing Guide before making a pull request.

--- a/plugins/http/README.md
+++ b/plugins/http/README.md
@@ -66,6 +66,45 @@ const response = await fetch('http://localhost:3003/users/2', {
 })
 ```
 
+## Native transport extensions
+
+Trusted native code can extend the request transport while preserving the
+existing JavaScript API. Extensions can validate request metadata, configure
+the final `reqwest::ClientBuilder`, and map transport failures to structured
+errors:
+
+```rust
+use tauri_plugin_http::{
+    ExtensionError, HttpTransportExtension, RequestContext,
+};
+
+struct CustomTransport;
+
+impl<R: tauri::Runtime> HttpTransportExtension<R> for CustomTransport {
+    fn configure(
+        &self,
+        builder: reqwest::ClientBuilder,
+        _request: &RequestContext,
+    ) -> Result<reqwest::ClientBuilder, ExtensionError> {
+        Ok(builder.https_only(true))
+    }
+}
+
+fn main() {
+    tauri::Builder::default()
+        .plugin(
+            tauri_plugin_http::Builder::new()
+                .extension(CustomTransport)
+                .build(),
+        )
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+```
+
+Extensions run in registration order and are trusted to replace transport
+settings. Request bodies are not exposed through `RequestContext`.
+
 ## Contributing
 
 PRs accepted. Please make sure to read the Contributing Guide before making a pull request.

--- a/plugins/http/src/commands.rs
+++ b/plugins/http/src/commands.rs
@@ -17,7 +17,7 @@ use tokio::sync::oneshot::{channel, Receiver, Sender};
 
 use crate::{
     scope::{Entry, Scope},
-    Error, Http, Result,
+    Error, Http, RequestContext, Result,
 };
 
 const HTTP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
@@ -177,7 +177,7 @@ fn attach_proxy(
 #[command]
 pub async fn fetch<R: Runtime>(
     webview: Webview<R>,
-    state: State<'_, Http>,
+    state: State<'_, Http<R>>,
     client_config: ClientConfig,
     command_scope: CommandScope<Entry>,
     global_scope: GlobalScope<Entry>,
@@ -228,6 +228,33 @@ pub async fn fetch<R: Runtime>(
             )
             .is_allowed(&url)
             {
+                let extensions = state.extensions.clone();
+                let connect_timeout = connect_timeout.map(Duration::from_millis);
+                let (danger_accept_invalid_certs, danger_accept_invalid_hostnames) = danger
+                    .as_ref()
+                    .map(|settings| {
+                        (
+                            settings.accept_invalid_certs,
+                            settings.accept_invalid_hostnames,
+                        )
+                    })
+                    .unwrap_or_default();
+                let request_context = RequestContext::new(
+                    method.clone(),
+                    url.clone(),
+                    headers.clone(),
+                    data.is_some(),
+                    connect_timeout,
+                    max_redirections,
+                    proxy.is_some(),
+                    danger_accept_invalid_certs,
+                    danger_accept_invalid_hostnames,
+                );
+
+                for extension in extensions.iter() {
+                    extension.validate(&request_context)?;
+                }
+
                 let mut builder = reqwest::ClientBuilder::new();
 
                 if let Some(danger_config) = danger {
@@ -249,7 +276,7 @@ pub async fn fetch<R: Runtime>(
                 }
 
                 if let Some(timeout) = connect_timeout {
-                    builder = builder.connect_timeout(Duration::from_millis(timeout));
+                    builder = builder.connect_timeout(timeout);
                 }
 
                 if let Some(max_redirections) = max_redirections {
@@ -267,6 +294,10 @@ pub async fn fetch<R: Runtime>(
                 #[cfg(feature = "cookies")]
                 {
                     builder = builder.cookie_provider(state.cookies_jar.clone());
+                }
+
+                for extension in extensions.iter() {
+                    builder = extension.configure(builder, &request_context)?;
                 }
 
                 let mut request = builder.build()?.request(method.clone(), url);
@@ -317,7 +348,17 @@ pub async fn fetch<R: Runtime>(
                 #[cfg(feature = "tracing")]
                 tracing::trace!("{:?}", request);
 
-                let fut = async move { request.send().await.map_err(Into::into) };
+                let fut = async move {
+                    request.send().await.map_err(|error| {
+                        extensions
+                            .iter()
+                            .find_map(|extension| {
+                                extension.map_transport_error(&error, &request_context)
+                            })
+                            .map(Error::from)
+                            .unwrap_or_else(|| Error::from(error))
+                    })
+                };
 
                 let mut resources_table = webview.resources_table();
                 let rid = resources_table.add_request(Box::pin(fut));

--- a/plugins/http/src/error.rs
+++ b/plugins/http/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     #[error(transparent)]
     Network(#[from] reqwest::Error),
     #[error(transparent)]
+    Extension(#[from] crate::ExtensionError),
+    #[error(transparent)]
     Http(#[from] http::Error),
     #[error(transparent)]
     HttpInvalidHeaderName(#[from] http::header::InvalidHeaderName),
@@ -50,8 +52,41 @@ impl Serialize for Error {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_string().as_ref())
+        match self {
+            Self::Extension(error) => error.value().serialize(serializer),
+            _ => serializer.serialize_str(self.to_string().as_ref()),
+        }
     }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extension_errors_keep_their_json_shape() {
+        let error = Error::Extension(crate::ExtensionError::from_value(serde_json::json!({
+            "code": "POLICY_REJECTED",
+            "host": "example.test"
+        })));
+
+        assert_eq!(
+            serde_json::to_value(error).unwrap(),
+            serde_json::json!({
+                "code": "POLICY_REJECTED",
+                "host": "example.test"
+            })
+        );
+    }
+
+    #[test]
+    fn existing_errors_remain_strings() {
+        let error = Error::RequestCanceled;
+        assert_eq!(
+            serde_json::to_value(error).unwrap(),
+            serde_json::Value::String("Request canceled".into())
+        );
+    }
+}

--- a/plugins/http/src/extension.rs
+++ b/plugins/http/src/extension.rs
@@ -1,0 +1,208 @@
+// Copyright 2019-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use std::{fmt, sync::Arc, time::Duration};
+
+use http::{HeaderMap, Method};
+use serde::Serialize;
+use tauri::{AppHandle, Runtime};
+use url::Url;
+
+/// A transport extension invoked for every scoped HTTP(S) request.
+///
+/// Extensions are trusted native components registered with [`crate::Builder`].
+/// They can validate request metadata before a client is built, configure the
+/// final [`reqwest::ClientBuilder`], and classify transport errors without
+/// changing the JavaScript API.
+pub trait HttpTransportExtension<R: Runtime>: Send + Sync + 'static {
+    /// Initializes the extension when the plugin is set up.
+    fn setup(&self, _app: &AppHandle<R>) -> Result<(), ExtensionError> {
+        Ok(())
+    }
+
+    /// Validates a request before any network client is built.
+    fn validate(&self, _request: &RequestContext) -> Result<(), ExtensionError> {
+        Ok(())
+    }
+
+    /// Configures the final request client after the plugin has applied its
+    /// timeout, redirect, proxy, cookie, and feature-gated TLS settings.
+    fn configure(
+        &self,
+        builder: reqwest::ClientBuilder,
+        _request: &RequestContext,
+    ) -> Result<reqwest::ClientBuilder, ExtensionError> {
+        Ok(builder)
+    }
+
+    /// Maps an already-failed transport error to an extension-owned error.
+    ///
+    /// Returning `None` preserves the original [`reqwest::Error`].
+    fn map_transport_error(
+        &self,
+        _error: &reqwest::Error,
+        _request: &RequestContext,
+    ) -> Option<ExtensionError> {
+        None
+    }
+}
+
+/// An extension-owned error value forwarded through the plugin IPC boundary.
+///
+/// The HTTP plugin treats the JSON value as opaque. This lets extensions keep
+/// their own stable error contracts without adding extension-specific variants
+/// to the plugin's error enum.
+#[derive(Debug, Clone)]
+pub struct ExtensionError(serde_json::Value);
+
+impl ExtensionError {
+    /// Creates an extension error from any serializable value.
+    pub fn new(value: impl Serialize) -> Result<Self, serde_json::Error> {
+        serde_json::to_value(value).map(Self)
+    }
+
+    /// Creates an extension error from an existing JSON value.
+    pub fn from_value(value: serde_json::Value) -> Self {
+        Self(value)
+    }
+
+    /// Returns the opaque JSON value supplied by the extension.
+    pub fn value(&self) -> &serde_json::Value {
+        &self.0
+    }
+}
+
+impl fmt::Display for ExtensionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0.to_string())
+    }
+}
+
+impl std::error::Error for ExtensionError {}
+
+/// Immutable request metadata exposed to transport extensions.
+///
+/// The request body is never exposed. Extensions only receive whether a body
+/// exists, along with the URL, method, filtered headers, and client options.
+#[derive(Debug, Clone)]
+pub struct RequestContext {
+    method: Method,
+    url: Url,
+    headers: HeaderMap,
+    has_body: bool,
+    connect_timeout: Option<Duration>,
+    max_redirections: Option<usize>,
+    proxy_requested: bool,
+    danger_accept_invalid_certs: bool,
+    danger_accept_invalid_hostnames: bool,
+}
+
+impl RequestContext {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        method: Method,
+        url: Url,
+        headers: HeaderMap,
+        has_body: bool,
+        connect_timeout: Option<Duration>,
+        max_redirections: Option<usize>,
+        proxy_requested: bool,
+        danger_accept_invalid_certs: bool,
+        danger_accept_invalid_hostnames: bool,
+    ) -> Self {
+        Self {
+            method,
+            url,
+            headers,
+            has_body,
+            connect_timeout,
+            max_redirections,
+            proxy_requested,
+            danger_accept_invalid_certs,
+            danger_accept_invalid_hostnames,
+        }
+    }
+
+    pub fn method(&self) -> &Method {
+        &self.method
+    }
+
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    pub fn has_body(&self) -> bool {
+        self.has_body
+    }
+
+    pub fn connect_timeout(&self) -> Option<Duration> {
+        self.connect_timeout
+    }
+
+    pub fn max_redirections(&self) -> Option<usize> {
+        self.max_redirections
+    }
+
+    pub fn proxy_requested(&self) -> bool {
+        self.proxy_requested
+    }
+
+    pub fn danger_accept_invalid_certs(&self) -> bool {
+        self.danger_accept_invalid_certs
+    }
+
+    pub fn danger_accept_invalid_hostnames(&self) -> bool {
+        self.danger_accept_invalid_hostnames
+    }
+}
+
+pub(crate) type ExtensionList<R> = Arc<Vec<Arc<dyn HttpTransportExtension<R>>>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extension_error_preserves_structured_json() {
+        let error = ExtensionError::new(serde_json::json!({
+            "code": "POLICY_REJECTED",
+            "host": "example.test"
+        }))
+        .unwrap();
+
+        assert_eq!(
+            error.to_string(),
+            r#"{"code":"POLICY_REJECTED","host":"example.test"}"#
+        );
+        assert_eq!(error.value()["code"], "POLICY_REJECTED");
+    }
+
+    #[test]
+    fn request_context_exposes_owned_request_metadata() {
+        let context = RequestContext::new(
+            Method::POST,
+            Url::parse("https://example.test/path").unwrap(),
+            HeaderMap::new(),
+            true,
+            Some(Duration::from_secs(2)),
+            Some(3),
+            true,
+            false,
+            false,
+        );
+
+        assert_eq!(context.method(), Method::POST);
+        assert_eq!(context.url().host_str(), Some("example.test"));
+        assert!(context.has_body());
+        assert_eq!(context.connect_timeout(), Some(Duration::from_secs(2)));
+        assert_eq!(context.max_redirections(), Some(3));
+        assert!(context.proxy_requested());
+        assert!(!context.danger_accept_invalid_certs());
+        assert!(!context.danger_accept_invalid_hostnames());
+    }
+}

--- a/plugins/http/src/lib.rs
+++ b/plugins/http/src/lib.rs
@@ -29,7 +29,7 @@
 //! - **brotli**: Provides response body brotli decompression.
 //! - **zstd**: Provides response body zstd decompression.
 //! - **deflate**: Provides response body deflate decompression.
-//! - **json**: Provides serialization and deserialization for JSON bodies.
+//! - **json**: Provides serialization and deserialization of JSON bodies.
 //! - **multipart**: Provides functionality for multipart forms.
 //! - **stream**: Adds support for futures::Stream.
 //! - **socks**: Provides SOCKS5 proxy support.
@@ -45,15 +45,20 @@
 //! - **dangerous-settings**: Allows dangerous client settings such as accepting invalid certificates or hostnames.
 
 pub use reqwest;
+
+use std::sync::Arc;
+
 use tauri::{
-    plugin::{Builder, TauriPlugin},
+    plugin::{Builder as PluginBuilder, TauriPlugin},
     Manager, Runtime,
 };
 
 pub use error::{Error, Result};
+pub use extension::{ExtensionError, HttpTransportExtension, RequestContext};
 
 mod commands;
 mod error;
+mod extension;
 #[cfg(feature = "cookies")]
 mod reqwest_cookie_store;
 mod scope;
@@ -61,71 +66,120 @@ mod scope;
 #[cfg(feature = "cookies")]
 const COOKIES_FILENAME: &str = ".cookies";
 
-pub(crate) struct Http {
+pub(crate) struct Http<R: Runtime> {
+    extensions: extension::ExtensionList<R>,
     #[cfg(feature = "cookies")]
-    cookies_jar: std::sync::Arc<crate::reqwest_cookie_store::CookieStoreMutex>,
+    cookies_jar: Arc<crate::reqwest_cookie_store::CookieStoreMutex>,
 }
 
-pub fn init<R: Runtime>() -> TauriPlugin<R> {
-    Builder::<R>::new("http")
-        .setup(|app, _| {
-            #[cfg(feature = "cookies")]
-            let cookies_jar = {
-                use crate::reqwest_cookie_store::*;
-                use std::fs::File;
-                use std::io::BufReader;
+/// Builds the HTTP plugin with optional native transport extensions.
+pub struct Builder<R: Runtime> {
+    extensions: Vec<Arc<dyn HttpTransportExtension<R>>>,
+}
 
-                let cache_dir = app.path().app_cache_dir()?;
-                std::fs::create_dir_all(&cache_dir)?;
+impl<R: Runtime> Default for Builder<R> {
+    fn default() -> Self {
+        Self {
+            extensions: Vec::new(),
+        }
+    }
+}
 
-                let path = cache_dir.join(COOKIES_FILENAME);
-                let file = File::options()
-                    .create(true)
-                    .append(true)
-                    .read(true)
-                    .open(&path)?;
+impl<R: Runtime> Builder<R> {
+    /// Creates an HTTP plugin builder without transport extensions.
+    pub fn new() -> Self {
+        Self::default()
+    }
 
-                let reader = BufReader::new(file);
-                CookieStoreMutex::load(path.clone(), reader).unwrap_or_else(|_e| {
-                    #[cfg(feature = "tracing")]
-                    tracing::warn!(
-                        "failed to load cookie store: {_e}, falling back to empty store"
-                    );
-                    CookieStoreMutex::new(path, Default::default())
-                })
-            };
+    /// Registers a native transport extension.
+    ///
+    /// Extensions run in registration order. Only trusted native code should
+    /// be registered because extensions can replace the request transport.
+    pub fn extension(mut self, extension: impl HttpTransportExtension<R>) -> Self {
+        self.extensions.push(Arc::new(extension));
+        self
+    }
 
-            let state = Http {
+    /// Registers a shared native transport extension.
+    pub fn extension_arc(mut self, extension: Arc<dyn HttpTransportExtension<R>>) -> Self {
+        self.extensions.push(extension);
+        self
+    }
+
+    /// Builds the HTTP plugin.
+    pub fn build(self) -> TauriPlugin<R> {
+        let extensions = Arc::new(self.extensions);
+
+        PluginBuilder::<R>::new("http")
+            .setup(|app, _| {
                 #[cfg(feature = "cookies")]
-                cookies_jar: std::sync::Arc::new(cookies_jar),
-            };
+                let cookies_jar = {
+                    use crate::reqwest_cookie_store::*;
+                    use std::fs::File;
+                    use std::io::BufReader;
 
-            app.manage(state);
+                    let cache_dir = app.path().app_cache_dir()?;
+                    std::fs::create_dir_all(&cache_dir)?;
 
-            Ok(())
-        })
-        .on_event(|app, event| {
-            #[cfg(feature = "cookies")]
-            if let tauri::RunEvent::Exit = event {
-                let state = app.state::<Http>();
+                    let path = cache_dir.join(COOKIES_FILENAME);
+                    let file = File::options()
+                        .create(true)
+                        .append(true)
+                        .read(true)
+                        .open(&path)?;
 
-                match state.cookies_jar.request_save() {
-                    Ok(rx) => {
-                        let _ = rx.recv();
-                    }
-                    Err(_e) => {
+                    let reader = BufReader::new(file);
+                    CookieStoreMutex::load(path.clone(), reader).unwrap_or_else(|_e| {
                         #[cfg(feature = "tracing")]
-                        tracing::error!("failed to save cookie jar: {_e}");
+                        tracing::warn!(
+                            "failed to load cookie store: {_e}, falling back to empty store"
+                        );
+                        CookieStoreMutex::new(path, Default::default())
+                    })
+                };
+
+                for extension in extensions.iter() {
+                    extension.setup(app)?;
+                }
+
+                let state = Http {
+                    extensions,
+                    #[cfg(feature = "cookies")]
+                    cookies_jar: Arc::new(cookies_jar),
+                };
+
+                app.manage(state);
+
+                Ok(())
+            })
+            .on_event(|_app, _event| {
+                #[cfg(feature = "cookies")]
+                if let tauri::RunEvent::Exit = _event {
+                    let state = _app.state::<Http<R>>();
+
+                    match state.cookies_jar.request_save() {
+                        Ok(rx) => {
+                            let _ = rx.recv();
+                        }
+                        Err(_e) => {
+                            #[cfg(feature = "tracing")]
+                            tracing::error!("failed to save cookie jar: {_e}");
+                        }
                     }
                 }
-            }
-        })
-        .invoke_handler(tauri::generate_handler![
-            commands::fetch,
-            commands::fetch_cancel,
-            commands::fetch_send,
-            commands::fetch_read_body,
-            commands::fetch_cancel_body,
-        ])
-        .build()
+            })
+            .invoke_handler(tauri::generate_handler![
+                commands::fetch,
+                commands::fetch_cancel,
+                commands::fetch_send,
+                commands::fetch_read_body,
+                commands::fetch_cancel_body,
+            ])
+            .build()
+    }
+}
+
+/// Creates the HTTP plugin with the default transport behavior.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new().build()
 }

--- a/plugins/http/src/lib.rs
+++ b/plugins/http/src/lib.rs
@@ -43,6 +43,7 @@
 //! - **tracing**: Adds request, response, and cookie-store diagnostics through `tracing`.
 //! - **unsafe-headers**: Allows webview requests to send any headers.
 //! - **dangerous-settings**: Allows dangerous client settings such as accepting invalid certificates or hostnames.
+//! - **spki-pinning**: Adds the native [`SpkiPinning`] transport extension for exact-host leaf SPKI pinning with Rustls.
 
 pub use reqwest;
 
@@ -62,6 +63,11 @@ mod extension;
 #[cfg(feature = "cookies")]
 mod reqwest_cookie_store;
 mod scope;
+#[cfg(feature = "spki-pinning")]
+mod spki_pinning;
+
+#[cfg(feature = "spki-pinning")]
+pub use spki_pinning::{SpkiPinError, SpkiPinning};
 
 #[cfg(feature = "cookies")]
 const COOKIES_FILENAME: &str = ".cookies";

--- a/plugins/http/src/spki_pinning.rs
+++ b/plugins/http/src/spki_pinning.rs
@@ -1,0 +1,478 @@
+// Copyright 2019-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use crate::{ExtensionError, HttpTransportExtension, RequestContext};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use rustls::{
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    pki_types::{CertificateDer, ServerName, UnixTime},
+    DigitallySignedStruct, Error as RustlsError, RootCertStore, SignatureScheme,
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+const ERROR_CODE_PIN_MISMATCH: &str = "SPKI_PIN_MISMATCH";
+const ERROR_CODE_HOST_NOT_PINNED: &str = "SPKI_HOST_NOT_PINNED";
+const ERROR_CODE_HTTP_NOT_ALLOWED: &str = "SPKI_HTTP_NOT_ALLOWED";
+const ERROR_CODE_DANGEROUS_SETTINGS: &str = "SPKI_DANGEROUS_SETTINGS";
+const ERROR_CODE_INITIALIZATION: &str = "SPKI_INITIALIZATION_FAILED";
+const RUSTLS_PIN_MISMATCH_MARKER: &str = "TAURI_HTTP_SPKI_PIN_MISMATCH:";
+const RUSTLS_HOST_NOT_PINNED_MARKER: &str = "TAURI_HTTP_SPKI_HOST_NOT_PINNED:";
+
+/// Native SPKI pinning transport extension.
+///
+/// Normal WebPKI chain and hostname validation runs before the leaf
+/// certificate's SubjectPublicKeyInfo SHA-256 digest is compared with the
+/// pins configured for the request host.
+#[derive(Debug, Clone)]
+pub struct SpkiPinning {
+    pins: Arc<HashMap<String, HashSet<[u8; 32]>>>,
+    require_pins_for_all_hosts: bool,
+    allow_http: bool,
+}
+
+impl SpkiPinning {
+    /// Creates a fail-closed pinning extension.
+    ///
+    /// By default every HTTPS request, including redirect targets, must have at
+    /// least one configured pin. Use [`allow_unpinned_hosts`](Self::allow_unpinned_hosts)
+    /// to keep normal WebPKI validation for hosts without pins.
+    pub fn new() -> Self {
+        Self {
+            pins: Arc::new(HashMap::new()),
+            require_pins_for_all_hosts: true,
+            allow_http: false,
+        }
+    }
+
+    /// Adds one `sha256/<base64>` SPKI pin for an exact DNS hostname.
+    ///
+    /// Register at least two pins per host before rotating a server key.
+    pub fn pin(
+        mut self,
+        host: impl AsRef<str>,
+        pin: impl AsRef<str>,
+    ) -> Result<Self, SpkiPinError> {
+        let host = normalize_host(host.as_ref())?;
+        let pin = parse_pin(pin.as_ref())?;
+        Arc::make_mut(&mut self.pins)
+            .entry(host)
+            .or_default()
+            .insert(pin);
+        Ok(self)
+    }
+
+    /// Allows hosts without configured pins to use normal WebPKI validation.
+    pub fn allow_unpinned_hosts(mut self) -> Self {
+        self.require_pins_for_all_hosts = false;
+        self
+    }
+
+    /// Allows plain HTTP requests and HTTPS-to-HTTP redirects.
+    ///
+    /// The default is HTTPS-only so a pinned request cannot silently leave the
+    /// TLS transport through a redirect.
+    pub fn allow_http(mut self) -> Self {
+        self.allow_http = true;
+        self
+    }
+}
+
+impl Default for SpkiPinning {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<R: tauri::Runtime> HttpTransportExtension<R> for SpkiPinning {
+    fn validate(&self, request: &RequestContext) -> Result<(), ExtensionError> {
+        if request.danger_accept_invalid_certs() || request.danger_accept_invalid_hostnames() {
+            return Err(extension_error(PinningFailure::new(
+                ERROR_CODE_DANGEROUS_SETTINGS,
+                "dangerous TLS settings cannot be combined with SPKI pinning",
+                request.url().host_str(),
+            )));
+        }
+
+        if request.url().scheme() != "https" {
+            return if self.allow_http {
+                Ok(())
+            } else {
+                Err(extension_error(PinningFailure::new(
+                    ERROR_CODE_HTTP_NOT_ALLOWED,
+                    "SPKI pinning is HTTPS-only unless plain HTTP is explicitly enabled",
+                    request.url().host_str(),
+                )))
+            };
+        }
+
+        if self.require_pins_for_all_hosts {
+            let host = request.url().host_str().unwrap_or_default();
+            if !self.pins.contains_key(host) {
+                return Err(extension_error(PinningFailure::new(
+                    ERROR_CODE_HOST_NOT_PINNED,
+                    "no SPKI pins are configured for the request host",
+                    Some(host),
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn configure(
+        &self,
+        builder: reqwest::ClientBuilder,
+        _request: &RequestContext,
+    ) -> Result<reqwest::ClientBuilder, ExtensionError> {
+        let tls = build_tls_config(self.pins.clone(), self.require_pins_for_all_hosts).map_err(
+            |message| {
+                extension_error(PinningFailure::new(
+                    ERROR_CODE_INITIALIZATION,
+                    message,
+                    None,
+                ))
+            },
+        )?;
+        Ok(builder
+            .https_only(!self.allow_http)
+            .use_preconfigured_tls(tls))
+    }
+
+    fn map_transport_error(
+        &self,
+        error: &reqwest::Error,
+        _request: &RequestContext,
+    ) -> Option<ExtensionError> {
+        if let Some(host) = error_chain_marker_value(error, RUSTLS_PIN_MISMATCH_MARKER) {
+            return Some(extension_error(PinningFailure::new(
+                ERROR_CODE_PIN_MISMATCH,
+                "the server certificate public key does not match a configured SPKI pin",
+                Some(&host),
+            )));
+        }
+        if let Some(host) = error_chain_marker_value(error, RUSTLS_HOST_NOT_PINNED_MARKER) {
+            return Some(extension_error(PinningFailure::new(
+                ERROR_CODE_HOST_NOT_PINNED,
+                "no SPKI pins are configured for the request host",
+                Some(&host),
+            )));
+        }
+        None
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SpkiPinError {
+    #[error("SPKI pin host must be a non-empty exact DNS hostname")]
+    InvalidHost,
+    #[error("SPKI pin must use the sha256/<base64> format")]
+    InvalidFormat,
+    #[error("SPKI pin must decode to exactly 32 bytes")]
+    InvalidLength,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PinningFailure<'a> {
+    code: &'static str,
+    message: String,
+    host: Option<&'a str>,
+}
+
+impl<'a> PinningFailure<'a> {
+    fn new(code: &'static str, message: impl Into<String>, host: Option<&'a str>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            host,
+        }
+    }
+}
+
+fn extension_error(error: PinningFailure<'_>) -> ExtensionError {
+    ExtensionError::new(error).expect("SPKI pinning errors must serialize")
+}
+
+fn normalize_host(host: &str) -> Result<String, SpkiPinError> {
+    let host = host.trim().trim_end_matches('.');
+    if host.is_empty() || host.contains('*') {
+        return Err(SpkiPinError::InvalidHost);
+    }
+    match url::Host::parse(host).map_err(|_| SpkiPinError::InvalidHost)? {
+        url::Host::Domain(host) if !host.is_empty() => Ok(host.to_ascii_lowercase()),
+        url::Host::Ipv4(_) | url::Host::Ipv6(_) | url::Host::Domain(_) => {
+            Err(SpkiPinError::InvalidHost)
+        }
+    }
+}
+
+fn parse_pin(pin: &str) -> Result<[u8; 32], SpkiPinError> {
+    let encoded = pin
+        .strip_prefix("sha256/")
+        .ok_or(SpkiPinError::InvalidFormat)?;
+    let decoded = STANDARD
+        .decode(encoded)
+        .map_err(|_| SpkiPinError::InvalidFormat)?;
+    decoded.try_into().map_err(|_| SpkiPinError::InvalidLength)
+}
+
+fn error_chain_marker_value(error: &reqwest::Error, marker: &str) -> Option<String> {
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(error);
+    while let Some(current) = source {
+        let message = current.to_string();
+        if let Some((_, value)) = message.split_once(marker) {
+            return value.split_whitespace().next().map(ToOwned::to_owned);
+        }
+        source = current.source();
+    }
+    None
+}
+
+#[derive(Debug)]
+struct PinnedServerCertVerifier {
+    web_pki: Arc<rustls::client::WebPkiServerVerifier>,
+    pins: Arc<HashMap<String, HashSet<[u8; 32]>>>,
+    require_pins_for_all_hosts: bool,
+}
+
+impl ServerCertVerifier for PinnedServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        self.web_pki.verify_server_cert(
+            end_entity,
+            intermediates,
+            server_name,
+            ocsp_response,
+            now,
+        )?;
+
+        let host = server_name
+            .to_str()
+            .trim_end_matches('.')
+            .to_ascii_lowercase();
+        let Some(pins) = self.pins.get(&host) else {
+            return if self.require_pins_for_all_hosts {
+                Err(RustlsError::General(format!(
+                    "{RUSTLS_HOST_NOT_PINNED_MARKER}{host}"
+                )))
+            } else {
+                Ok(ServerCertVerified::assertion())
+            };
+        };
+
+        let (_, certificate) = x509_parser::parse_x509_certificate(end_entity.as_ref())
+            .map_err(|_| RustlsError::General("failed to parse certificate SPKI".into()))?;
+        let digest: [u8; 32] = Sha256::digest(certificate.public_key().raw).into();
+        if pins.contains(&digest) {
+            Ok(ServerCertVerified::assertion())
+        } else {
+            Err(RustlsError::General(format!(
+                "{RUSTLS_PIN_MISMATCH_MARKER}{host}"
+            )))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        self.web_pki.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        self.web_pki.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.web_pki.supported_verify_schemes()
+    }
+}
+
+fn build_tls_config(
+    pins: Arc<HashMap<String, HashSet<[u8; 32]>>>,
+    require_pins_for_all_hosts: bool,
+) -> Result<rustls::ClientConfig, String> {
+    let roots = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    };
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let web_pki = rustls::client::WebPkiServerVerifier::builder_with_provider(
+        Arc::new(roots),
+        provider.clone(),
+    )
+    .build()
+    .map_err(|error| error.to_string())?;
+    let verifier = Arc::new(PinnedServerCertVerifier {
+        web_pki,
+        pins,
+        require_pins_for_all_hosts,
+    });
+
+    rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|error| error.to_string())
+        .map(|builder| {
+            builder
+                .dangerous()
+                .with_custom_certificate_verifier(verifier)
+                .with_no_client_auth()
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair, KeyUsagePurpose};
+
+    const EXAMPLE_PIN: &str = "sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+    fn test_verifier(
+        pins: HashMap<String, HashSet<[u8; 32]>>,
+    ) -> (PinnedServerCertVerifier, CertificateDer<'static>, [u8; 32]) {
+        let ca_key = KeyPair::generate().unwrap();
+        let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![
+            KeyUsagePurpose::KeyCertSign,
+            KeyUsagePurpose::DigitalSignature,
+        ];
+        let ca = ca_params.self_signed(&ca_key).unwrap();
+
+        let leaf_key = KeyPair::generate().unwrap();
+        let leaf = CertificateParams::new(vec![
+            "api.example.test".into(),
+            "redirect.example.test".into(),
+        ])
+        .unwrap()
+        .signed_by(&leaf_key, &ca, &ca_key)
+        .unwrap();
+        let leaf = leaf.der().clone();
+        let (_, parsed) = x509_parser::parse_x509_certificate(leaf.as_ref()).unwrap();
+        let pin = Sha256::digest(parsed.public_key().raw).into();
+
+        let mut roots = RootCertStore::empty();
+        roots.add(ca.der().clone()).unwrap();
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let web_pki =
+            rustls::client::WebPkiServerVerifier::builder_with_provider(Arc::new(roots), provider)
+                .build()
+                .unwrap();
+
+        (
+            PinnedServerCertVerifier {
+                web_pki,
+                pins: Arc::new(pins),
+                require_pins_for_all_hosts: true,
+            },
+            leaf,
+            pin,
+        )
+    }
+
+    fn verify(
+        verifier: &PinnedServerCertVerifier,
+        leaf: &CertificateDer<'_>,
+        host: &'static str,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        verifier.verify_server_cert(
+            leaf,
+            &[],
+            &ServerName::try_from(host).unwrap(),
+            &[],
+            UnixTime::now(),
+        )
+    }
+
+    #[test]
+    fn accepts_multiple_pins_for_a_normalized_host() {
+        let extension = SpkiPinning::new()
+            .pin("API.Example.COM.", EXAMPLE_PIN)
+            .unwrap()
+            .pin(
+                "api.example.com",
+                "sha256/AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=",
+            )
+            .unwrap();
+
+        assert_eq!(extension.pins["api.example.com"].len(), 2);
+    }
+
+    #[test]
+    fn rejects_wildcards_ips_invalid_hosts_and_malformed_pins() {
+        for host in ["*.example.com", "127.0.0.1", "not a host"] {
+            assert!(matches!(
+                SpkiPinning::new().pin(host, EXAMPLE_PIN),
+                Err(SpkiPinError::InvalidHost)
+            ));
+        }
+        assert!(matches!(
+            SpkiPinning::new().pin("example.com", "AAAAAAAA"),
+            Err(SpkiPinError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn webpki_and_hostname_validation_run_before_pin_matching() {
+        let (mut verifier, leaf, leaf_pin) = test_verifier(HashMap::new());
+        Arc::make_mut(&mut verifier.pins)
+            .entry("api.example.test".into())
+            .or_default()
+            .insert(leaf_pin);
+
+        assert!(verify(&verifier, &leaf, "api.example.test").is_ok());
+
+        let hostname_error = verify(&verifier, &leaf, "wrong.example.test").unwrap_err();
+        assert!(matches!(
+            hostname_error,
+            RustlsError::InvalidCertificate(rustls::CertificateError::NotValidForName)
+                | RustlsError::InvalidCertificate(
+                    rustls::CertificateError::NotValidForNameContext { .. }
+                )
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_pins_and_unpinned_redirect_hosts() {
+        let mut pins = HashMap::new();
+        pins.insert("api.example.test".into(), HashSet::from([[0; 32]]));
+        let (verifier, leaf, _) = test_verifier(pins);
+
+        let mismatch = verify(&verifier, &leaf, "api.example.test").unwrap_err();
+        assert_eq!(
+            mismatch.to_string(),
+            format!("unexpected error: {RUSTLS_PIN_MISMATCH_MARKER}api.example.test")
+        );
+
+        let redirect = verify(&verifier, &leaf, "redirect.example.test").unwrap_err();
+        assert_eq!(
+            redirect.to_string(),
+            format!("unexpected error: {RUSTLS_HOST_NOT_PINNED_MARKER}redirect.example.test")
+        );
+    }
+
+    #[test]
+    fn builds_a_rustls_client_config() {
+        let extension = SpkiPinning::new().pin("example.com", EXAMPLE_PIN).unwrap();
+        let _config = build_tls_config(extension.pins, true).unwrap();
+    }
+}


### PR DESCRIPTION
## Motivation

Implements the SPKI pinning request from #3414 on top of the native transport extension API in the preceding PR.

The JavaScript fetch API remains unchanged. Pin configuration is native Rust code and cannot be disabled by frontend request options.

## Security behavior

- Normal WebPKI certificate-chain, validity, signature, and hostname validation runs first.
- The SHA-256 digest of the leaf certificate's DER SubjectPublicKeyInfo is then matched against exact-host pins.
- Multiple pins per host support safe server-key rotation.
- Every HTTPS host, including redirect targets, requires pins by default.
- The client is HTTPS-only by default, preventing downgrade redirects.
- `allow_unpinned_hosts()` and `allow_http()` are explicit native opt-ins.
- Dangerous certificate and hostname settings are rejected while the extension is installed.
- Failures are returned as structured extension errors through the unchanged plugin IPC API.

## API

```rust
let pinning = tauri_plugin_http::SpkiPinning::new()
    .pin("api.example.com", "sha256/CURRENT_BASE64_SPKI_HASH")?
    .pin("api.example.com", "sha256/BACKUP_BASE64_SPKI_HASH")?;

tauri::Builder::default().plugin(
    tauri_plugin_http::Builder::new()
        .extension(pinning)
        .build(),
);
```

The implementation is behind the optional `spki-pinning` Cargo feature, so applications that do not use it do not receive its Rustls, X.509, and hashing dependencies.

Depends on #3538 and should be reviewed as a stacked change. The second commit contains the SPKI-specific delta; once #3538 merges, this PR automatically reduces to that commit.