### PR TITLE
fix(opener): avoid blocking-runtime panic in reveal_item_in_dir

### DIFF
--- a/.changes/fix-opener-reveal-item-in-dir-blocking-panic.md
+++ b/.changes/fix-opener-reveal-item-in-dir-blocking-panic.md
@@ -1,0 +1,6 @@
+---
+"opener": "patch"
+"opener-js": "patch"
+---
+
+Fixed `revealItemInDir` panicking on Linux (and other zbus-based platforms) with `Cannot start a runtime from within a runtime` when called from an async command context. The blocking D-Bus call now runs via `spawn_blocking` instead of on the async runtime worker thread.

--- a/plugins/opener/src/commands.rs
+++ b/plugins/opener/src/commands.rs
@@ -72,5 +72,10 @@ pub async fn open_path<R: Runtime>(
 /// TODO: in the next major version, rename to `reveal_items_in_dir`
 #[tauri::command]
 pub async fn reveal_item_in_dir(paths: Vec<PathBuf>) -> crate::Result<()> {
-    crate::reveal_items_in_dir(&paths)
+    // `reveal_items_in_dir` blocks synchronously (e.g. via `zbus::blocking` on Linux),
+    // so it must run off the async runtime worker thread or it panics with
+    // "Cannot start a runtime from within a runtime".
+    tauri::async_runtime::spawn_blocking(move || crate::reveal_items_in_dir(&paths))
+        .await
+        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?
 }


### PR DESCRIPTION
On Linux, `reveal_items_in_dir` opens a blocking zbus connection
(`zbus::blocking::Connection::session()`). The `reveal_item_in_dir` command runs
that synchronously on the async runtime's worker thread, which panics with
"Cannot start a runtime from within a runtime" — the JS promise then just hangs,
no rejection ever reaches the frontend.

Wrapped the call in `tauri::async_runtime::spawn_blocking` so it runs off the
async worker thread. Same fix the issue reporter already confirmed works as an
app-side workaround, just moved into the plugin so nobody has to hand-roll it.

Fixes #3552

Verified with `cargo check` / `cargo fmt --check` / `cargo clippy` on the opener
crate — all clean. Don't have a Linux box handy to reproduce the actual panic,
but the change is a direct port of the reporter's verified workaround.

Added a `.changes` entry per the repo's covector convention.