### PR TITLE
fix(barcode-scanner): settle the pending scan() promise on cancel (fix #3560)

### DIFF
--- a/.changes/barcode-scanner-cancel-settles-scan.md
+++ b/.changes/barcode-scanner-cancel-settles-scan.md
@@ -1,0 +1,6 @@
+---
+"barcode-scanner": patch
+"barcode-scanner-js": patch
+---
+
+Fix `cancel()` on Android leaving the pending `scan()` promise unsettled: `destroy()` cleared the saved invoke before it was rejected, so the `"cancelled"` rejection never reached the caller. The pending scan is now rejected before the camera is torn down, matching iOS.

--- a/plugins/barcode-scanner/android/src/main/java/BarcodeScannerPlugin.kt
+++ b/plugins/barcode-scanner/android/src/main/java/BarcodeScannerPlugin.kt
@@ -332,8 +332,10 @@ class BarcodeScannerPlugin(private val activity: Activity) : Plugin(activity),
 
     @Command
     fun cancel(invoke: Invoke) {
-        destroy()
+        // Reject the pending scan before destroy() clears savedInvoke, otherwise the
+        // scan() promise is never settled. Mirrors the iOS implementation.
         savedInvoke?.reject("cancelled")
+        destroy()
         invoke.resolve()
     }
 


### PR DESCRIPTION
Fixes #3560.

### Bug

On Android, `cancel()` tore the camera down but never settled the pending `scan()` promise. In `BarcodeScannerPlugin.kt`, `cancel()` called `destroy()` first, and `destroy()` sets `savedInvoke = null`, so the following `savedInvoke?.reject("cancelled")` was a no-op. Frontend code awaiting `scan()` was stranded forever, which is especially bad in windowed mode where the page background stays transparent.

### Fix

Reject the pending invoke before calling `destroy()`. This is the order the iOS implementation already uses (`self.invoke?.reject("cancelled")` then `destroy()`), so both platforms now behave the same: `scan()` rejects with `"cancelled"`, and `cancel()` itself resolves.

### Verification

Built `examples/api` for Android (`x86_64`, debug) and ran it on an Android 16 / API 36 emulator, the same API level as in the report. Scanner view, Scan, then Cancel:

- **Before** (unpatched build) the console shows only `cancelled`, which is the example's own `cancelScan()` message. The `scan()` promise never settled, so its `.catch` never ran.
- **After** (this branch) the console shows `{ "message": "cancelled" }` from `scan().catch(...)` followed by `cancelled`. The camera is released in both cases.

Changeset added for `barcode-scanner` and `barcode-scanner-js` (patch).
