### PR TITLE
fix(updater): restore the current app when a macOS install fails (fix #3505, #3506)

### DIFF
--- a/.changes/updater-macos-restore-on-failure.md
+++ b/.changes/updater-macos-restore-on-failure.md
@@ -1,0 +1,6 @@
+---
+"updater": patch
+"updater-js": patch
+---
+
+On macOS, a failed install no longer deletes the installed app. The previous bundle is moved back into place when the new one cannot be moved in, the privileged fallback moves the previous bundle aside instead of deleting it first, the update is refused up front when the temp directory is on another volume, and the installed bundle root is `0755` rather than the temp directory's `0700`.

--- a/.changes/updater-macos-restore-on-failure.md
+++ b/.changes/updater-macos-restore-on-failure.md
@@ -3,4 +3,4 @@
 "updater-js": patch
 ---
 
-On macOS, a failed install no longer deletes the installed app. The previous bundle is moved back into place when the new one cannot be moved in, the privileged fallback moves the previous bundle aside instead of deleting it first, the update is refused up front when the temp directory is on another volume, and the installed bundle root is `0755` rather than the temp directory's `0700`.
+On macOS, a failed install no longer deletes the installed app. On APFS the current and new bundles are exchanged in one atomic step (`renamex_np` with `RENAME_SWAP`), so the install path is never empty; elsewhere the previous bundle is moved back into place when the new one cannot be moved in, the privileged fallback moves the previous bundle aside instead of deleting it first, the update is refused up front when the temp directory is on another volume, and the installed bundle root is `0755` rather than the temp directory's `0700`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6861,6 +6861,7 @@ dependencies = [
  "futures-util",
  "http",
  "infer",
+ "libc",
  "log",
  "minisign-verify",
  "osakit",

--- a/plugins/updater/Cargo.toml
+++ b/plugins/updater/Cargo.toml
@@ -70,6 +70,7 @@ tar = { version = "0.4", optional = true }
 flate2 = { version = "1", optional = true }
 
 [target."cfg(target_os = \"macos\")".dependencies]
+libc = "0.2"
 tar = "0.4"
 flate2 = "1"
 osakit = { version = "0.3", features = ["full"] }

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -1337,18 +1337,28 @@ impl Update {
             std::fs::Permissions::from_mode(0o755),
         )?;
 
-        // Move the current app to backup and the new one into place. The current app
-        // is put back if the second move fails.
+        // Exchange the current app and the new one in a single step where the file
+        // system supports it, so the install path is never empty; the previous app
+        // then sits in the extraction temp dir, which is removed on drop. Where the
+        // swap is not supported, fall back to two renames with a restore on failure.
         let backup = tmp_backup_dir.path().join("current_app");
-        let need_authorization =
-            match replace_bundle(&self.extract_path, tmp_extract_dir.path(), &backup) {
-                Ok(()) => false,
-                Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => true,
-                Err(err) => {
-                    std::fs::remove_dir_all(tmp_extract_dir.path()).ok();
-                    return Err(err.into());
-                }
-            };
+        let moved = match swap_bundle(&self.extract_path, tmp_extract_dir.path()) {
+            Err(err)
+                if err.raw_os_error() == Some(libc::ENOTSUP)
+                    || err.raw_os_error() == Some(libc::EINVAL) =>
+            {
+                replace_bundle(&self.extract_path, tmp_extract_dir.path(), &backup)
+            }
+            other => other,
+        };
+        let need_authorization = match moved {
+            Ok(()) => false,
+            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => true,
+            Err(err) => {
+                std::fs::remove_dir_all(tmp_extract_dir.path()).ok();
+                return Err(err.into());
+            }
+        };
 
         if need_authorization {
             log::debug!("app installation needs admin privileges");
@@ -1385,6 +1395,26 @@ impl Update {
             .status();
 
         Ok(())
+    }
+}
+
+/// Exchange `target` and `staged` atomically, so there is no instant at which
+/// `target` does not exist. APFS supports the swap; other file systems return
+/// `ENOTSUP`, and the caller falls back to [`replace_bundle`].
+#[cfg(target_os = "macos")]
+fn swap_bundle(target: &Path, staged: &Path) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let from = CString::new(staged.as_os_str().as_bytes())?;
+    let to = CString::new(target.as_os_str().as_bytes())?;
+    // SAFETY: both pointers are valid NUL-terminated strings that outlive the call,
+    // and `renamex_np` only reads them.
+    let result = unsafe { libc::renamex_np(from.as_ptr(), to.as_ptr(), libc::RENAME_SWAP) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
     }
 }
 
@@ -1680,6 +1710,33 @@ mod tests {
             "old"
         );
         assert!(!staged.exists());
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn swap_bundle_exchanges_the_two_bundles_in_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("App.app");
+        let staged = dir.path().join("staged");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("version"), "old").unwrap();
+        std::fs::create_dir(&staged).unwrap();
+        std::fs::write(staged.join("version"), "new").unwrap();
+
+        match super::swap_bundle(&target, &staged) {
+            // A temp dir on a file system without swap support proves nothing here.
+            Err(err) if err.raw_os_error() == Some(libc::ENOTSUP) => return,
+            other => other.unwrap(),
+        }
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("version")).unwrap(),
+            "new"
+        );
+        assert_eq!(
+            std::fs::read_to_string(staged.join("version")).unwrap(),
+            "old"
+        );
     }
 
     #[test]

--- a/plugins/updater/src/updater.rs
+++ b/plugins/updater/src/updater.rs
@@ -1287,6 +1287,7 @@ impl Update {
     /// └── ...
     fn install_inner(&self, bytes: &[u8]) -> Result<()> {
         use flate2::read::GzDecoder;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
         let cursor = Cursor::new(bytes);
         let mut extracted_files: Vec<PathBuf> = Vec::new();
@@ -1299,6 +1300,12 @@ impl Update {
         let tmp_extract_dir = tempfile::Builder::new()
             .prefix("tauri_updated_app")
             .tempdir()?;
+
+        // The app is moved with renames, which only work within one file system.
+        // Refuse now rather than fail after the current app has been moved away.
+        if self.extract_path.metadata()?.dev() != tmp_extract_dir.path().metadata()?.dev() {
+            return Err(Error::TempDirNotOnSameMountPoint);
+        }
 
         let decoder = GzDecoder::new(cursor);
         let mut archive = tar::Archive::new(decoder);
@@ -1322,29 +1329,36 @@ impl Update {
             extracted_files.push(extraction_path);
         }
 
-        // Try to move the current app to backup
-        let move_result = std::fs::rename(
-            &self.extract_path,
-            tmp_backup_dir.path().join("current_app"),
-        );
-        let need_authorization = if let Err(err) = move_result {
-            if err.kind() == std::io::ErrorKind::PermissionDenied {
-                true
-            } else {
-                std::fs::remove_dir_all(tmp_extract_dir.path()).ok();
-                return Err(err.into());
-            }
-        } else {
-            false
-        };
+        // The temp dir becomes the installed bundle's root, and tempfile creates it
+        // with mode 0700, which stops every other user of the machine from launching
+        // the updated app.
+        std::fs::set_permissions(
+            tmp_extract_dir.path(),
+            std::fs::Permissions::from_mode(0o755),
+        )?;
+
+        // Move the current app to backup and the new one into place. The current app
+        // is put back if the second move fails.
+        let backup = tmp_backup_dir.path().join("current_app");
+        let need_authorization =
+            match replace_bundle(&self.extract_path, tmp_extract_dir.path(), &backup) {
+                Ok(()) => false,
+                Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => true,
+                Err(err) => {
+                    std::fs::remove_dir_all(tmp_extract_dir.path()).ok();
+                    return Err(err.into());
+                }
+            };
 
         if need_authorization {
             log::debug!("app installation needs admin privileges");
-            // Use AppleScript to perform moves with admin privileges
+            // Use AppleScript to perform the same moves with admin privileges: the
+            // current app is only deleted once the new one is in place.
             let apple_script = format!(
-                "do shell script \"rm -rf '{src}' && mv -f '{new}' '{src}'\" with administrator privileges",
+                "do shell script \"mv -f '{src}' '{backup}' && {{ mv -f '{new}' '{src}' || {{ mv -f '{backup}' '{src}'; exit 1; }}; }} && rm -rf '{backup}'\" with administrator privileges",
                 src = self.extract_path.display(),
-                new = tmp_extract_dir.path().display()
+                new = tmp_extract_dir.path().display(),
+                backup = backup.display()
             );
 
             let (tx, rx) = std::sync::mpsc::channel();
@@ -1364,13 +1378,6 @@ impl Update {
                     "Failed to move the new app into place",
                 )));
             }
-        } else {
-            // Remove existing directory if it exists
-            if self.extract_path.exists() {
-                std::fs::remove_dir_all(&self.extract_path)?;
-            }
-            // Move the new app to the target path
-            std::fs::rename(tmp_extract_dir.path(), &self.extract_path)?;
         }
 
         let _ = std::process::Command::new("touch")
@@ -1379,6 +1386,20 @@ impl Update {
 
         Ok(())
     }
+}
+
+/// Move `staged` into `target`, keeping what was at `target` in `backup` until the
+/// move has succeeded. If the second rename fails, the first is undone so `target`
+/// is left exactly as it was. Both renames must be within one file system.
+#[cfg(any(target_os = "macos", test))]
+fn replace_bundle(target: &Path, staged: &Path, backup: &Path) -> std::io::Result<()> {
+    std::fs::rename(target, backup)?;
+    if let Err(err) = std::fs::rename(staged, target) {
+        // Best effort: the error worth reporting is the one from the failed move.
+        let _ = std::fs::rename(backup, target);
+        return Err(err);
+    }
+    Ok(())
 }
 
 /// Gets the base target string used by the updater. If bundle type is available it
@@ -1636,6 +1657,49 @@ fn escape_msi_property_arg(arg: impl AsRef<OsStr>) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn replace_bundle_moves_the_staged_bundle_into_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("App.app");
+        let staged = dir.path().join("staged");
+        let backup = dir.path().join("backup");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("version"), "old").unwrap();
+        std::fs::create_dir(&staged).unwrap();
+        std::fs::write(staged.join("version"), "new").unwrap();
+
+        super::replace_bundle(&target, &staged, &backup).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("version")).unwrap(),
+            "new"
+        );
+        assert_eq!(
+            std::fs::read_to_string(backup.join("version")).unwrap(),
+            "old"
+        );
+        assert!(!staged.exists());
+    }
+
+    #[test]
+    fn replace_bundle_restores_the_current_bundle_when_the_move_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("App.app");
+        let backup = dir.path().join("backup");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("version"), "old").unwrap();
+        let missing = dir.path().join("missing");
+
+        let err = super::replace_bundle(&target, &missing, &backup).unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+        assert_eq!(
+            std::fs::read_to_string(target.join("version")).unwrap(),
+            "old"
+        );
+        assert!(!backup.exists());
+    }
 
     #[test]
     #[cfg(windows)]


### PR DESCRIPTION
Fixes #3505, fixes #3506.

I hit this on a Mac where the update kept "failing" and afterwards the app was simply gone from /Applications. The cause is in the macOS `install_inner`: the current .app gets renamed into a `TempDir` before the new bundle is renamed into place, and if that second rename fails the function just returns the error. Nothing puts the old bundle back, and the `TempDir` drop deletes it on the way out. The admin fallback has the same problem in shell form, it does `rm -rf` on the app first and `mv` the new one in second.

While in there I also fixed the 0700 bundle root from #3506, since it comes from the same temp dir.

What changed:

- on APFS the current and new bundles are exchanged in one step with `renamex_np(RENAME_SWAP)` (what Sparkle does), so there is no moment where the install path is empty, not even if the process dies mid-update
- where the file system can't swap (`ENOTSUP`), the two renames go through `replace_bundle()`, which renames the backup back if the second rename fails
- the AppleScript now moves the old app aside and only removes it once the new one is in place; if the second `mv` fails it moves the old one back
- compare `st_dev` of the app and the temp dir before touching anything and return the existing `TempDirNotOnSameMountPoint` (same as the AppImage path already does), instead of failing after the app has been moved
- chmod the staged bundle root to 0755

The only dependency change is `libc` for the macOS target, which was already in the lockfile through tauri.

Testing: three unit tests, `swap_bundle` exchanging two directories (macOS only, skips on a file system that reports `ENOTSUP`), and `replace_bundle` on the normal path and on the restore when the second rename fails. `cargo test`, `clippy -D warnings` and `fmt --check` with the flags CI uses are clean on macOS. Side note, the two doctests in `lib.rs` already fail on `v2` before this change; `--all-targets` skips doctests so CI never sees them.

I also ran it for real in an app pointed at this branch through `[patch.crates-io]`, serving a signed update from localhost. A normal update swaps the bundle in a few seconds and it ends up 0755 with nothing left in the temp dir. Killing the app with `kill -9` two seconds in (mid download) leaves the installed bundle untouched and it updates fine on the next launch; killing it a bit later just lands after the swap. In none of the runs did the install path end up empty, which was the whole problem.
